### PR TITLE
fixed electron variable (missing-hits) in "NtupleWriterLeptons" plugin

### DIFF
--- a/core/plugins/NtupleWriterLeptons.cxx
+++ b/core/plugins/NtupleWriterLeptons.cxx
@@ -49,7 +49,7 @@ void NtupleWriterElectrons::process(const edm::Event & event, uhh2::Event & ueve
         ele.set_trackIso(pfiso.sumChargedParticlePt);
         ele.set_photonIso(pfiso.sumPhotonEt);
         ele.set_puChargedHadronIso(pfiso.sumPUPt);
-        ele.set_gsfTrack_trackerExpectedHitsInner_numberOfLostHits(pat_ele.gsfTrack()->hitPattern().numberOfLostTrackerHits(reco::HitPattern::MISSING_INNER_HITS));
+        ele.set_gsfTrack_trackerExpectedHitsInner_numberOfLostHits(pat_ele.gsfTrack()->hitPattern().numberOfHits(reco::HitPattern::MISSING_INNER_HITS));
         ele.set_gsfTrack_px( pat_ele.gsfTrack()->px());
         ele.set_gsfTrack_py( pat_ele.gsfTrack()->py());
         ele.set_gsfTrack_pz( pat_ele.gsfTrack()->pz());


### PR DESCRIPTION
fixed the variable used for the electron "number-of-missing-hits" (which enters the electron cut-based ID), in order to match the definitions used in the Egamma POG

* refs

 * https://hypernews.cern.ch/HyperNews/CMS/get/recoTracking/1459.html
 * https://github.com/ikrav/cmssw/blob/egm_id_phys14/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleMissingHitsCut.cc#L38 (found after some browsing of https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedElectronIdentificationRun2)
