### PR TITLE
Few minor changes

### DIFF
--- a/common/include/GenTools.h
+++ b/common/include/GenTools.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "UHH2/core/include/AnalysisModule.h"
 #include "UHH2/core/include/Event.h"
 
@@ -25,7 +27,7 @@ GenParticle const * findMother(GenParticle const & p, vector<GenParticle> const 
 
 class NGenParticleCalculator : public AnalysisModule {
 public:
-    explicit NGenParticleCalculator(Context & ctx, std::string hndl_name, int genp_id, boost::optional<int> mother_id = boost::none);
+    explicit NGenParticleCalculator(Context & ctx, std::string hndl_name, int genp_id, boost::optional<int> mother_id = boost::none, boost::optional<int> veto_mother_id = boost::none);
 
     virtual bool process(Event & event);
 
@@ -33,4 +35,5 @@ private:
     Event::Handle<int> hndl_;
     int genp_id_;
     boost::optional<int> mother_id_;
+    boost::optional<int> veto_mother_id_;
 };

--- a/common/include/ObjectIdUtils.h
+++ b/common/include/ObjectIdUtils.h
@@ -18,6 +18,8 @@ typedef std::function<bool (const Electron &, const uhh2::Event &)> ElectronId;
 typedef std::function<bool (const Muon &, const uhh2::Event &)> MuonId;
 typedef std::function<bool (const Tau &, const uhh2::Event &)> TauId;
 typedef std::function<bool (const TopJet &, const uhh2::Event &)> TopJetId;
+typedef std::function<bool (const GenParticle &, const uhh2::Event &)> GenParticleId;
+
 
 /** \brief Cut on minimum pt and maximum |eta| of a particle
  * 
@@ -100,4 +102,70 @@ private:
     std::vector<id_type> ids;
 };
 
+/** \brief Construct a new object id, taking the logical or of several other ids.
+ * 
+ * Similar to above, except that this Id requires only one of the implemented ids to be passed in
+ * order to pass 'true'.
+ * Can e.g. be used for a GenParticleId.
+ */
+template<typename T>
+class OrId {
+public:
+    typedef std::function<bool (const T&, const uhh2::Event &)> id_type;
+    
+    OrId(const id_type & id1, const id_type & id2){
+        add(id1);
+        add(id2);
+    }
+    
+    OrId(const id_type & id1, const id_type & id2, const id_type & id3){
+        add(id1);
+        add(id2);
+        add(id3);
+    }
+    
+    OrId(const id_type & id1, const id_type & id2, const id_type & id3, const id_type & id4){
+        add(id1);
+        add(id2);
+        add(id3);
+        add(id4);
+    }
+    
+    OrId & add(const id_type & id){
+        ids.push_back(id);
+        return *this;
+    }
+    
+    bool operator()(const T & obj, const uhh2::Event & event) const {
+        for(const auto & id : ids){
+            if(id(obj, event)) return true;
+        }
+        return false;
+    }
+    
+private:
+    std::vector<id_type> ids;
+};
+
+/** \brief Construct a new object id, taking the logical or of several other ids.
+ * 
+ * Similar to above, except that this Id requires only one of the implemented ids to be passed in
+ * order to pass 'true'.
+ * Can e.g. be used for a GenParticleId.
+ */
+template<typename T>
+class VetoId {
+public:
+    typedef std::function<bool (const T&, const uhh2::Event &)> id_type;
+    
+    VetoId(const id_type & id): id_(id) {}
+    
+    bool operator()(const T & obj, const uhh2::Event & event) const {
+        if(id_(obj, event)) return true;
+        return false;
+    }
+    
+private:
+    id_type id_;
+};
 

--- a/common/include/Utils.h
+++ b/common/include/Utils.h
@@ -68,6 +68,11 @@ inline void sort_by_pt(std::vector<P> & particles){
     std::sort(particles.begin(), particles.end(), [](const P & p1, const P & p2){return p1.pt() > p2.pt();});
 }
 
+template<typename P>
+inline void sort_by_pt(std::vector<P*> & particles){
+    std::sort(particles.begin(), particles.end(), [](const P* p1, const P* p2){return p1->pt() > p2->pt();});
+}
+
 /** common code to filter out objects from a collection according to an object id
  *
  */

--- a/common/src/GenTools.cc
+++ b/common/src/GenTools.cc
@@ -9,8 +9,8 @@ GenParticle const * findMother(GenParticle const & igenp, vector<GenParticle> co
 }
 
 
-NGenParticleCalculator::NGenParticleCalculator(Context & ctx, std::string hndl_name, int genp_id, boost::optional<int> mother_id) :
-		hndl_(ctx.get_handle<int>(hndl_name)), genp_id_(genp_id), mother_id_(mother_id) {}
+NGenParticleCalculator::NGenParticleCalculator(Context & ctx, std::string hndl_name, int genp_id, boost::optional<int> mother_id, boost::optional<int> veto_mother_id) :
+		hndl_(ctx.get_handle<int>(hndl_name)), genp_id_(genp_id), mother_id_(mother_id), veto_mother_id_(veto_mother_id) {}
 
 bool NGenParticleCalculator::process(Event & event)
 {
@@ -28,6 +28,10 @@ bool NGenParticleCalculator::process(Event & event)
 					if (abs(gen_mother->pdgId()) == *mother_id_)
 					{
 						right_mother = true;
+					}
+					else if (veto_mother_id_ && abs(gen_mother->pdgId()) == *veto_mother_id_)
+					{
+						right_mother = false;
 						break;
 					}
 					gen_mother = findMother(*gen_mother, event.genparticles);


### PR DESCRIPTION
Expanded functionality in GenTools module but that should not affect anyone.

Main changes are:
* Adding an OrId in ObjectIdUtils so that one can now also look for the logical 'Or' of different Ids (e.g. useful for GenParticleIds)
* Overloading the sort_by_pt() function in the Utils module so that can now also run on a vector of pointers (useful if one wants to create his own Particle collection and sort it but does not want to copy all the particles from the original collection)