### PR TITLE
undeclare event output

### DIFF
--- a/common/src/TauIds.cxx
+++ b/common/src/TauIds.cxx
@@ -15,7 +15,7 @@ bool TauIDMedium::operator()(const Tau & tau, const Event & event) const {
     return true;
 }
 
-bool TauIDDecayModeFinding::operator()(const Tau & tau, const Event & event) const {
+bool TauIDDecayModeFinding::operator()(const Tau & tau, const Event &) const {
     if(!tau.get_bool(Tau::decayModeFinding)) return false;
     return true;
 }

--- a/core/include/AnalysisModule.h
+++ b/core/include/AnalysisModule.h
@@ -177,6 +177,10 @@ public:
     template<typename T>
     GenericEvent::Handle<T> declare_event_output(const std::string & branch_name, const std::string & event_member_name = "");
 
+    void undeclare_event_output(const std::string & branch_name) {
+        do_undeclare_event_output(branch_name);
+    }
+
 
     /** \brief Get a handle by type and name, allowing to set / get event contents
      *
@@ -198,7 +202,8 @@ protected:
 
     virtual void do_declare_event_input(const std::type_info & ti, const std::string & bname, const std::string & mname) = 0;
     virtual void do_declare_event_output(const std::type_info & ti, const std::string & bname, const std::string & mname) = 0;
-    
+    virtual void do_undeclare_event_output(const std::string & branch_name) = 0;
+
     std::map<std::string, std::string> settings;
 
 private:

--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -121,7 +121,11 @@ private:
         if(!outfile || !outtree) return;
         outputs.emplace_back(event_output{ti, bname, ges.get_raw_handle(ti, mname)});
     }
-    
+
+    virtual void do_undeclare_event_output(const std::string & bname) override {
+        throw runtime_error("undeclare_event_output not implemented in CMSSW!");
+    }
+
     TFile * outfile;
     TTree * outtree;
     

--- a/core/src/AnalysisModuleRunner.cxx
+++ b/core/src/AnalysisModuleRunner.cxx
@@ -173,7 +173,8 @@ private:
     // input branches is done in begin_input_file.
     virtual void do_declare_event_input(const std::type_info & ti, const std::string & bname, const std::string & mname) override;
     virtual void do_declare_event_output(const std::type_info & ti, const std::string & bname, const std::string & mname) override;
-    
+    virtual void do_undeclare_event_output(const std::string & branch_name) override;
+
     // read metadata from a tree "uhh2_meta" in dir into data. Returns whether the tree
     // was found or not. Also checks consistency opf all entries in case there is more than one entry
     // in the metadata tree (in case of merged output).
@@ -447,6 +448,13 @@ void SFrameContext::do_declare_event_output(const type_info & ti, const string &
     auto handle = ges.get_raw_handle(ti, mname);
     do_declare_event_output_handle(ti, bname, handle);
 }
+
+void SFrameContext::do_undeclare_event_output(const std::string & branch_name) {
+    if (!event_output_bname2bi.count(branch_name)) {
+        throw runtime_error("Can not undeclare event output '" + branch_name + "' as it has not been declared before.");
+    }
+    event_output_bname2bi.erase(branch_name);
+};
 
 void SFrameContext::do_declare_event_input_handle(const type_info & ti, const string & bname, const GenericEvent::RawHandle & handle) {
     event_input_bname2bi.insert(make_pair(bname, make_unique<branchinfo>(ti, handle)));


### PR DESCRIPTION
declaring and implementing Context::undeclare_event_output(string), to remove branches from output.
Implementation in CMSSWContext simply throws a runtime exception.