### PR TITLE
SubJetCorrector added

### DIFF
--- a/common/include/JetCorrections.h
+++ b/common/include/JetCorrections.h
@@ -46,6 +46,18 @@ private:
     std::unique_ptr<FactorizedJetCorrector> corrector;
 };
 
+class SubJetCorrector: public uhh2::AnalysisModule {
+public:
+    explicit SubJetCorrector(const std::vector<std::string> & filenames);
+    
+    virtual bool process(uhh2::Event & event) override;
+    
+    virtual ~SubJetCorrector();
+    
+private:
+    std::unique_ptr<FactorizedJetCorrector> corrector;
+};
+
 
 /** \brief Cross-clean lepton and jets by subtracting lepton four momenta from nearby jets
  * 


### PR DESCRIPTION
I added a SubJetCorrector class similar to (Top)JetCorrector.
Preliminary studies show that it may be needed to correct subjets at 13TeV
The behavior is similar to UHHAnalysis subjet recorrector:
1) It is not needed to uncorrect the subjets because the ntuplewriter corrects the subjets at level 0, that is: they're not corrected.
2) However the subJEC_raw value is set to the full correction, thus by uncorrecting we would un-apply a correction that was never applied in the first place.
3) The analyzer then must be careful to apply subjet JECs only *once* in the entire analysis.