### PR TITLE
Put clean_collection into Utils.h, allow NSelections to also run on diff...

### DIFF
--- a/common/include/NSelections.h
+++ b/common/include/NSelections.h
@@ -19,6 +19,7 @@
 // The constructor defaults are such that no explicit id is passed ('none'); in this case, all objects are counted,
 // which corresponds to the first of the two described modes.
 
+using namespace uhh2;
 
 class NTauSelection: public uhh2::Selection {
 public:
@@ -50,18 +51,24 @@ private:
 
 class NJetSelection: public uhh2::Selection {
 public:
-    explicit NJetSelection(int nmin, int nmax = -1, const boost::optional<JetId> & jetid = boost::none);
+    explicit NJetSelection(int nmin, int nmax = -1,
+        const boost::optional<JetId> & jetid = boost::none,
+        const boost::optional<Event::Handle<std::vector<Jet> > > & jetcollection = boost::none);
     virtual bool passes(const uhh2::Event & event);
 private:
     int nmin, nmax;
     boost::optional<JetId> jetid;
+    boost::optional<Event::Handle<std::vector<Jet> > > jetcollection;
 };
 
 class NTopJetSelection: public uhh2::Selection {
 public:
-    explicit NTopJetSelection(int nmin, int nmax = -1, const boost::optional<TopJetId> & topjetid = boost::none);
+    explicit NTopJetSelection(int nmin, int nmax = -1,
+        const boost::optional<TopJetId> & topjetid = boost::none,
+        const boost::optional<Event::Handle<std::vector<TopJet> > > & topjetcollection = boost::none);
     virtual bool passes(const uhh2::Event & event);
 private:
     int nmin, nmax;
     boost::optional<TopJetId> topjetid;
+    boost::optional<Event::Handle<std::vector<TopJet> > > topjetcollection;
 };

--- a/common/include/TopJetIds.h
+++ b/common/include/TopJetIds.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include "UHH2/core/include/Event.h"
+#include "UHH2/common/include/ObjectIdUtils.h"
+#include "UHH2/common/include/JetIds.h"
+
 
 // see also ElectronIds.h for general comments
 
@@ -40,6 +43,26 @@ public:
     
 private:
     double threshold;
+};
+
+/** \brief Higgs tagger as e.g. used in Rebekka's analysis
+ * 
+ * Look for the number of b-tagged subjets (so far, the default is a medium working point but
+ * probably have to change that!). If this number is greater or equal two, calculate the mass
+ * of the two leading b-tagged subjets and return true if it is greater than minmass (default 60 GeV).
+ */
+
+class HiggsTag {
+public:
+    explicit HiggsTag(float minmass = 60.f, float maxmass = std::numeric_limits<float>::infinity(), JetId const & id = CSVBTag(CSVBTag::WP_MEDIUM)) :
+        minmass_(minmass), maxmass_(maxmass), btagid_(id) {}
+
+    bool operator()(TopJet const & topjet, uhh2::Event const & event) const;
+
+private:
+    float minmass_, maxmass_;
+    JetId btagid_;
+
 };
 
    

--- a/common/include/Utils.h
+++ b/common/include/Utils.h
@@ -67,3 +67,17 @@ template<typename P>
 inline void sort_by_pt(std::vector<P> & particles){
     std::sort(particles.begin(), particles.end(), [](const P & p1, const P & p2){return p1.pt() > p2.pt();});
 }
+
+/** common code to filter out objects from a collection according to an object id
+ *
+ */
+template<typename T>
+inline void clean_collection(std::vector<T> & objects, const uhh2::Event & event, const std::function<bool (const T &, const uhh2::Event &)> obj_id){
+    std::vector<T> result;
+    for(const auto & obj : objects){
+        if(obj_id(obj, event)){
+            result.push_back(obj);
+        }
+    }
+    std::swap(result, objects);
+}

--- a/common/src/CleaningModules.cxx
+++ b/common/src/CleaningModules.cxx
@@ -1,24 +1,10 @@
 #include "UHH2/core/include/Event.h"
 #include "UHH2/common/include/CleaningModules.h"
+#include "UHH2/common/include/Utils.h"
+
 
 using namespace uhh2;
 using namespace std;
