### PR TITLE
gen-histos for electrons as well; default: true

### DIFF
--- a/common/include/ElectronHists.h
+++ b/common/include/ElectronHists.h
@@ -9,7 +9,7 @@
  */
 class ElectronHists: public uhh2::Hists {
 public:
-    ElectronHists(uhh2::Context & ctx, const std::string & dirname, bool gen_plots=false);
+    ElectronHists(uhh2::Context & ctx, const std::string & dirname, bool gen_plots=true);
     
     virtual void fill(const uhh2::Event & ev) override;
     

--- a/common/include/MuonHists.h
+++ b/common/include/MuonHists.h
@@ -9,7 +9,7 @@
  */
 class MuonHists: public uhh2::Hists {
 public:
-    MuonHists(uhh2::Context & ctx, const std::string & dirname);
+    MuonHists(uhh2::Context & ctx, const std::string & dirname, bool gen_plots=true);
     
     virtual void fill(const uhh2::Event & ev) override;
     
@@ -22,6 +22,7 @@ private:
     TH1F *number, *pt, *eta, *phi, *isolation, *charge, *ptrel, *deltaRmin;
     TH1F *pt_1, *eta_1, *phi_1, *isolation_1, *charge_1, *ptrel_1, *deltaRmin_1;
     TH1F *pt_2, *eta_2, *phi_2, *isolation_2, *charge_2, *ptrel_2, *deltaRmin_2;
+    TH1F *eff_sub, *eff_tot, *pt_response;
     
     TH2F *deltaRmin_ptrel, *deltaRmin_ptrel_1, *deltaRmin_ptrel_2;
 };

--- a/common/src/MuonHists.cxx
+++ b/common/src/MuonHists.cxx
@@ -11,7 +11,7 @@
 using namespace uhh2;
 using namespace std;
 
-MuonHists::MuonHists(Context & ctx, const std::string & dname): Hists(ctx, dname){
+MuonHists::MuonHists(Context & ctx, const std::string & dname, bool gen_plots): Hists(ctx, dname){
     number = book<TH1F>("number","number of muons",7,-0.5,6.5);
     
     pt = book<TH1F>("pt","p_{T} muon",100,0,500);
@@ -40,13 +40,38 @@ MuonHists::MuonHists(Context & ctx, const std::string & dname): Hists(ctx, dname
     charge_2 = book<TH1F>("charge_2", "muon 2 charge",3,-1.5,1.5);
     deltaRmin_2 = book<TH1F>("deltaRmin_2", "#Delta R_{min}(mu 2,jet)", 40, 0, 2.0);
     deltaRmin_ptrel_2 = book<TH2F>("deltaRmin_ptrel_2", "x=#Delta R_{min}(mu 2,jet) y=p_{T}^{rel}(mu 2,jet)", 40, 0, 2.0, 40, 0, 200.);
+
+    if (gen_plots) {
+        eff_sub     = book<TH1F>("eff_sub",     "p_{T}",                100,0,500);
+        eff_tot     = book<TH1F>("eff_tot",     "p_{T}",                100,0,500);
+        pt_response = book<TH1F>("pt_response", "(p_{T, gen} - p_{T, reco}) / p_{T, gen}",
+                                                                        800,-2.,2.);
+    } else {
+        eff_sub     = 0;
+        eff_tot     = 0;
+        pt_response = 0;
+    }
 }
 
 void MuonHists::fill(const Event & event){
     auto w = event.weight;
     assert(event.muons);
     number->Fill(event.muons->size(), w);
-    
+
+    if (eff_sub && event.genparticles) {
+        for (const auto & gp: *event.genparticles) {
+            if (abs(gp.pdgId()) == 13) {
+                auto gp_pt = gp.pt();
+                eff_tot->Fill(gp_pt, w);
+                auto mu = closestParticle(gp, *event.muons);
+                if (mu && deltaR(gp, *mu) < 0.1) {
+                    eff_sub->Fill(gp_pt, w);
+                    pt_response->Fill((gp_pt - mu->pt()) / gp_pt, w);
+                }
+            }
+        }
+    }
+
     // buffer values for ptrel and drmin to avoid recomputation:
     vector<float> drmin_buf;
     vector<float> ptrel_buf;


### PR DESCRIPTION
I switched the default filling of the gen-plots to true. However, if the genparticles collection is not available, they will simply not be filled.

