### PR TITLE
Make private members in hist classes protected

### DIFF
--- a/common/include/ElectronHists.h
+++ b/common/include/ElectronHists.h
@@ -13,7 +13,7 @@ public:
     
     virtual void fill(const uhh2::Event & ev) override;
     
-private:
+protected:
     
     // declare all histograms as members. Note that one could also use get_hist
     // as in the example's ExampleHists instead of saving the histograms here. However,

--- a/common/include/EventHists.h
+++ b/common/include/EventHists.h
@@ -21,7 +21,7 @@ public:
 
     virtual void fill(const uhh2::Event & ev) override;
 
-private:
+protected:
     TH1F *N_PrimVertices, *Weights, *MET, *HT, *HTLep, *ST;
 
     uhh2::Event::Handle<double> h_ht;

--- a/common/include/HypothesisHists.h
+++ b/common/include/HypothesisHists.h
@@ -15,7 +15,7 @@ public:
 
     virtual void fill(const uhh2::Event & ev) override;
 
-private:
+protected:
     TH1F *Discriminator, *Discriminator_2, *Discriminator_3;
     TH1F *M_ttbar_rec, *M_ttbar_gen, *M_toplep_rec, *M_tophad_rec, *M_tophad_rec_1jet, *M_tophad_rec_2jet, *M_tophad_rec_3jet;
     TH1F *Pt_toplep_rec, *Pt_tophad_rec, *Pt_ttbar_rec, *Pt_ttbar_gen;

--- a/common/include/JetHists.h
+++ b/common/include/JetHists.h
@@ -60,7 +60,7 @@ public:
   //UserJet defines the i-th Jet to be plotted. The other variables are needed for plotting and to have different histogram names/axis.
   void add_iJetHists(unsigned int UserJet, double minPt=20, double maxPt=800, const std::string & axisSuffix="userjet", const std::string & histSuffix="userjet");
   
- private:
+ protected:
   
   std::vector<unsigned int> m_userjet;
   std::vector<jetHist> userjets;
@@ -90,7 +90,7 @@ class TopJetHists: public JetHistsBase{
   void add_iTopJetHists(unsigned int UserJet, double minPt=0, double maxPt=800, double minPt_sub=0, double maxPt_sub=500, const std::string & axisSuffix="userjet", const std::string & histSuffix="userjet");
 
 
- private:
+ protected:
      
   struct subjetHist {
     TH1F* number, *sum4Vec, *pt, *eta, *phi, *mass, *csv;

--- a/common/include/MuonHists.h
+++ b/common/include/MuonHists.h
@@ -13,7 +13,7 @@ public:
     
     virtual void fill(const uhh2::Event & ev) override;
     
-private:
+protected:
     
     // declare all histograms as members. Note that one could also use get_hist
     // as in the example's ExampleHists instead of saving the histograms here. However,

--- a/common/include/TauHists.h
+++ b/common/include/TauHists.h
@@ -15,7 +15,7 @@ public:
     
     virtual void fill(const uhh2::Event & ev) override;
     
-private:
+protected:
     
     TH1F *number, *pt, *eta, *phi, *charge, *ptrel, *deltaRmin;
     TH1F *pt_1, *pt_1_binned, *pt_muon1_tau1, *pt_muon1_tau1_binned, *eta_1, *phi_1, *charge_1, *ptrel_1, *deltaRmin_1;


### PR DESCRIPTION
Make the private members in hist classes in common module (e.g. EventHists, ElectronHists, etc.) protected; this way one can make his own hist class inheriting from these hist classes and is able to manipulate inherited members of the mother hist classes.