### PR TITLE
addition of a ttbar-chi2 discriminator for top-tagged events

### DIFF
--- a/common/include/ReconstructionHypothesis.h
+++ b/common/include/ReconstructionHypothesis.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "UHH2/core/include/Particle.h"
+#include "UHH2/core/include/TopJet.h"
 #include <map>
 
 /**
@@ -16,12 +17,15 @@
  */
 class ReconstructionHypothesis {
 public:
+  explicit ReconstructionHypothesis(){ m_tophad_topjet_ptr = 0; }
+
   LorentzVector toplep_v4() const{return m_toplep_v4;}
   LorentzVector tophad_v4() const{return m_tophad_v4;} 
   LorentzVector neutrino_v4() const{return m_neutrino_v4;} 
   Particle lepton() const{return m_lepton;}
-  std::vector<Particle> tophad_jets() const{return m_tophad_jets;}
   std::vector<Particle> toplep_jets() const{return m_toplep_jets;}
+  std::vector<Particle> tophad_jets() const{return m_tophad_jets;}
+  const TopJet* tophad_topjet_ptr() const{return m_tophad_topjet_ptr;}
   LorentzVector top_v4() const{ return m_lepton.charge() > 0 ? m_toplep_v4 : m_tophad_v4;}
   LorentzVector antitop_v4() const{ return m_lepton.charge() < 0 ? m_toplep_v4 : m_tophad_v4;}
   LorentzVector wlep_v4() const{ return m_neutrino_v4+m_lepton.v4();}
@@ -45,8 +49,9 @@ public:
   void set_toplep_v4(LorentzVector v4){m_toplep_v4=v4;}
   void set_tophad_v4(LorentzVector v4){m_tophad_v4=v4;} 
   void set_neutrino_v4(LorentzVector v4){m_neutrino_v4=v4;}
-  void add_toplep_jet(const Particle & j){m_toplep_jets.push_back(j);}
-  void add_tophad_jet(const Particle & j){m_tophad_jets.push_back(j);}
+  void add_toplep_jet(const Particle& j){m_toplep_jets.push_back(j);}
+  void add_tophad_jet(const Particle& j){m_tophad_jets.push_back(j);}
+  void set_tophad_topjet_ptr(const TopJet* const tjp){m_tophad_topjet_ptr = tjp;}
   void set_lepton(const Particle & l){m_lepton = l;}
   void set_discriminator(const std::string & label, float discr){
       m_discriminators[label] = discr;
@@ -58,8 +63,9 @@ private:
   LorentzVector m_tophad_v4;
   LorentzVector m_neutrino_v4;
 
-  std::vector<Particle> m_tophad_jets;
   std::vector<Particle> m_toplep_jets;
+  std::vector<Particle> m_tophad_jets;
+  const TopJet* m_tophad_topjet_ptr;
   Particle m_lepton;
 
   std::map<std::string, float> m_discriminators;

--- a/common/include/ReconstructionHypothesisDiscriminators.h
+++ b/common/include/ReconstructionHypothesisDiscriminators.h
@@ -55,6 +55,27 @@ private:
     cfg config;
 };
 
+/** \brief Calculate the chi-square reconstruction discriminator
+ *         (only for events with a top-tagged jet; see TopTagReconstruction class)
+ * 
+ * Chi-square discriminator specific to events where the hadronic-top corresponds to one jet passing top-tagging.
+ * Class implementation follows the same structure of the Chi2Discriminator class.
+ * The chi2 term for the hadronic-top is calculated using the groomed mass of the top-tagged jet.
+ */
+class Chi2DiscriminatorTTAG: public uhh2::AnalysisModule {
+public:
+    struct cfg {
+        std::string discriminator_label;
+        cfg(): discriminator_label("Chi2"){}
+    };
+    
+    Chi2DiscriminatorTTAG(uhh2::Context & ctx, const std::string & rechyps_name, const cfg & config = cfg());
+    virtual bool process(uhh2::Event & event) override;
+    
+private:
+    uhh2::Event::Handle<std::vector<ReconstructionHypothesis>> h_hyps;
+    cfg config;
+};
 
 /** \brief Top-DeltaR quality flag for Monte-Carlo
  * 

--- a/common/src/ReconstructionHypothesisDiscriminators.cxx
+++ b/common/src/ReconstructionHypothesisDiscriminators.cxx
@@ -39,6 +39,7 @@ const ReconstructionHypothesis * get_best_hypothesis(const std::vector<Reconstru
         return nullptr;
     }
 }
+////
 
 Chi2Discriminator::Chi2Discriminator(Context & ctx, const std::string & rechyps_name, const cfg & config_): config(config_){
     h_hyps = ctx.get_handle<vector<ReconstructionHypothesis>>(rechyps_name);
@@ -62,7 +63,43 @@ bool Chi2Discriminator::process(uhh2::Event & event){
   }
   return true;
 }
+////
 
+Chi2DiscriminatorTTAG::Chi2DiscriminatorTTAG(Context & ctx, const std::string & rechyps_name, const cfg & config_): config(config_){
+  h_hyps = ctx.get_handle<vector<ReconstructionHypothesis>>(rechyps_name);
+}
+
+
+bool Chi2DiscriminatorTTAG::process(uhh2::Event & event){
+  auto & hyps = event.get(h_hyps);
+
+  const double mass_thad       = 181.;
+  const double mass_thad_sigma =  15.;
+  const double mass_tlep       = 174.;
+  const double mass_tlep_sigma =  18.;
+
+  for(auto & hyp: hyps){
+
+    if(!hyp.tophad_topjet_ptr())
+      std::runtime_error("Chi2DiscriminatorTTAG::process -- null pointer for TopJet associated to hadronic-top");
+
+    LorentzVector tjet_subjet_sum;
+    for(const auto& subj : hyp.tophad_topjet_ptr()->subjets()) tjet_subjet_sum += subj.v4();
+
+    const double mass_tlep_rec = inv_mass(hyp.toplep_v4());
+    const double mass_thad_rec = inv_mass(tjet_subjet_sum);
+
+    const double chi2_thad = pow((mass_thad_rec - mass_thad) / mass_thad_sigma, 2);
+    const double chi2_tlep = pow((mass_tlep_rec - mass_tlep) / mass_tlep_sigma, 2);
+
+    hyp.set_discriminator(config.discriminator_label        , chi2_tlep + chi2_thad);
+    hyp.set_discriminator(config.discriminator_label+"_tlep", chi2_tlep);
+    hyp.set_discriminator(config.discriminator_label+"_thad", chi2_thad);
+  }
+
+  return true;
+}
+////
 
 TopDRMCDiscriminator::TopDRMCDiscriminator(Context & ctx, const std::string & rechyps_name, const cfg & config_): config(config_){
     h_hyps = ctx.get_handle<vector<ReconstructionHypothesis>>(rechyps_name);

--- a/common/src/ReconstructionHypothesisDiscriminators.cxx
+++ b/common/src/ReconstructionHypothesisDiscriminators.cxx
@@ -81,7 +81,7 @@ bool Chi2DiscriminatorTTAG::process(uhh2::Event & event){
   for(auto & hyp: hyps){
 
     if(!hyp.tophad_topjet_ptr())
-      std::runtime_error("Chi2DiscriminatorTTAG::process -- null pointer for TopJet associated to hadronic-top");
+      throw std::runtime_error("Chi2DiscriminatorTTAG::process -- null pointer for TopJet associated to hadronic-top");
 
     LorentzVector tjet_subjet_sum;
     for(const auto& subj : hyp.tophad_topjet_ptr()->subjets()) tjet_subjet_sum += subj.v4();

--- a/common/src/TTbarReconstruction.cxx
+++ b/common/src/TTbarReconstruction.cxx
@@ -153,6 +153,7 @@ bool TopTagReconstruction::process(uhh2::Event & event) {
 
         LorentzVector tophad_v4(tj.v4());
         hyp.add_tophad_jet(tj);
+        hyp.set_tophad_topjet_ptr(&tj);
 
         LorentzVector toplep_v4(lepton.v4() + neutrino_p4);
 


### PR DESCRIPTION
* addition of an alternative chi2-discriminator (in ReconstructionHypothesisDiscriminators), to be used for events with a top-tagged jet
  * hadronic term of the chi2 calculated using the groomed (instead of ungroomed) topjet mass

* added a pointer to TopJet as data member of the ReconstructionHypothesis class, in order to be able to access TopJet-specific methods (e.g. subjets)
