### PR TITLE
correction for some LQtoTMu xml files

### DIFF
--- a/common/datasets/MC_LQ_TMu_M700_20x25.xml
+++ b/common/datasets/MC_LQ_TMu_M700_20x25.xml
@@ -11,11 +11,13 @@
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu700_469_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu700_470_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu700_471_Ntuple.root" Lumi="0.0"/>
+<In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu700_472_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu700_473_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu700_474_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu700_475_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu700_476_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu700_477_Ntuple.root" Lumi="0.0"/>
+<In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu700_478_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu700_479_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu700_480_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu700_481_Ntuple.root" Lumi="0.0"/>
@@ -35,6 +37,7 @@
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu700_495_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu700_496_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu700_497_Ntuple.root" Lumi="0.0"/>
+<In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu700_498_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu700_499_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu700_500_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu700_501_Ntuple.root" Lumi="0.0"/>
@@ -55,6 +58,7 @@
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu700_516_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu700_517_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu700_518_Ntuple.root" Lumi="0.0"/>
+<In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu700_519_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu700_520_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu700_521_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu700_522_Ntuple.root" Lumi="0.0"/>
@@ -81,4 +85,5 @@
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu700_543_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu700_544_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu700_545_Ntuple.root" Lumi="0.0"/>
+<In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu700_546_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu700_548_Ntuple.root" Lumi="0.0"/>

--- a/common/datasets/MC_LQ_TMu_M900_20x25.xml
+++ b/common/datasets/MC_LQ_TMu_M900_20x25.xml
@@ -5,6 +5,7 @@
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu900_553_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu900_554_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu900_555_Ntuple.root" Lumi="0.0"/>
+<In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu900_556_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu900_557_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu900_558_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu900_559_Ntuple.root" Lumi="0.0"/>
@@ -25,10 +26,14 @@
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu900_574_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu900_575_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu900_576_Ntuple.root" Lumi="0.0"/>
+<In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu900_577_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu900_578_Ntuple.root" Lumi="0.0"/>
+<In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu900_579_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu900_580_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu900_581_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu900_582_Ntuple.root" Lumi="0.0"/>
+<In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu900_583_Ntuple.root" Lumi="0.0"/>
+<In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu900_584_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu900_585_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu900_586_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu900_587_Ntuple.root" Lumi="0.0"/>
@@ -48,9 +53,11 @@
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu900_601_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu900_602_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu900_603_Ntuple.root" Lumi="0.0"/>
+<In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu900_604_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu900_605_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu900_606_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu900_607_Ntuple.root" Lumi="0.0"/>
+<In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu900_608_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu900_609_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu900_610_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu900_611_Ntuple.root" Lumi="0.0"/>
@@ -68,6 +75,8 @@
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu900_623_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu900_624_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu900_625_Ntuple.root" Lumi="0.0"/>
+<In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu900_626_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu900_627_Ntuple.root" Lumi="0.0"/>
+<In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu900_628_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu900_629_Ntuple.root" Lumi="0.0"/>
 <In FileName="/nfs/dust/cms/user/mstoev/LQAnalysis/LQtoTopMu/ntuple/LQtoTMu900_630_Ntuple.root" Lumi="0.0"/>


### PR DESCRIPTION
Some jobs were crashing when producing the miniAODs for LQtoTopMuon. Hence, some (many) events were missing after ntuplelisation. Missing events are added now