### PR TITLE
moved to ungroomed mass in CMSTopTag ID

### DIFF
--- a/common/src/TopJetIds.cxx
+++ b/common/src/TopJetIds.cxx
@@ -8,18 +8,13 @@ bool CMSTopTag::operator()(const TopJet & topjet, const uhh2::Event &) const {
     auto subjets = topjet.subjets();
     if(subjets.size() < 3) return false;
     
-    LorentzVector allsubjets;
-    for(const auto & subjet : subjets) {
-        allsubjets += subjet.v4();
-    }
-    if(!allsubjets.isTimelike()) {
-        return false;
-    }
-    auto mjet = allsubjets.M();
+    auto mjet = topjet.v4().M();
     if(mjet < m_mjetLower) return false;
     if(mjet > m_mjetUpper) return false;
+
     auto mmin = m_disubjet_min(topjet);
     if(mmin < m_mminLower) return false;
+
     return true;
 }
 


### PR DESCRIPTION
* change in the definition of the "CMS-Top-Tagger" ID
  * current version uses groomed mass (mass of sum of subjets p4)
  * Zprime semileptonic analysis at 8TeV used ungroomed mass (following approach in JME-13-007 and Z' all-hadronic analysis)
  * reverting to ungroomed mass and pushing this change centrally (as discussed w/ Thomas Peiffer)
  * this change can be propagated to 'next-ntuple-format' branch
