### PR TITLE
moved implementation of safe-inv-mass method to src/

### DIFF
--- a/common/include/Utils.h
+++ b/common/include/Utils.h
@@ -87,17 +87,7 @@ inline void clean_collection(std::vector<T> & objects, const uhh2::Event & event
     std::swap(result, objects);
 }
 
-
-namespace {
 /** invariant mass of a LorentzVector, but save for timelike / spacelike vectors
  *
  */
-float inv_mass_save(const LorentzVector & p4){
-    if(p4.isTimelike()){
-            return p4.mass();
-    }
-    else{
-        return -sqrt(-p4.mass2());
-    }
-}
-}
+float inv_mass_safe(const LorentzVector&);

--- a/common/src/Utils.cxx
+++ b/common/src/Utils.cxx
@@ -26,6 +26,10 @@ const Jet * nextJet(const Particle  & p, const std::vector<Jet> & jets){
     return closestParticle(p, jets);
 }
 
+float inv_mass_safe(const LorentzVector& p4){
+
+  return p4.isTimelike() ? p4.mass() : -sqrt(-p4.mass2());
+}
 
 double pTrel(const Particle  & p, const Particle * reference_axis){
     double ptrel=0;


### PR DESCRIPTION
move implementation of "safe inv. mass" method to src/Utils.cxx

* removed body of non-templated function from header file (avoids multiple copies of the function and a bunch of warnings)
* minor renaming to make content clearer