-
-namespace {
-    
-// common code to filter out objects from a collection according to an object id
-template<typename T>
-void clean_collection(vector<T> & objects, const uhh2::Event & event, const std::function<bool (const T &, const Event &)> obj_id){
-    vector<T> result;
-    for(const auto & obj : objects){
-        if(obj_id(obj, event)){
-            result.push_back(obj);
-        }
-    }
-    std::swap(result, objects);
-}
-    
-}
 
 
 JetCleaner::JetCleaner(const JetId & jet_id_): jet_id(jet_id_){}

--- a/common/src/NSelections.cxx
+++ b/common/src/NSelections.cxx
@@ -41,15 +41,23 @@ bool NElectronSelection::passes(const Event & event){
     return passes_minmax(*event.electrons, nmin, nmax, event, eleid);
 }
 
-NJetSelection::NJetSelection(int nmin_, int nmax_, const boost::optional<JetId> & jetid_): nmin(nmin_), nmax(nmax_), jetid(jetid_){}
+NJetSelection::NJetSelection(int nmin_, int nmax_,
+    const boost::optional<JetId> & jetid_,
+    const boost::optional<Event::Handle<std::vector<Jet> > > & jetcollection_) :
+    nmin(nmin_), nmax(nmax_), jetid(jetid_), jetcollection(jetcollection_){}
 
 bool NJetSelection::passes(const Event & event){
-    return passes_minmax(*event.jets, nmin, nmax, event, jetid);
+    const auto & jets = jetcollection ? event.get(*jetcollection) : *event.jets;
+    return passes_minmax(jets, nmin, nmax, event, jetid);
 }
 
-NTopJetSelection::NTopJetSelection(int nmin_, int nmax_, const boost::optional<TopJetId> & topjetid_): nmin(nmin_), nmax(nmax_), topjetid(topjetid_){}
+NTopJetSelection::NTopJetSelection(int nmin_, int nmax_,
+    const boost::optional<TopJetId> & topjetid_,
+    const boost::optional<Event::Handle<std::vector<TopJet> > > & topjetcollection_) :
+    nmin(nmin_), nmax(nmax_), topjetid(topjetid_), topjetcollection(topjetcollection_){}
 
 bool NTopJetSelection::passes(const Event & event){
-  return passes_minmax(*event.topjets, nmin, nmax, event, topjetid);
+    const auto & jets = topjetcollection ? event.get(*topjetcollection) : *event.topjets;
+  return passes_minmax(jets, nmin, nmax, event, topjetid);
 }
 

--- a/common/src/TopJetIds.cxx
+++ b/common/src/TopJetIds.cxx
@@ -29,12 +29,30 @@ CMSTopTag::CMSTopTag(double mminLower, double mjetLower, double mjetUpper): m_mm
 
 
     
-bool Tau32::operator()(const TopJet & topjet, const uhh2::Event &) const{
+bool Tau32::operator()(const TopJet & topjet, const uhh2::Event &) const {
     auto tau2 = topjet.tau2();
     if(!std::isfinite(tau2) || tau2 == 0.0) return false;
     auto tau3 = topjet.tau3();
     if(!std::isfinite(tau3)) return false;
     return tau3 / tau2 < threshold;
+}
+
+
+bool HiggsTag::operator()(TopJet const & topjet, uhh2::Event const & event) const {
+    auto subjets = topjet.subjets();
+    if(subjets.size() < 2) return false;
+    clean_collection(subjets, event, btagid_);
+    if (subjets.size() < 2) return false;
+    sort_by_pt(subjets);
+
+    LorentzVector firsttwosubjets = subjets[0].v4() + subjets[1].v4();
+    if(!firsttwosubjets.isTimelike()) {
+        return false;
+    }
+    auto mjet = firsttwosubjets.M();
+    if(mjet < minmass_) return false;
+    if(mjet > maxmass_) return false;
+    return true;
 }
 
 


### PR DESCRIPTION
...erent collections and add HiggsTag class in TopJetIds.h

* I put the clean_collection function from a private namespace in CleaningModules.cxx into Utils.h so that other modules can use it, too; if this is not desirable as it might again lead to an inflation of the Utils.h module let me know and I'll find a workaround.
* I changed the NJetSelection and NTopJetSelection modules so that they can also run on different collections beside the default collections (especially necessary for NTopJetSelections).
* I implemented a first version of the HiggsTagger which is now basically a TopJetId (as implemented in Rebekka's analysis); this is mainly for me and Heiner and should be used with caution since it will potentially be modified in the future.

I think none of the above modifications should mess with anyone's code and can probably be merged safely.