### PR TITLE
add dummy member to enum in Muon.h

### DIFF
--- a/core/include/Muon.h
+++ b/core/include/Muon.h
@@ -13,7 +13,7 @@ public:
   };
   
   enum tag {
-      /* for future use */
+      dummy = 0 /* for future use */
   };
   
   bool get_bool(bool_id i) const {


### PR DESCRIPTION
This fix is required for root 6. Otherwise, the member variables of the muon are not stored when running the NtupleWriter.