### PR TITLE
correctors for jet collections obtained from handles

### DIFF
--- a/common/include/JetCorrections.h
+++ b/common/include/JetCorrections.h
@@ -58,6 +58,44 @@ private:
     std::unique_ptr<FactorizedJetCorrector> corrector;
 };
 
+class GenericJetCorrector: public uhh2::AnalysisModule {
+public:
+    explicit GenericJetCorrector(uhh2::Context & ctx, const std::vector<std::string> & filenames, const std::string & collectionname);
+    
+    virtual bool process(uhh2::Event & event) override;
+    
+    virtual ~GenericJetCorrector();
+    
+private:
+    std::unique_ptr<FactorizedJetCorrector> corrector;
+    uhh2::Event::Handle<std::vector<Jet> > h_jets;
+};
+
+class GenericTopJetCorrector: public uhh2::AnalysisModule {
+public:
+    explicit GenericTopJetCorrector(uhh2::Context & ctx, const std::vector<std::string> & filenames, const std::string & collectionname);
+    
+    virtual bool process(uhh2::Event & event) override;
+    
+    virtual ~GenericTopJetCorrector();
+    
+private:
+    std::unique_ptr<FactorizedJetCorrector> corrector;
+    uhh2::Event::Handle<std::vector<TopJet> > h_jets;
+};
+
+class GenericSubJetCorrector: public uhh2::AnalysisModule {
+public:
+    explicit GenericSubJetCorrector(uhh2::Context & ctx, const std::vector<std::string> & filenames, const std::string & collectionname);
+    
+    virtual bool process(uhh2::Event & event) override;
+    
+    virtual ~GenericSubJetCorrector();
+    
+private:
+    std::unique_ptr<FactorizedJetCorrector> corrector;
+    uhh2::Event::Handle<std::vector<TopJet> > h_jets;
+};
 
 /** \brief Cross-clean lepton and jets by subtracting lepton four momenta from nearby jets
  * 

--- a/common/src/JetCorrections.cxx
+++ b/common/src/JetCorrections.cxx
@@ -99,6 +99,63 @@ bool SubJetCorrector::process(uhh2::Event & event){
 // note: implement here because only here (and not in the header file), the destructor of FactorizedJetCorrector is known
 SubJetCorrector::~SubJetCorrector(){}
 
+GenericJetCorrector::GenericJetCorrector(uhh2::Context & ctx, const std::vector<std::string> & filenames, const std::string & collectionname){
+    corrector = build_corrector(filenames);
+    h_jets = ctx.get_handle<std::vector<Jet> >(collectionname);
+}
+    
+bool GenericJetCorrector::process(uhh2::Event & event){
+
+    const auto jets = &event.get(h_jets);
+    assert(jets);
+    for(auto & jet : *jets){
+        correct_jet(*corrector, jet, event);
+    }
+    return true;
+}
+
+// note: implement here because only here (and not in the header file), the destructor of FactorizedJetCorrector is known
+GenericJetCorrector::~GenericJetCorrector(){}
+
+GenericTopJetCorrector::GenericTopJetCorrector(uhh2::Context & ctx, const std::vector<std::string> & filenames, const std::string & collectionname){
+    corrector = build_corrector(filenames);
+    h_jets = ctx.get_handle<std::vector<TopJet> >(collectionname);
+}
+    
+bool GenericTopJetCorrector::process(uhh2::Event & event){
+
+    const auto jets = &event.get(h_jets);
+    assert(jets);
+    for(auto & jet : *jets){
+        correct_jet(*corrector, jet, event);
+    }
+    return true;
+}
+
+// note: implement here because only here (and not in the header file), the destructor of FactorizedJetCorrector is known
+GenericTopJetCorrector::~GenericTopJetCorrector(){}
+
+GenericSubJetCorrector::GenericSubJetCorrector(uhh2::Context & ctx, const std::vector<std::string> & filenames, const std::string & collectionname){
+    corrector = build_corrector(filenames);
+    h_jets = ctx.get_handle<std::vector<TopJet> >(collectionname);
+}
+    
+bool GenericSubJetCorrector::process(uhh2::Event & event){
+
+    const auto topjets = &event.get(h_jets);
+    assert(topjets);
+    for(auto & topjet : *topjets){
+        auto subjets = topjet.subjets();
+        for (auto & subjet : subjets) { 
+            correct_jet(*corrector, subjet, event);
+        }
+        topjet.set_subjets(move(subjets));
+    }
+    return true;
+}
+
+// note: implement here because only here (and not in the header file), the destructor of FactorizedJetCorrector is known
+GenericSubJetCorrector::~GenericSubJetCorrector(){}
 
 // ** JetLeptonCleaner
 


### PR DESCRIPTION
This commit adds the Generic*JetCorrector classes that allow to correct (Top,Sub)Jets collections obtained from handles.
In principle, to avoid the uncontrolled proliferation of corrector classes, one could merge these classes with the standard ones by overloading the constructor with some bogus default values for the additional parameters.
The "process" method would then check the validity of the values of the additional parameters and decide whether to correct the standard collection or the "handle".
I don't know whether that would be cleaner / more efficient. It depends on how widespread is the use-case of correcting "Handle" Jet collections (probably rather uncommon, apart from jet tagging studies).
