### PR TITLE
updates for lepton reconstruction (mini-isolation)

### DIFF
--- a/core/include/Electron.h
+++ b/core/include/Electron.h
@@ -4,19 +4,25 @@
 #include "Tags.h"
 #include "FlavorParticle.h"
 
-class Electron: public Particle{
-public:
-    
-  enum tag {eid_PHYS14_20x25_veto, eid_PHYS14_20x25_loose, eid_PHYS14_20x25_medium, eid_PHYS14_20x25_tight };
-  
+class Electron: public Particle {
+
+ public:
+  enum tag {
+    eid_PHYS14_20x25_veto,
+    eid_PHYS14_20x25_loose,
+    eid_PHYS14_20x25_medium,
+    eid_PHYS14_20x25_tight,
+  };
+
   static tag tagname2tag(const std::string & tagname){
-      if(tagname == "eid_PHYS14_20x25_veto") return eid_PHYS14_20x25_veto;
-      if(tagname == "eid_PHYS14_20x25_loose") return eid_PHYS14_20x25_loose;
-      if(tagname == "eid_PHYS14_20x25_medium") return eid_PHYS14_20x25_medium;
-      if(tagname == "eid_PHYS14_20x25_tight") return eid_PHYS14_20x25_tight;
-      throw std::runtime_error("unknown Electron::tag '" + tagname + "'");
+    if(tagname == "eid_PHYS14_20x25_veto")   return eid_PHYS14_20x25_veto;
+    if(tagname == "eid_PHYS14_20x25_loose")  return eid_PHYS14_20x25_loose;
+    if(tagname == "eid_PHYS14_20x25_medium") return eid_PHYS14_20x25_medium;
+    if(tagname == "eid_PHYS14_20x25_tight")  return eid_PHYS14_20x25_tight;
+
+    throw std::runtime_error("unknown Electron::tag '" + tagname + "'");
   }
-  
+
   Electron(){
    m_supercluster_eta = 0; 
    m_supercluster_phi = 0; 
@@ -41,6 +47,15 @@ public:
    m_fbrem = 0;
    m_EoverPIn = 0;
    m_EcalEnergy = 0;
+   m_mvaNonTrigV0 = 0;
+   m_mvaTrigV0 = 0;
+
+   m_pfMINIIso_CH       = 0;
+   m_pfMINIIso_NH       = 0;
+   m_pfMINIIso_Ph       = 0;
+   m_pfMINIIso_PU       = 0;
+   m_pfMINIIso_NH_pfwgt = 0;
+   m_pfMINIIso_Ph_pfwgt = 0;
   }
 
   float supercluster_eta() const{return m_supercluster_eta;} 
@@ -66,6 +81,16 @@ public:
   float fbrem() const{return m_fbrem;}
   float EoverPIn() const{return m_EoverPIn;}
   float EcalEnergy() const{return m_EcalEnergy;}
+  float mvaNonTrigV0() const{return m_mvaNonTrigV0;}
+  float mvaTrigV0() const{return m_mvaTrigV0;}
+
+  float pfMINIIso_CH      () const { return m_pfMINIIso_CH; }
+  float pfMINIIso_NH      () const { return m_pfMINIIso_NH; }
+  float pfMINIIso_Ph      () const { return m_pfMINIIso_Ph; }
+  float pfMINIIso_PU      () const { return m_pfMINIIso_PU; }
+  float pfMINIIso_NH_pfwgt() const { return m_pfMINIIso_NH_pfwgt; }
+  float pfMINIIso_Ph_pfwgt() const { return m_pfMINIIso_Ph_pfwgt; }
+
   float get_tag(tag t)const {return tags.get_tag(static_cast<int>(t));}
   bool has_tag(tag t) const {return tags.has_tag(static_cast<int>(t));}
 
@@ -92,6 +117,16 @@ public:
   void set_fbrem(float x){m_fbrem=x;}
   void set_EoverPIn(float x){m_EoverPIn=x;}
   void set_EcalEnergy(float x){m_EcalEnergy=x;}
+  void set_mvaNonTrigV0(float x){m_mvaNonTrigV0=x;}
+  void set_mvaTrigV0(float x){m_mvaTrigV0=x;}
+
+  void set_pfMINIIso_CH      (float x){ m_pfMINIIso_CH       = x; }
+  void set_pfMINIIso_NH      (float x){ m_pfMINIIso_NH       = x; }
+  void set_pfMINIIso_Ph      (float x){ m_pfMINIIso_Ph       = x; }
+  void set_pfMINIIso_PU      (float x){ m_pfMINIIso_PU       = x; }
+  void set_pfMINIIso_NH_pfwgt(float x){ m_pfMINIIso_NH_pfwgt = x; }
+  void set_pfMINIIso_Ph_pfwgt(float x){ m_pfMINIIso_Ph_pfwgt = x; }
+
   void set_tag(tag t, float value) { tags.set_tag(static_cast<int>(t), value);}
 
   float gsfTrack_dxy_vertex(const float point_x, const float point_y) const{ 
@@ -145,9 +180,16 @@ public:
   float m_fbrem;
   float m_EoverPIn;
   float m_EcalEnergy;
-  float m_mvaTrigV0;
   float m_mvaNonTrigV0;
+  float m_mvaTrigV0;
   float m_AEff;
-  
+
+  float m_pfMINIIso_CH;
+  float m_pfMINIIso_NH;
+  float m_pfMINIIso_Ph;
+  float m_pfMINIIso_PU;
+  float m_pfMINIIso_NH_pfwgt;
+  float m_pfMINIIso_Ph_pfwgt;
+
   Tags tags;
 };

--- a/core/include/Muon.h
+++ b/core/include/Muon.h
@@ -6,20 +6,20 @@
 #include <stdint.h>
 
 class Muon: public Particle{
-public:
+ public:
   enum bool_id {
-      soft = 0, tight, highpt,
+      soft = 0, loose, medium, tight, highpt,
       tracker, pf, global, standalone
   };
-  
+
   enum tag {
-      dummy = 0 /* for future use */
+    dummy = 0 /* for future use */
   };
-  
+
   bool get_bool(bool_id i) const {
       return (id_bits & (uint64_t(1) << static_cast<uint64_t>(i)));
   }
-  
+
   void set_bool(bool_id i, bool value) {
       if(value){
           id_bits |= uint64_t(1) << static_cast<uint64_t>(i);
@@ -28,9 +28,7 @@ public:
           id_bits &= ~(uint64_t(1) << static_cast<uint64_t>(i));
       }
   }
-    
-    
-    
+
   Muon(){
       id_bits = 0;
       
@@ -43,6 +41,13 @@ public:
       m_sumNeutralHadronEt = 0;
       m_sumPhotonEt = 0;
       m_sumPUPt = 0;
+
+      m_pfMINIIso_CH       = 0;
+      m_pfMINIIso_NH       = 0;
+      m_pfMINIIso_Ph       = 0;
+      m_pfMINIIso_PU       = 0;
+      m_pfMINIIso_NH_pfwgt = 0;
+      m_pfMINIIso_Ph_pfwgt = 0;
   }
   
   float dxy() const{return m_dxy;}
@@ -54,6 +59,13 @@ public:
   float sumPhotonEt() const{return m_sumPhotonEt;}
   float sumPUPt() const{return m_sumPUPt;}
 
+  float pfMINIIso_CH      () const { return m_pfMINIIso_CH; }
+  float pfMINIIso_NH      () const { return m_pfMINIIso_NH; }
+  float pfMINIIso_Ph      () const { return m_pfMINIIso_Ph; }
+  float pfMINIIso_PU      () const { return m_pfMINIIso_PU; }
+  float pfMINIIso_NH_pfwgt() const { return m_pfMINIIso_NH_pfwgt; }
+  float pfMINIIso_Ph_pfwgt() const { return m_pfMINIIso_Ph_pfwgt; }
+
   void set_dxy(float x){m_dxy=x;}
   void set_dxy_error(float x){m_dxy_error=x;}
   void set_dz(float x){m_dz=x;} 
@@ -62,9 +74,16 @@ public:
   void set_sumNeutralHadronEt(float x){m_sumNeutralHadronEt=x;} 
   void set_sumPhotonEt(float x){m_sumPhotonEt=x;}
   void set_sumPUPt(float x){m_sumPUPt=x;}
-  
+
+  void set_pfMINIIso_CH      (float x){ m_pfMINIIso_CH       = x; }
+  void set_pfMINIIso_NH      (float x){ m_pfMINIIso_NH       = x; }
+  void set_pfMINIIso_Ph      (float x){ m_pfMINIIso_Ph       = x; }
+  void set_pfMINIIso_PU      (float x){ m_pfMINIIso_PU       = x; }
+  void set_pfMINIIso_NH_pfwgt(float x){ m_pfMINIIso_NH_pfwgt = x; }
+  void set_pfMINIIso_Ph_pfwgt(float x){ m_pfMINIIso_Ph_pfwgt = x; }
+
   float get_tag(tag t) const { return tags.get_tag(static_cast<int>(t)); }
-  void set_tag(tag t, float value) { return tags.set_tag(static_cast<int>(t), value); }
+  void set_tag(tag t, float value) { tags.set_tag(static_cast<int>(t), value); }
 
   float relIso() const{
     return ( m_sumChargedHadronPt + std::max( 0.0, m_sumNeutralHadronEt + m_sumPhotonEt - 0.5*m_sumPUPt) ) / pt();
@@ -83,7 +102,7 @@ public:
 
  private:
   uint64_t id_bits;
-  
+
   float m_dxy;
   float m_dxy_error;
   float m_dz;
@@ -92,7 +111,13 @@ public:
   float m_sumNeutralHadronEt;
   float m_sumPhotonEt;
   float m_sumPUPt;
-  
+
+  float m_pfMINIIso_CH;
+  float m_pfMINIIso_NH;
+  float m_pfMINIIso_Ph;
+  float m_pfMINIIso_PU;
+  float m_pfMINIIso_NH_pfwgt;
+  float m_pfMINIIso_Ph_pfwgt;
+
   Tags tags;
 };
-

--- a/core/plugins/BuildFile.xml
+++ b/core/plugins/BuildFile.xml
@@ -9,6 +9,9 @@
 <use  name="DataFormats/JetReco"/>
 <use  name="DataFormats/Provenance"/>
 <use  name="DataFormats/PatCandidates" />
+<use  name="PhysicsTools/IsolationAlgos" />
+<use  name="CommonTools/Utils" />
+<use  name="EgammaAnalysis/ElectronTools" />
 <use  name="RecoJets/JetAlgorithms" />
 <use  name="SimDataFormats/GeneratorProducts" />
 <use name="RecoBTau/JetTagComputer" />

--- a/core/plugins/CandIsolatorFromDepositsMINIISO.cc
+++ b/core/plugins/CandIsolatorFromDepositsMINIISO.cc
@@ -1,0 +1,176 @@
+#include "UHH2/core/plugins/CandIsolatorFromDepositsMINIISO.h"
+
+// Framework
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/RecoCandidate/interface/IsoDepositDirection.h"
+#include "DataFormats/RecoCandidate/interface/IsoDeposit.h"
+#include "DataFormats/RecoCandidate/interface/IsoDepositFwd.h"
+#include "DataFormats/RecoCandidate/interface/IsoDepositVetos.h"
+
+#include "DataFormats/Candidate/interface/CandAssociation.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include <string>
+#include <boost/regex.hpp>
+
+#include "PhysicsTools/IsolationAlgos/interface/IsoDepositVetoFactory.h"
+
+using namespace edm;
+using namespace reco;
+using namespace reco::isodeposit;
+
+bool isNumber(const std::string &str) {
+   static boost::regex re("^[+-]?(\\d+\\.?|\\d*\\.\\d*)$");
+   return regex_match(str.c_str(), re);
+}
+double toNumber(const std::string &str) {
+    return atof(str.c_str());
+}
+
+CandIsolatorFromDepositsMINIISO::SingleDeposit::SingleDeposit(const edm::ParameterSet &iConfig, edm::ConsumesCollector && iC) :
+  srcToken_(iC.consumes<reco::IsoDepositMap>(iConfig.getParameter<edm::InputTag>("src"))),
+  dRmin_(iConfig.getParameter<double>("dRmin")),
+  dRmax_(iConfig.getParameter<double>("dRmax")),
+  kTfac_(iConfig.getParameter<double>("kTfac")),
+  weightExpr_(iConfig.getParameter<std::string>("weight")),
+  skipDefaultVeto_(iConfig.getParameter<bool>("skipDefaultVeto"))
+						      //,vetos_(new AbsVetos())
+{
+  std::string mode = iConfig.getParameter<std::string>("mode");
+  if (mode == "sum") mode_ = Sum;
+  else if (mode == "sumRelative") mode_ = SumRelative;
+  else if (mode == "sum2") mode_ = Sum2;
+  else if (mode == "sum2Relative") mode_ = Sum2Relative;
+  else if (mode == "max") mode_ = Max;
+  else if (mode == "maxRelative") mode_ = MaxRelative;
+  else if (mode == "nearestDR") mode_ = NearestDR;
+  else if (mode == "count") mode_ = Count;
+  else if (mode == "meanDR") mode_ = MeanDR;
+  else if (mode == "sumDR") mode_ = SumDR;
+  else throw cms::Exception("Not Implemented") << "Mode '" << mode << "' not implemented. " <<
+    "Supported modes are 'sum', 'sumRelative', 'count'." <<
+    //"Supported modes are 'sum', 'sumRelative', 'max', 'maxRelative', 'count'." << // TODO: on request only
+    "New methods can be easily implemented if requested.";
+  typedef std::vector<std::string> vstring;
+  vstring vetos = iConfig.getParameter< vstring >("vetos");
+  reco::isodeposit::EventDependentAbsVeto *evdep;
+  for (vstring::const_iterator it = vetos.begin(), ed = vetos.end(); it != ed; ++it) {
+    vetos_.push_back(IsoDepositVetoFactory::make(it->c_str(), evdep, iC));
+    if (evdep) evdepVetos_.push_back(evdep);
+  }
+  std::string weight = iConfig.getParameter<std::string>("weight");
+  if (isNumber(weight)) {
+    //std::cout << "Weight is a simple number, " << toNumber(weight) << std::endl;
+    weight_ = toNumber(weight);
+    usesFunction_ = false;
+  } else {
+    usesFunction_ = true;
+    //std::cout << "Weight is a function, this might slow you down... " << std::endl;
+  }
+  //std::cout << "CandIsolatorFromDeposits::SingleDeposit::SingleDeposit: Total of " << vetos_.size() << " vetos" << std::endl;
+}
+void CandIsolatorFromDepositsMINIISO::SingleDeposit::cleanup() {
+    for (AbsVetos::iterator it = vetos_.begin(), ed = vetos_.end(); it != ed; ++it) {
+        delete *it;
+    }
+    vetos_.clear();
+    // NOTE: we DON'T have to delete the evdepVetos_, they have already been deleted above. We just clear the vectors
+    evdepVetos_.clear();
+}
+void CandIsolatorFromDepositsMINIISO::SingleDeposit::open(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
+    iEvent.getByToken(srcToken_, hDeps_);
+    for (EventDependentAbsVetos::iterator it = evdepVetos_.begin(), ed = evdepVetos_.end(); it != ed; ++it) {
+        (*it)->setEvent(iEvent,iSetup);
+    }
+}
+
+double CandIsolatorFromDepositsMINIISO::SingleDeposit::compute(const reco::CandidateBaseRef &cand) {
+  double deltaR_ = cand->pt() ? fmax(dRmin_, fmin(dRmax_, kTfac_/cand->pt())) : dRmax_;
+    const IsoDeposit &dep = (*hDeps_)[cand];
+    double eta = dep.eta(), phi = dep.phi(); // better to center on the deposit direction
+                                             // that could be, e.g., the impact point at calo
+    for (AbsVetos::iterator it = vetos_.begin(), ed = vetos_.end(); it != ed; ++it) {
+        (*it)->centerOn(eta, phi);
+    }
+    double weight = (usesFunction_ ? weightExpr_(*cand) : weight_);
+    switch (mode_) {
+        case Count:        return weight * dep.countWithin(deltaR_, vetos_, skipDefaultVeto_);
+        case Sum:          return weight * dep.sumWithin(deltaR_, vetos_, skipDefaultVeto_);
+        case SumRelative:  return weight * dep.sumWithin(deltaR_, vetos_, skipDefaultVeto_) / dep.candEnergy() ;
+        case Sum2:         return weight * dep.sum2Within(deltaR_, vetos_, skipDefaultVeto_);
+        case Sum2Relative: return weight * dep.sum2Within(deltaR_, vetos_, skipDefaultVeto_) / (dep.candEnergy() * dep.candEnergy()) ;
+        case Max:          return weight * dep.maxWithin(deltaR_, vetos_, skipDefaultVeto_);
+        case NearestDR:    return weight * dep.nearestDR(deltaR_, vetos_, skipDefaultVeto_);
+        case MaxRelative:  return weight * dep.maxWithin(deltaR_, vetos_, skipDefaultVeto_) / dep.candEnergy() ;
+        case MeanDR:  return weight * dep.algoWithin<reco::IsoDeposit::MeanDRAlgo>(deltaR_, vetos_, skipDefaultVeto_);
+        case SumDR:  return weight * dep.algoWithin<reco::IsoDeposit::SumDRAlgo>(deltaR_, vetos_, skipDefaultVeto_);
+    }
+    throw cms::Exception("Logic error") << "Should not happen at " << __FILE__ << ", line " << __LINE__; // avoid gcc warning
+}
+
+
+/// constructor with config
+CandIsolatorFromDepositsMINIISO::CandIsolatorFromDepositsMINIISO(const ParameterSet& par) {
+  typedef std::vector<edm::ParameterSet> VPSet;
+  VPSet depPSets = par.getParameter<VPSet>("deposits");
+  for (VPSet::const_iterator it = depPSets.begin(), ed = depPSets.end(); it != ed; ++it) {
+    sources_.push_back(SingleDeposit(*it, consumesCollector()));
+  }
+  if (sources_.size() == 0) throw cms::Exception("Configuration Error") << "Please specify at least one deposit!";
+  produces<CandDoubleMap>();
+}
+
+/// destructor
+CandIsolatorFromDepositsMINIISO::~CandIsolatorFromDepositsMINIISO() {
+  std::vector<SingleDeposit>::iterator it, begin = sources_.begin(), end = sources_.end();
+  for (it = begin; it != end; ++it) it->cleanup();
+}
+
+/// build deposits
+void CandIsolatorFromDepositsMINIISO::produce(Event& event, const EventSetup& eventSetup){
+
+  std::vector<SingleDeposit>::iterator it, begin = sources_.begin(), end = sources_.end();
+  for (it = begin; it != end; ++it) it->open(event, eventSetup);
+
+  const IsoDepositMap & map = begin->map();
+
+  if (map.size()==0) { // !!???
+        event.put(std::auto_ptr<CandDoubleMap>(new CandDoubleMap()));
+        return;
+  }
+  std::auto_ptr<CandDoubleMap> ret(new CandDoubleMap());
+  CandDoubleMap::Filler filler(*ret);
+
+  typedef reco::IsoDepositMap::const_iterator iterator_i;
+  typedef reco::IsoDepositMap::container::const_iterator iterator_ii;
+  iterator_i depI = map.begin();
+  iterator_i depIEnd = map.end();
+  for (; depI != depIEnd; ++depI){
+    std::vector<double> retV(depI.size(),0);
+    edm::Handle<edm::View<reco::Candidate> > candH;
+    event.get(depI.id(), candH);
+    const edm::View<reco::Candidate>& candV = *candH;
+
+    iterator_ii depII = depI.begin();
+    iterator_ii depIIEnd = depI.end();
+    size_t iRet = 0;
+    for (; depII != depIIEnd; ++depII,++iRet){
+      double sum=0;
+      for (it = begin; it != end; ++it) sum += it->compute(candV.refAt(iRet));
+      retV[iRet] = sum;
+    }
+    filler.insert(candH, retV.begin(), retV.end());
+  }
+  filler.fill();
+  event.put(ret);
+}
+
+DEFINE_FWK_MODULE( CandIsolatorFromDepositsMINIISO );

--- a/core/plugins/CandIsolatorFromDepositsMINIISO.h
+++ b/core/plugins/CandIsolatorFromDepositsMINIISO.h
@@ -1,0 +1,61 @@
+#ifndef MuonIsolationProducers_CandIsolatorFromDeposits_H
+#define MuonIsolationProducers_CandIsolatorFromDeposits_H
+
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
+#include "DataFormats/RecoCandidate/interface/IsoDepositFwd.h"
+#include "DataFormats/RecoCandidate/interface/IsoDeposit.h"
+#include "PhysicsTools/IsolationAlgos/interface/EventDependentAbsVeto.h"
+
+#include "DataFormats/Candidate/interface/Candidate.h"
+#include "CommonTools/Utils/interface/StringObjectFunction.h"
+#include "DataFormats/Common/interface/OwnVector.h"
+
+#include <string>
+
+namespace edm { class Event; }
+namespace edm { class EventSetup; }
+
+class CandIsolatorFromDepositsMINIISO : public edm::stream::EDProducer<> {
+
+public:
+  typedef edm::ValueMap<double> CandDoubleMap;
+
+  enum Mode { Sum, SumRelative, Sum2, Sum2Relative, Max, MaxRelative, Count, NearestDR,MeanDR,SumDR };
+  CandIsolatorFromDepositsMINIISO(const edm::ParameterSet&);
+
+  virtual ~CandIsolatorFromDepositsMINIISO();
+
+  virtual void produce(edm::Event&, const edm::EventSetup&);
+
+private:
+  class SingleDeposit {
+    public:
+        SingleDeposit(const edm::ParameterSet &, edm::ConsumesCollector && iC) ;
+        void cleanup() ;
+        void open(const edm::Event &iEvent, const edm::EventSetup &iSetup) ;
+        double compute(const reco::CandidateBaseRef &cand) ;
+        const reco::IsoDepositMap & map() { return *hDeps_; }
+    private:
+        Mode mode_;
+        edm::EDGetTokenT<reco::IsoDepositMap> srcToken_;
+        double dRmin_;
+        double dRmax_;
+        double kTfac_;
+        bool   usesFunction_;
+        double weight_;
+        StringObjectFunction<reco::Candidate> weightExpr_;
+        reco::isodeposit::AbsVetos vetos_;
+        reco::isodeposit::EventDependentAbsVetos evdepVetos_; // note: these are a subset of the above. Don't delete twice!
+        bool   skipDefaultVeto_;
+        edm::Handle<reco::IsoDepositMap> hDeps_; // transient
+  };
+  // datamembers
+  std::vector<SingleDeposit> sources_;
+
+};
+#endif

--- a/core/plugins/NtupleWriterLeptons.cxx
+++ b/core/plugins/NtupleWriterLeptons.cxx
@@ -64,7 +64,17 @@ void NtupleWriterElectrons::process(const edm::Event & event, uhh2::Event & ueve
         ele.set_fbrem(pat_ele.fbrem());
         ele.set_EoverPIn(pat_ele.eSuperClusterOverP());
         ele.set_EcalEnergy(pat_ele.ecalEnergy());
-        
+
+        ele.set_mvaNonTrigV0(pat_ele.hasUserFloat("mvaNoTrig") ? pat_ele.userFloat("mvaNoTrig") : -999.);
+        ele.set_mvaTrigV0   (pat_ele.hasUserFloat("mvaTrig")   ? pat_ele.userFloat("mvaTrig")   : -999.);
+
+        ele.set_pfMINIIso_CH      (pat_ele.hasUserFloat("elPFMiniIsoValueCHSTAND") ? pat_ele.userFloat("elPFMiniIsoValueCHSTAND") : -999.);
+        ele.set_pfMINIIso_NH      (pat_ele.hasUserFloat("elPFMiniIsoValueNHSTAND") ? pat_ele.userFloat("elPFMiniIsoValueNHSTAND") : -999.);
+        ele.set_pfMINIIso_Ph      (pat_ele.hasUserFloat("elPFMiniIsoValuePhSTAND") ? pat_ele.userFloat("elPFMiniIsoValuePhSTAND") : -999.);
+        ele.set_pfMINIIso_PU      (pat_ele.hasUserFloat("elPFMiniIsoValuePUSTAND") ? pat_ele.userFloat("elPFMiniIsoValuePUSTAND") : -999.);
+        ele.set_pfMINIIso_NH_pfwgt(pat_ele.hasUserFloat("elPFMiniIsoValueNHPFWGT") ? pat_ele.userFloat("elPFMiniIsoValueNHPFWGT") : -999.);
+        ele.set_pfMINIIso_Ph_pfwgt(pat_ele.hasUserFloat("elPFMiniIsoValuePhPFWGT") ? pat_ele.userFloat("elPFMiniIsoValuePhPFWGT") : -999.);
+
         const edm::Ptr<pat::Electron> eleptr(ele_handle, i);
         for(size_t i_id=0; i_id<id_tags.size(); ++i_id){
             ele.set_tag(id_tags[i_id], (*electron_ids[i_id])[eleptr]);
@@ -91,7 +101,7 @@ NtupleWriterMuons::~NtupleWriterMuons(){}
 void NtupleWriterMuons::process(const edm::Event & event, uhh2::Event & uevent){
    edm::Handle<std::vector<pat::Muon>> mu_handle;
    event.getByToken(src_token, mu_handle);
-   
+
    edm::Handle<std::vector<reco::Vertex>> pv_handle;
    event.getByToken(pv_token, pv_handle);
    if(pv_handle->empty()){
@@ -99,7 +109,7 @@ void NtupleWriterMuons::process(const edm::Event & event, uhh2::Event & uevent){
        return;
    }
    const auto & PV = pv_handle->front();
-   
+
    vector<Muon> mus;
    for (const pat::Muon & pat_mu : *mu_handle) {
      mus.emplace_back();
@@ -109,32 +119,40 @@ void NtupleWriterMuons::process(const edm::Event & event, uhh2::Event & uevent){
      mu.set_eta( pat_mu.eta());
      mu.set_phi( pat_mu.phi());
      mu.set_energy( pat_mu.energy());
-     
+
      mu.set_dxy(pat_mu.muonBestTrack()->dxy(PV.position()));
      mu.set_dxy_error(pat_mu.muonBestTrack()->dxyError());
      mu.set_dz(pat_mu.muonBestTrack()->dz(PV.position()));
      mu.set_dz_error(pat_mu.muonBestTrack()->dzError());
-     
+
      mu.set_bool(Muon::global, pat_mu.isGlobalMuon());
      mu.set_bool(Muon::pf, pat_mu.isPFMuon());
      mu.set_bool(Muon::tracker, pat_mu.isTrackerMuon());
      mu.set_bool(Muon::standalone, pat_mu.isStandAloneMuon());
-     
-     mu.set_bool(Muon::soft, pat_mu.isSoftMuon(PV));
-     mu.set_bool(Muon::tight, pat_mu.isTightMuon(PV));
+
+     mu.set_bool(Muon::soft  , pat_mu.isSoftMuon(PV));
+     mu.set_bool(Muon::loose , pat_mu.isLooseMuon());
+     mu.set_bool(Muon::medium, pat_mu.isMediumMuon());
+     mu.set_bool(Muon::tight , pat_mu.isTightMuon(PV));
      mu.set_bool(Muon::highpt, pat_mu.isHighPtMuon(PV));
-     
+
      mu.set_sumChargedHadronPt(pat_mu.pfIsolationR04().sumChargedHadronPt);
      mu.set_sumNeutralHadronEt(pat_mu.pfIsolationR04().sumNeutralHadronEt);
      mu.set_sumPhotonEt(pat_mu.pfIsolationR04().sumPhotonEt);
      mu.set_sumPUPt(pat_mu.pfIsolationR04().sumPUPt);
+
+     mu.set_pfMINIIso_CH      (pat_mu.hasUserFloat("muPFMiniIsoValueCHSTAND") ? pat_mu.userFloat("muPFMiniIsoValueCHSTAND") : -999.);
+     mu.set_pfMINIIso_NH      (pat_mu.hasUserFloat("muPFMiniIsoValueNHSTAND") ? pat_mu.userFloat("muPFMiniIsoValueNHSTAND") : -999.);
+     mu.set_pfMINIIso_Ph      (pat_mu.hasUserFloat("muPFMiniIsoValuePhSTAND") ? pat_mu.userFloat("muPFMiniIsoValuePhSTAND") : -999.);
+     mu.set_pfMINIIso_PU      (pat_mu.hasUserFloat("muPFMiniIsoValuePUSTAND") ? pat_mu.userFloat("muPFMiniIsoValuePUSTAND") : -999.);
+     mu.set_pfMINIIso_NH_pfwgt(pat_mu.hasUserFloat("muPFMiniIsoValueNHPFWGT") ? pat_mu.userFloat("muPFMiniIsoValueNHPFWGT") : -999.);
+     mu.set_pfMINIIso_Ph_pfwgt(pat_mu.hasUserFloat("muPFMiniIsoValuePhPFWGT") ? pat_mu.userFloat("muPFMiniIsoValuePhPFWGT") : -999.);
    }
    uevent.set(handle, move(mus));
    if(muons_handle){
        EventAccess_::set_unmanaged(uevent, *muons_handle, &uevent.get(handle));
    }
 }
-
 
 
 NtupleWriterTaus::NtupleWriterTaus(Config & cfg, bool set_taus_member){
@@ -201,7 +219,7 @@ void NtupleWriterTaus::process(const edm::Event & event, uhh2::Event & uevent){
          FILL_TAU_BIT(byTightIsolationMVA3newDMwLT);
          FILL_TAU_BIT(byVTightIsolationMVA3newDMwLT);  // 30
          FILL_TAU_BIT(byVVTightIsolationMVA3newDMwLT); // 31
-         
+
          #undef FILL_TAU_BIT
          #define FILL_TAU_FLOAT(name) tau.set_##name (pat_tau.tauID(#name))
          
@@ -219,5 +237,4 @@ void NtupleWriterTaus::process(const edm::Event & event, uhh2::Event & uevent){
     if(taus_handle){
        EventAccess_::set_unmanaged(uevent, *taus_handle, &uevent.get(handle));
     }
- }
-
+}

--- a/core/plugins/PATElectronUserData.cc
+++ b/core/plugins/PATElectronUserData.cc
@@ -1,0 +1,117 @@
+// c++ include files
+#include <memory>
+#include <vector>
+#include <string>
+
+// default include files
+#include <FWCore/Framework/interface/Frameworkfwd.h>
+#include <FWCore/Framework/interface/EDProducer.h>
+#include <FWCore/Framework/interface/Event.h>
+#include <FWCore/Framework/interface/MakerMacros.h>
+#include <FWCore/ParameterSet/interface/ParameterSet.h>
+
+// non-default include files
+#include <DataFormats/PatCandidates/interface/Electron.h>
+
+#include <EgammaAnalysis/ElectronTools/interface/EGammaMvaEleEstimatorCSA14.h>
+
+// class declaration
+class PATElectronUserData : public edm::EDProducer {
+ public:
+  explicit PATElectronUserData(const edm::ParameterSet&);
+  ~PATElectronUserData() {}
+
+ private:
+  virtual void produce(edm::Event&, const edm::EventSetup&);
+
+  edm::EDGetTokenT< edm::View<pat::Electron> > src_;
+  std::vector<std::string> float_vmaps_;
+
+  std::vector<std::string> weights_mvaNoTrig_;
+  std::unique_ptr<EGammaMvaEleEstimatorCSA14> egammaMVAnotrig;
+
+  std::vector<std::string> weights_mvaTrig_;
+  std::unique_ptr<EGammaMvaEleEstimatorCSA14> egammaMVAtrig;
+};
+
+// constructor
+PATElectronUserData::PATElectronUserData(const edm::ParameterSet& iConfig){
+
+  src_ = consumes< edm::View<pat::Electron> >(iConfig.getParameter<edm::InputTag>("src"));
+  if(iConfig.exists("float_vmaps")) float_vmaps_ = iConfig.getParameter<std::vector<std::string>>("float_vmaps");
+
+  if(iConfig.exists("weights_mvaTrig")){
+
+    weights_mvaTrig_ = iConfig.getParameter<std::vector<std::string>>("weights_mvaTrig");
+
+    std::vector<std::string> weights_mvaTrig_FP;
+    weights_mvaTrig_FP.reserve(weights_mvaTrig_.size());
+    for(int i=0; i<int(weights_mvaTrig_.size()); ++i){
+      weights_mvaTrig_FP.push_back(edm::FileInPath(weights_mvaTrig_.at(i)).fullPath());
+    }
+    
+    egammaMVAtrig.reset(new EGammaMvaEleEstimatorCSA14());
+    egammaMVAtrig->initialize("BDT", EGammaMvaEleEstimatorCSA14::kTrig, true, weights_mvaTrig_FP);
+  }
+
+  if(iConfig.exists("weights_mvaNoTrig")){
+
+    weights_mvaNoTrig_ = iConfig.getParameter<std::vector<std::string>>("weights_mvaNoTrig");
+
+    std::vector<std::string> weights_mvaNoTrig_FP;
+    weights_mvaNoTrig_FP.reserve(weights_mvaNoTrig_.size());
+    for(int i=0; i<int(weights_mvaNoTrig_.size()); ++i){
+      weights_mvaNoTrig_FP.push_back(edm::FileInPath(weights_mvaNoTrig_.at(i)).fullPath());
+    }
+    
+    egammaMVAnotrig.reset(new EGammaMvaEleEstimatorCSA14());
+    egammaMVAnotrig->initialize("BDT", EGammaMvaEleEstimatorCSA14::kNonTrig, true, weights_mvaNoTrig_FP);
+  }
+
+  produces< pat::ElectronCollection >();
+}
+
+// ------------ method called to produce the data  ------------
+void PATElectronUserData::produce(edm::Event& iEvent, const edm::EventSetup& iSetup){
+
+  edm::Handle< edm::View<pat::Electron> > patElecs;
+  iEvent.getByToken(src_, patElecs);
+
+  std::vector< edm::Handle< edm::ValueMap<double> > > fvmaps;
+  for(int i=0; i<int(float_vmaps_.size()); ++i){
+
+    edm::Handle< edm::ValueMap<double> > fvmap;
+    iEvent.getByLabel(float_vmaps_.at(i), fvmap);
+    fvmaps.push_back(fvmap);
+  }
+
+  std::auto_ptr< pat::ElectronCollection > newElecs(new pat::ElectronCollection);
+  newElecs->reserve(patElecs->size());
+
+  for(int i=0; i<int(patElecs->size()); ++i){
+
+    newElecs->push_back(patElecs->at(i));
+    pat::Electron& ele = newElecs->back();
+
+    float notrigMVA = egammaMVAnotrig->mvaValue(ele, false);
+    float trigMVA   = egammaMVAtrig  ->mvaValue(ele, false);
+
+    ele.addUserFloat("mvaNoTrig", notrigMVA);
+    ele.addUserFloat("mvaTrig", trigMVA);
+
+    for(int j=0; j<int(fvmaps.size()); ++j){
+
+      if(ele.hasUserFloat(float_vmaps_.at(j)))
+	throw cms::Exception("InputError") << "@@@ PATElectronUserData::produce -- PAT user-float label already exists: " << float_vmaps_.at(j);
+
+      const double& val = (*(fvmaps.at(j)))[patElecs->refAt(i)];
+      ele.addUserFloat(float_vmaps_.at(j), float(val));
+    }
+  }
+
+  iEvent.put(newElecs);
+
+  return;
+}
+
+DEFINE_FWK_MODULE(PATElectronUserData);

--- a/core/plugins/PATMuonUserData.cc
+++ b/core/plugins/PATMuonUserData.cc
@@ -1,0 +1,74 @@
+// system include files
+#include <memory>
+#include <vector>
+#include <string>
+
+// user include files
+#include <FWCore/Framework/interface/Frameworkfwd.h>
+#include <FWCore/Framework/interface/EDProducer.h>
+#include <FWCore/Framework/interface/Event.h>
+#include <FWCore/Framework/interface/MakerMacros.h>
+#include <FWCore/ParameterSet/interface/ParameterSet.h>
+
+#include <DataFormats/PatCandidates/interface/Muon.h>
+
+// class declaration
+class PATMuonUserData : public edm::EDProducer {
+ public:
+  explicit PATMuonUserData(const edm::ParameterSet&);
+  ~PATMuonUserData() {}
+
+ private:
+  virtual void produce(edm::Event&, const edm::EventSetup&);
+
+  edm::EDGetTokenT< edm::View<pat::Muon> > src_;
+  std::vector<std::string> float_vmaps_;
+};
+
+// constructor
+PATMuonUserData::PATMuonUserData( const edm::ParameterSet& iConfig ){
+
+  src_ = consumes< edm::View<pat::Muon> >(iConfig.getParameter<edm::InputTag>("src"));
+  if(iConfig.exists("float_vmaps")) float_vmaps_ = iConfig.getParameter<std::vector<std::string>>("float_vmaps");
+
+  produces< pat::MuonCollection >();
+}
+
+// ------------ method called to produce the data  ------------
+void PATMuonUserData::produce(edm::Event& iEvent, const edm::EventSetup& iSetup){
+
+  edm::Handle< edm::View<pat::Muon> > patMuons;
+  iEvent.getByToken(src_, patMuons);
+
+  std::vector< edm::Handle< edm::ValueMap<double> > > fvmaps;
+  for(int i=0; i<int(float_vmaps_.size()); ++i){
+
+    edm::Handle< edm::ValueMap<double> > fvmap;
+    iEvent.getByLabel(float_vmaps_.at(i), fvmap);
+    fvmaps.push_back(fvmap);
+  }
+
+  std::auto_ptr< pat::MuonCollection > newMuons(new pat::MuonCollection);
+  newMuons->reserve(patMuons->size());
+
+  for(int i=0; i<int(patMuons->size()); ++i){
+
+    newMuons->push_back(patMuons->at(i));
+    pat::Muon& muo = newMuons->back();
+
+    for(int j=0; j<int(fvmaps.size()); ++j){
+
+      if(muo.hasUserFloat(float_vmaps_.at(j)))
+        throw cms::Exception("InputError") << "@@@ PATMuonUserData::produce -- PAT user-float label already exists: " << float_vmaps_.at(j);
+
+      const double& val = (*(fvmaps.at(j)))[patMuons->refAt(i)];
+      muo.addUserFloat(float_vmaps_.at(j), float(val));
+    }
+  }
+
+  iEvent.put(newMuons);
+
+  return;
+}
+
+DEFINE_FWK_MODULE(PATMuonUserData);

--- a/core/plugins/PFCandIsolatorFromDepositsMINIISO.cc
+++ b/core/plugins/PFCandIsolatorFromDepositsMINIISO.cc
@@ -1,0 +1,221 @@
+#include "UHH2/core/plugins/PFCandIsolatorFromDepositsMINIISO.h"
+
+// Framework
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/RecoCandidate/interface/IsoDepositDirection.h"
+#include "DataFormats/RecoCandidate/interface/IsoDeposit.h"
+#include "DataFormats/RecoCandidate/interface/IsoDepositFwd.h"
+#include "DataFormats/RecoCandidate/interface/IsoDepositVetos.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#include "DataFormats/RecoCandidate/interface/RecoCandidate.h"
+#include "DataFormats/Candidate/interface/CandAssociation.h"
+#include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include <string>
+#include <boost/regex.hpp>
+
+#include "PhysicsTools/IsolationAlgos/interface/IsoDepositVetoFactory.h"
+
+using namespace edm;
+using namespace reco;
+using namespace reco::isodeposit;
+
+bool PFCandIsolatorFromDepositsMINIISO::SingleDeposit::isNumber(const std::string &str) const {
+   static boost::regex re("^[+-]?(\\d+\\.?|\\d*\\.\\d*)$");
+   return regex_match(str.c_str(), re);
+}
+double PFCandIsolatorFromDepositsMINIISO::SingleDeposit::toNumber(const std::string &str) const {
+    return atof(str.c_str());
+}
+
+PFCandIsolatorFromDepositsMINIISO::SingleDeposit::SingleDeposit(const edm::ParameterSet &iConfig, edm::ConsumesCollector && iC) :
+  srcToken_(iC.consumes<reco::IsoDepositMap>(iConfig.getParameter<edm::InputTag>("src"))),
+  dRmin_(iConfig.getParameter<double>("dRmin")),
+  dRmax_(iConfig.getParameter<double>("dRmax")),
+  kTfac_(iConfig.getParameter<double>("kTfac")),
+  weightExpr_(iConfig.getParameter<std::string>("weight")),
+  skipDefaultVeto_(iConfig.getParameter<bool>("skipDefaultVeto")),
+  usePivotForBarrelEndcaps_(iConfig.getParameter<bool>("PivotCoordinatesForEBEE"))
+						      //,vetos_(new AbsVetos())
+{
+  std::string mode = iConfig.getParameter<std::string>("mode");
+  if (mode == "sum") mode_ = Sum;
+  else if (mode == "sumRelative") mode_ = SumRelative;
+  else if (mode == "sum2") mode_ = Sum2;
+  else if (mode == "sum2Relative") mode_ = Sum2Relative;
+  else if (mode == "max") mode_ = Max;
+  else if (mode == "maxRelative") mode_ = MaxRelative;
+  else if (mode == "nearestDR") mode_ = NearestDR;
+  else if (mode == "count") mode_ = Count;
+  else throw cms::Exception("Not Implemented") << "Mode '" << mode << "' not implemented. " <<
+    "Supported modes are 'sum', 'sumRelative', 'count'." <<
+    //"Supported modes are 'sum', 'sumRelative', 'max', 'maxRelative', 'count'." << // TODO: on request only
+    "New methods can be easily implemented if requested.";
+  typedef std::vector<std::string> vstring;
+  vstring vetos = iConfig.getParameter< vstring >("vetos");
+  reco::isodeposit::EventDependentAbsVeto *evdep=0;
+  static boost::regex ecalSwitch("^Ecal(Barrel|Endcaps):(.*)");
+
+  for (vstring::const_iterator it = vetos.begin(), ed = vetos.end(); it != ed; ++it) {
+    boost::cmatch match;
+    // in that case, make two series of vetoes
+    if( usePivotForBarrelEndcaps_) {
+      if (regex_match(it->c_str(), match, ecalSwitch))
+	{
+	  if(match[1] == "Barrel") {
+	    //	    std::cout << " Adding Barrel veto " << std::string(match[2]) << std::endl;
+	    barrelVetos_.push_back(IsoDepositVetoFactory::make(std::string(match[2]).c_str(), evdep, iC)); // I don't know a better syntax
+	  }
+	  if(match[1] == "Endcaps") {
+	    //	    std::cout << " Adding Endcap veto " << std::string(match[2]) << std::endl;
+	    endcapVetos_.push_back(IsoDepositVetoFactory::make(std::string(match[2]).c_str(), evdep, iC));
+	  }
+	}
+      else
+	{
+	  barrelVetos_.push_back(IsoDepositVetoFactory::make(it->c_str(), evdep, iC));
+	  endcapVetos_.push_back(IsoDepositVetoFactory::make(it->c_str(), evdep, iC));
+	}
+    } else {
+      //only one serie of vetoes, just barrel
+      barrelVetos_.push_back(IsoDepositVetoFactory::make(it->c_str(), evdep, iC));
+    }
+    if (evdep) evdepVetos_.push_back(evdep);
+  }
+
+  std::string weight = iConfig.getParameter<std::string>("weight");
+  if (isNumber(weight)) {
+    //std::cout << "Weight is a simple number, " << toNumber(weight) << std::endl;
+    weight_ = toNumber(weight);
+    usesFunction_ = false;
+  } else {
+    usesFunction_ = true;
+    //std::cout << "Weight is a function, this might slow you down... " << std::endl;
+  }
+  //std::cout << "PFCandIsolatorFromDeposits::SingleDeposit::SingleDeposit: Total of " << vetos_.size() << " vetos" << std::endl;
+}
+void PFCandIsolatorFromDepositsMINIISO::SingleDeposit::cleanup() {
+    for (AbsVetos::iterator it = barrelVetos_.begin(), ed = barrelVetos_.end(); it != ed; ++it) {
+        delete *it;
+    }
+    for (AbsVetos::iterator it = endcapVetos_.begin(), ed = endcapVetos_.end(); it != ed; ++it) {
+        delete *it;
+    }
+    barrelVetos_.clear();
+    endcapVetos_.clear();
+    // NOTE: we DON'T have to delete the evdepVetos_, they have already been deleted above. We just clear the vectors
+    evdepVetos_.clear();
+}
+void PFCandIsolatorFromDepositsMINIISO::SingleDeposit::open(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
+    iEvent.getByToken(srcToken_, hDeps_);
+    for (EventDependentAbsVetos::iterator it = evdepVetos_.begin(), ed = evdepVetos_.end(); it != ed; ++it) {
+        (*it)->setEvent(iEvent,iSetup);
+    }
+}
+
+double PFCandIsolatorFromDepositsMINIISO::SingleDeposit::compute(const reco::CandidateBaseRef &cand) {
+  double deltaR_ = cand->pt() ? fmax(dRmin_, fmin(dRmax_, kTfac_/cand->pt())) : dRmax_;
+    const IsoDeposit &dep = (*hDeps_)[cand];
+    double eta = dep.eta(), phi = dep.phi(); // better to center on the deposit direction
+                                             // that could be, e.g., the impact point at calo
+    bool barrel=true;
+    if( usePivotForBarrelEndcaps_) {
+      const reco::PFCandidate * myPFCand = dynamic_cast<const reco::PFCandidate*>(&(*cand));
+      if(myPFCand)  {
+	// exact barrel boundary
+	barrel = fabs(myPFCand->positionAtECALEntrance().eta())<1.479;
+      }
+      else {
+	const reco::RecoCandidate * myRecoCand = dynamic_cast<const reco::RecoCandidate*>(&(*cand));
+	if(myRecoCand) {
+	  // not optimal. isEB should be used.
+	  barrel = ( fabs(myRecoCand->superCluster()->eta())<1.479 );
+	}
+      }
+    }
+    // if ! usePivotForBarrelEndcaps_ only the barrel series is used, which does not prevent the vetoes do be different in barrel & endcaps
+    reco::isodeposit::AbsVetos * vetos = (barrel) ? &barrelVetos_ : &endcapVetos_;
+
+    for (AbsVetos::iterator it = vetos->begin(), ed = vetos->end(); it != ed; ++it) {
+        (*it)->centerOn(eta, phi);
+    }
+    double weight = (usesFunction_ ? weightExpr_(*cand) : weight_);
+    switch (mode_) {
+        case Count:        return weight * dep.countWithin(deltaR_, *vetos, skipDefaultVeto_);
+        case Sum:          return weight * dep.sumWithin(deltaR_, *vetos, skipDefaultVeto_);
+        case SumRelative:  return weight * dep.sumWithin(deltaR_, *vetos, skipDefaultVeto_) / dep.candEnergy() ;
+        case Sum2:         return weight * dep.sum2Within(deltaR_, *vetos, skipDefaultVeto_);
+        case Sum2Relative: return weight * dep.sum2Within(deltaR_, *vetos, skipDefaultVeto_) / (dep.candEnergy() * dep.candEnergy()) ;
+        case Max:          return weight * dep.maxWithin(deltaR_, *vetos, skipDefaultVeto_);
+        case NearestDR:    return weight * dep.nearestDR(deltaR_, *vetos, skipDefaultVeto_);
+        case MaxRelative:  return weight * dep.maxWithin(deltaR_, *vetos, skipDefaultVeto_) / dep.candEnergy() ;
+    }
+    throw cms::Exception("Logic error") << "Should not happen at " << __FILE__ << ", line " << __LINE__; // avoid gcc warning
+}
+
+/// constructor with config
+PFCandIsolatorFromDepositsMINIISO::PFCandIsolatorFromDepositsMINIISO(const ParameterSet& par) {
+  typedef std::vector<edm::ParameterSet> VPSet;
+  VPSet depPSets = par.getParameter<VPSet>("deposits");
+  for (VPSet::const_iterator it = depPSets.begin(), ed = depPSets.end(); it != ed; ++it) {
+    sources_.push_back(SingleDeposit(*it, consumesCollector()));
+  }
+  if (sources_.size() == 0) throw cms::Exception("Configuration Error") << "Please specify at least one deposit!";
+  produces<CandDoubleMap>();
+}
+
+/// destructor
+PFCandIsolatorFromDepositsMINIISO::~PFCandIsolatorFromDepositsMINIISO() {
+  std::vector<SingleDeposit>::iterator it, begin = sources_.begin(), end = sources_.end();
+  for (it = begin; it != end; ++it) it->cleanup();
+}
+
+/// build deposits
+void PFCandIsolatorFromDepositsMINIISO::produce(Event& event, const EventSetup& eventSetup){
+
+  std::vector<SingleDeposit>::iterator it, begin = sources_.begin(), end = sources_.end();
+  for (it = begin; it != end; ++it) it->open(event, eventSetup);
+
+  const IsoDepositMap & map = begin->map();
+
+  if (map.size()==0) { // !!???
+        event.put(std::auto_ptr<CandDoubleMap>(new CandDoubleMap()));
+        return;
+  }
+  std::auto_ptr<CandDoubleMap> ret(new CandDoubleMap());
+  CandDoubleMap::Filler filler(*ret);
+
+  typedef reco::IsoDepositMap::const_iterator iterator_i;
+  typedef reco::IsoDepositMap::container::const_iterator iterator_ii;
+  iterator_i depI = map.begin();
+  iterator_i depIEnd = map.end();
+  for (; depI != depIEnd; ++depI){
+    std::vector<double> retV(depI.size(),0);
+    edm::Handle<edm::View<reco::Candidate> > candH;
+    event.get(depI.id(), candH);
+    const edm::View<reco::Candidate>& candV = *candH;
+
+    iterator_ii depII = depI.begin();
+    iterator_ii depIIEnd = depI.end();
+    size_t iRet = 0;
+    for (; depII != depIIEnd; ++depII,++iRet){
+      double sum=0;
+      for (it = begin; it != end; ++it) sum += it->compute(candV.refAt(iRet));
+      retV[iRet] = sum;
+    }
+    filler.insert(candH, retV.begin(), retV.end());
+  }
+  filler.fill();
+  event.put(ret);
+}
+
+DEFINE_FWK_MODULE( PFCandIsolatorFromDepositsMINIISO );

--- a/core/plugins/PFCandIsolatorFromDepositsMINIISO.h
+++ b/core/plugins/PFCandIsolatorFromDepositsMINIISO.h
@@ -1,0 +1,69 @@
+#ifndef PFCandIsolatorFromDepositsMINIISO_H
+#define PFCandIsolatorFromDepositsMINIISO_H
+
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
+#include "DataFormats/RecoCandidate/interface/IsoDepositFwd.h"
+#include "DataFormats/RecoCandidate/interface/IsoDeposit.h"
+#include "PhysicsTools/IsolationAlgos/interface/EventDependentAbsVeto.h"
+
+#include "DataFormats/Candidate/interface/Candidate.h"
+#include "CommonTools/Utils/interface/StringObjectFunction.h"
+#include "DataFormats/Common/interface/OwnVector.h"
+
+#include <string>
+
+namespace edm { class Event; }
+namespace edm { class EventSetup; }
+
+class PFCandIsolatorFromDepositsMINIISO : public edm::stream::EDProducer<> {
+
+public:
+  typedef edm::ValueMap<double> CandDoubleMap;
+
+  enum Mode { Sum, SumRelative, Sum2, Sum2Relative, Max, MaxRelative, Count, NearestDR };
+  PFCandIsolatorFromDepositsMINIISO(const edm::ParameterSet&);
+
+  virtual ~PFCandIsolatorFromDepositsMINIISO();
+
+  virtual void produce(edm::Event&, const edm::EventSetup&);
+
+private:
+  class SingleDeposit {
+    public:
+        SingleDeposit(const edm::ParameterSet &, edm::ConsumesCollector && iC) ;
+        void cleanup() ;
+        void open(const edm::Event &iEvent, const edm::EventSetup &iSetup) ;
+        double compute(const reco::CandidateBaseRef &cand) ;
+        const reco::IsoDepositMap & map() { return *hDeps_; }
+    private:
+        Mode mode_;
+        edm::EDGetTokenT<reco::IsoDepositMap> srcToken_;
+        double dRmin_;
+        double dRmax_;
+        double kTfac_;
+        bool   usesFunction_;
+        double weight_;
+
+        StringObjectFunction<reco::Candidate> weightExpr_;
+        reco::isodeposit::AbsVetos barrelVetos_;
+        reco::isodeposit::AbsVetos endcapVetos_;
+        reco::isodeposit::EventDependentAbsVetos evdepVetos_; // note: these are a subset of the above. Don't delete twice!
+        bool   skipDefaultVeto_;
+	bool usePivotForBarrelEndcaps_;
+        edm::Handle<reco::IsoDepositMap> hDeps_; // transient
+
+	bool isNumber(const std::string &str) const ;
+	double toNumber(const std::string &str) const ;
+  };
+  // datamembers
+  std::vector<SingleDeposit> sources_;
+
+
+
+};
+#endif

--- a/core/plugins/convertPackedCandToPFCand.cc
+++ b/core/plugins/convertPackedCandToPFCand.cc
@@ -1,0 +1,47 @@
+#include <FWCore/Framework/interface/Frameworkfwd.h>
+#include <FWCore/Framework/interface/EDProducer.h>
+#include <FWCore/Framework/interface/Event.h>
+#include <FWCore/Framework/interface/MakerMacros.h>
+#include <FWCore/ParameterSet/interface/ParameterSet.h>
+ 
+#include <DataFormats/PatCandidates/interface/PackedCandidate.h>
+#include <DataFormats/ParticleFlowCandidate/interface/PFCandidate.h>
+#include <memory>
+
+class convertPackedCandToPFCand : public edm::EDProducer {
+
+ public:
+  convertPackedCandToPFCand(const edm::ParameterSet& iConfig);
+  ~convertPackedCandToPFCand() {}
+  
+ private:
+  void produce(edm::Event& iEvent, const edm::EventSetup& iSetup);
+  edm::EDGetTokenT< pat::PackedCandidateCollection > src_;
+};
+
+convertPackedCandToPFCand::convertPackedCandToPFCand(const edm::ParameterSet& iConfig){
+
+  src_ = consumes< pat::PackedCandidateCollection >(iConfig.getParameter<edm::InputTag>("src"));
+  produces<reco::PFCandidateCollection>();
+}
+
+void convertPackedCandToPFCand::produce(edm::Event& iEvent,const edm::EventSetup& iSetup){
+
+  edm::Handle< pat::PackedCandidateCollection > packedCands_;
+  iEvent.getByToken(src_, packedCands_);
+
+  std::auto_ptr< reco::PFCandidateCollection > recoPFCands(new reco::PFCandidateCollection());
+
+  reco::PFCandidate dummy;
+  for(int iCand=0; iCand<int(packedCands_->size()); ++iCand){
+
+    reco::PFCandidate intPFCand(packedCands_->at(iCand).charge(),packedCands_->at(iCand).p4(), dummy.translatePdgIdToType(packedCands_->at(iCand).pdgId()));
+    recoPFCands->push_back(intPFCand);
+  }
+
+  iEvent.put(recoPFCands);
+
+  return;
+}
+
+DEFINE_FWK_MODULE(convertPackedCandToPFCand);

--- a/core/python/electron_pfMiniIsolation_cff.py
+++ b/core/python/electron_pfMiniIsolation_cff.py
@@ -1,0 +1,88 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoParticleFlow.PFProducer.electronPFIsolationDeposits_cff import *
+from RecoParticleFlow.PFProducer.electronPFIsolationValues_cff import *
+
+def init_module_elPFMiniIsoValue(imod, R_max, R_min, KTfac):
+    mod = cms.EDProducer('PFCandIsolatorFromDepositsMINIISO',
+      deposits = cms.VPSet(
+        cms.PSet(
+          src = imod.deposits[0].src,
+          weight = imod.deposits[0].weight,
+          vetos = imod.deposits[0].vetos,
+          skipDefaultVeto = imod.deposits[0].skipDefaultVeto,
+          mode = imod.deposits[0].mode,
+          PivotCoordinatesForEBEE = imod.deposits[0].PivotCoordinatesForEBEE,
+
+          dRmax = cms.double(R_max),
+          dRmin = cms.double(R_min),
+          kTfac = cms.double(KTfac),
+        )
+      )
+    )
+
+    return mod
+
+def load_elecPFMiniIso(proc, seq_name, algo, isoval_list, src,
+                       src_charged_hadron='', src_neutral_hadron='', src_photon='', src_charged_pileup='',
+                       dRmax=.20, dRmin=.05, kTfac=10.):
+
+    # deposits
+    iso_seq = cms.Sequence()
+
+    if src_charged_hadron:
+        setattr(proc, 'elPFMiniIsoDepositCH'+algo, elPFIsoDepositCharged.clone())
+        getattr(proc, 'elPFMiniIsoDepositCH'+algo).src = cms.InputTag(src)
+        getattr(proc, 'elPFMiniIsoDepositCH'+algo).ExtractorPSet.inputCandView = cms.InputTag(src_charged_hadron)
+        iso_seq += getattr(proc, 'elPFMiniIsoDepositCH'+algo)
+
+    if src_neutral_hadron:
+        setattr(proc, 'elPFMiniIsoDepositNH'+algo, elPFIsoDepositNeutral.clone())
+        getattr(proc, 'elPFMiniIsoDepositNH'+algo).src = cms.InputTag(src)
+        getattr(proc, 'elPFMiniIsoDepositNH'+algo).ExtractorPSet.inputCandView = cms.InputTag(src_neutral_hadron)
+        iso_seq += getattr(proc, 'elPFMiniIsoDepositNH'+algo)
+
+    if src_photon:
+        setattr(proc, 'elPFMiniIsoDepositPh'+algo, elPFIsoDepositGamma.clone())
+        getattr(proc, 'elPFMiniIsoDepositPh'+algo).src = cms.InputTag(src)
+        getattr(proc, 'elPFMiniIsoDepositPh'+algo).ExtractorPSet.inputCandView = cms.InputTag(src_photon)
+        iso_seq += getattr(proc, 'elPFMiniIsoDepositPh'+algo)
+
+    if src_charged_pileup:
+        setattr(proc, 'elPFMiniIsoDepositPU'+algo, elPFIsoDepositPU.clone())
+        getattr(proc, 'elPFMiniIsoDepositPU'+algo).src = cms.InputTag(src)
+        getattr(proc, 'elPFMiniIsoDepositPU'+algo).ExtractorPSet.inputCandView = cms.InputTag(src_charged_pileup)
+        iso_seq += getattr(proc, 'elPFMiniIsoDepositPU'+algo)
+
+    # values
+    iso_vals_seq = cms.Sequence()
+
+    if src_charged_hadron:
+        setattr(proc, 'elPFMiniIsoValueCH'+algo, init_module_elPFMiniIsoValue(elPFIsoValueCharged03PFId, R_max=dRmax, R_min=dRmin, KTfac=kTfac))
+        getattr(proc, 'elPFMiniIsoValueCH'+algo).deposits[0].src = cms.InputTag('elPFMiniIsoDepositCH'+algo)
+        iso_vals_seq += getattr(proc, 'elPFMiniIsoValueCH'+algo)
+        isoval_list.append('elPFMiniIsoValueCH'+algo)
+
+    if src_neutral_hadron:
+        setattr(proc, 'elPFMiniIsoValueNH'+algo, init_module_elPFMiniIsoValue(elPFIsoValueNeutral03PFId, R_max=dRmax, R_min=dRmin, KTfac=kTfac))
+        getattr(proc, 'elPFMiniIsoValueNH'+algo).deposits[0].src = cms.InputTag('elPFMiniIsoDepositNH'+algo)
+        iso_vals_seq += getattr(proc, 'elPFMiniIsoValueNH'+algo)
+        isoval_list.append('elPFMiniIsoValueNH'+algo)
+
+    if src_photon:
+        setattr(proc, 'elPFMiniIsoValuePh'+algo, init_module_elPFMiniIsoValue(elPFIsoValueGamma03PFId, R_max=dRmax, R_min=dRmin, KTfac=kTfac))
+        getattr(proc, 'elPFMiniIsoValuePh'+algo).deposits[0].src = cms.InputTag('elPFMiniIsoDepositPh'+algo)
+        iso_vals_seq += getattr(proc, 'elPFMiniIsoValuePh'+algo)
+        isoval_list.append('elPFMiniIsoValuePh'+algo)
+
+    if src_charged_pileup:
+        setattr(proc, 'elPFMiniIsoValuePU'+algo, init_module_elPFMiniIsoValue(elPFIsoValuePU03PFId, R_max=dRmax, R_min=dRmin, KTfac=kTfac))
+        getattr(proc, 'elPFMiniIsoValuePU'+algo).deposits[0].src = cms.InputTag('elPFMiniIsoDepositPU'+algo)
+        iso_vals_seq += getattr(proc, 'elPFMiniIsoValuePU'+algo)
+        isoval_list.append('elPFMiniIsoValuePU'+algo)
+
+    iso_seq *= iso_vals_seq
+
+    setattr(proc, seq_name, iso_seq)
+
+    return

--- a/core/python/muon_pfMiniIsolation_cff.py
+++ b/core/python/muon_pfMiniIsolation_cff.py
@@ -1,0 +1,86 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoMuon.MuonIsolation.muonPFIsolationDeposits_cff import *
+from RecoMuon.MuonIsolation.muonPFIsolationValues_cff import *
+
+def init_module_muPFMiniIsoValue(imod, R_max, R_min, KTfac):
+    mod = cms.EDProducer('CandIsolatorFromDepositsMINIISO',
+      deposits = cms.VPSet(
+        cms.PSet(
+          src = imod.deposits[0].src,
+          weight = imod.deposits[0].weight,
+          vetos = imod.deposits[0].vetos,
+          skipDefaultVeto = imod.deposits[0].skipDefaultVeto,
+          mode = imod.deposits[0].mode,
+
+          dRmax = cms.double(R_max),
+          dRmin = cms.double(R_min),
+          kTfac = cms.double(KTfac),
+        )
+      )
+    )
+
+    return mod
+
+def load_muonPFMiniIso(proc, seq_name, algo, isoval_list, src,
+                       src_charged_hadron='', src_neutral_hadron='', src_photon='', src_charged_pileup='',
+                       dRmax=.20, dRmin=.05, kTfac=10.):
+    # deposits
+    iso_seq = cms.Sequence()
+
+    if src_charged_hadron:
+        setattr(proc, 'muPFMiniIsoDepositCH'+algo, muPFIsoDepositCharged.clone())
+        getattr(proc, 'muPFMiniIsoDepositCH'+algo).src = cms.InputTag(src)
+        getattr(proc, 'muPFMiniIsoDepositCH'+algo).ExtractorPSet.inputCandView = cms.InputTag(src_charged_hadron)
+        iso_seq += getattr(proc, 'muPFMiniIsoDepositCH'+algo)
+
+    if src_neutral_hadron:
+        setattr(proc, 'muPFMiniIsoDepositNH'+algo, muPFIsoDepositNeutral.clone())
+        getattr(proc, 'muPFMiniIsoDepositNH'+algo).src = cms.InputTag(src)
+        getattr(proc, 'muPFMiniIsoDepositNH'+algo).ExtractorPSet.inputCandView = cms.InputTag(src_neutral_hadron)
+        iso_seq += getattr(proc, 'muPFMiniIsoDepositNH'+algo)
+
+    if src_photon:
+        setattr(proc, 'muPFMiniIsoDepositPh'+algo, muPFIsoDepositGamma.clone())
+        getattr(proc, 'muPFMiniIsoDepositPh'+algo).src = cms.InputTag(src)
+        getattr(proc, 'muPFMiniIsoDepositPh'+algo).ExtractorPSet.inputCandView = cms.InputTag(src_photon)
+        iso_seq += getattr(proc, 'muPFMiniIsoDepositPh'+algo)
+
+    if src_charged_pileup:
+        setattr(proc, 'muPFMiniIsoDepositPU'+algo, muPFIsoDepositPU.clone())
+        getattr(proc, 'muPFMiniIsoDepositPU'+algo).src = cms.InputTag(src)
+        getattr(proc, 'muPFMiniIsoDepositPU'+algo).ExtractorPSet.inputCandView = cms.InputTag(src_charged_pileup)
+        iso_seq += getattr(proc, 'muPFMiniIsoDepositPU'+algo)
+
+    # values
+    iso_vals_seq = cms.Sequence()
+
+    if src_charged_hadron:
+        setattr(proc, 'muPFMiniIsoValueCH'+algo, init_module_muPFMiniIsoValue(muPFIsoValueCharged03, R_max=dRmax, R_min=dRmin, KTfac=kTfac))
+        getattr(proc, 'muPFMiniIsoValueCH'+algo).deposits[0].src = cms.InputTag('muPFMiniIsoDepositCH'+algo)
+        iso_vals_seq += getattr(proc, 'muPFMiniIsoValueCH'+algo)
+        isoval_list.append('muPFMiniIsoValueCH'+algo)
+
+    if src_neutral_hadron:
+        setattr(proc, 'muPFMiniIsoValueNH'+algo, init_module_muPFMiniIsoValue(muPFIsoValueNeutral03, R_max=dRmax, R_min=dRmin, KTfac=kTfac))
+        getattr(proc, 'muPFMiniIsoValueNH'+algo).deposits[0].src = cms.InputTag('muPFMiniIsoDepositNH'+algo)
+        iso_vals_seq += getattr(proc, 'muPFMiniIsoValueNH'+algo)
+        isoval_list.append('muPFMiniIsoValueNH'+algo)
+
+    if src_photon:
+        setattr(proc, 'muPFMiniIsoValuePh'+algo, init_module_muPFMiniIsoValue(muPFIsoValueGamma03, R_max=dRmax, R_min=dRmin, KTfac=kTfac))
+        getattr(proc, 'muPFMiniIsoValuePh'+algo).deposits[0].src = cms.InputTag('muPFMiniIsoDepositPh'+algo)
+        iso_vals_seq += getattr(proc, 'muPFMiniIsoValuePh'+algo)
+        isoval_list.append('muPFMiniIsoValuePh'+algo)
+
+    if src_charged_pileup:
+        setattr(proc, 'muPFMiniIsoValuePU'+algo, init_module_muPFMiniIsoValue(muPFIsoValuePU03, R_max=dRmax, R_min=dRmin, KTfac=kTfac))
+        getattr(proc, 'muPFMiniIsoValuePU'+algo).deposits[0].src = cms.InputTag('muPFMiniIsoDepositPU'+algo)
+        iso_vals_seq += getattr(proc, 'muPFMiniIsoValuePU'+algo)
+        isoval_list.append('muPFMiniIsoValuePU'+algo)
+
+    iso_seq *= iso_vals_seq
+
+    setattr(proc, seq_name, iso_seq)
+
+    return

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -24,8 +24,7 @@ process.MessageLogger.cerr.FwkReport.reportEvery = cms.untracked.int32(1)
 process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(False) , allowUnscheduled = cms.untracked.bool(True) )
 
 process.source = cms.Source("PoolSource",
-                            fileNames  = cms.untracked.vstring("file:../../../../../../../0A303F70-1DFE-E411-B2C7-001E67A4069F.root"),
-#                            fileNames  = cms.untracked.vstring("file:/nfs/dust/cms/user/peiffer/ZprimeToTT_M-2000_W-200_50ns_MCRUN2_TEST_MINIAODSIM.root"),
+                            fileNames  = cms.untracked.vstring("file:/nfs/dust/cms/user/peiffer/ZprimeToTT_M-2000_W-200_50ns_MCRUN2_TEST_MINIAODSIM.root"),
                             skipEvents = cms.untracked.uint32(0)
 )
 

--- a/core/python/pfCandidatesByType_cff.py
+++ b/core/python/pfCandidatesByType_cff.py
@@ -1,0 +1,39 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoParticleFlow.PFProducer.particleFlowTmpPtrs_cfi import *
+from CommonTools.ParticleFlow.pfNoPileUp_cff import *
+from CommonTools.ParticleFlow.ParticleSelectors.pfAllChargedParticles_cfi import *
+from CommonTools.ParticleFlow.ParticleSelectors.pfAllChargedHadrons_cfi import *
+from CommonTools.ParticleFlow.ParticleSelectors.pfAllNeutralHadrons_cfi import *
+from CommonTools.ParticleFlow.ParticleSelectors.pfAllPhotons_cfi import *
+
+convertedPackedPFCandidates = cms.EDProducer('convertPackedCandToPFCand',
+  src = cms.InputTag('packedPFCandidates')
+)
+
+convertedPackedPFCandidatePtrs = particleFlowTmpPtrs.clone(src = 'convertedPackedPFCandidates')
+
+pfPileUp.PFCandidates = 'convertedPackedPFCandidatePtrs'
+pfPileUp.Vertices = 'offlineSlimmedPrimaryVertices'
+pfNoPileUp.bottomCollection = pfPileUp.PFCandidates
+
+pfAllChargedParticles.src = 'pfNoPileUp'
+pfAllChargedHadrons.src = 'pfNoPileUp'
+pfAllNeutralHadrons.src = 'pfNoPileUp'
+pfAllPhotons.src = 'pfNoPileUp'
+pfPileUpAllChargedParticles = pfAllChargedParticles.clone(src = 'pfPileUp')
+
+pfSelectorsSequence = cms.Sequence(
+    pfAllChargedParticles
+  + pfAllChargedHadrons
+  + pfAllNeutralHadrons
+  + pfAllPhotons
+  + pfPileUpAllChargedParticles
+)
+
+pfCandidatesByTypeSequence = cms.Sequence(
+    convertedPackedPFCandidates
+  * convertedPackedPFCandidatePtrs
+  * pfNoPileUpSequence
+  * pfSelectorsSequence
+)

--- a/env.sh
+++ b/env.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+cmsenv
+
+# Electron MVA
+mkdir -p $CMSSW_BASE/src/EgammaAnalysis/ElectronTools/data/CSA14
+cd $CMSSW_BASE/src/EgammaAnalysis/ElectronTools/data/CSA14
+
+wget https://raw.githubusercontent.com/HuguesBrun/cmssw/addTheElecIDMVAoutputCSA14/EgammaAnalysis/ElectronTools/data/CSA14/EIDmva_EB_10_25ns_BDT.weights.xml
+wget https://raw.githubusercontent.com/HuguesBrun/cmssw/addTheElecIDMVAoutputCSA14/EgammaAnalysis/ElectronTools/data/CSA14/EIDmva_EB_10_50ns_BDT.weights.xml
+wget https://raw.githubusercontent.com/HuguesBrun/cmssw/addTheElecIDMVAoutputCSA14/EgammaAnalysis/ElectronTools/data/CSA14/EIDmva_EB_5_25ns_BDT.weights.xml
+wget https://raw.githubusercontent.com/HuguesBrun/cmssw/addTheElecIDMVAoutputCSA14/EgammaAnalysis/ElectronTools/data/CSA14/EIDmva_EB_5_50ns_BDT.weights.xml
+wget https://raw.githubusercontent.com/HuguesBrun/cmssw/addTheElecIDMVAoutputCSA14/EgammaAnalysis/ElectronTools/data/CSA14/EIDmva_EE_10_25ns_BDT.weights.xml
+wget https://raw.githubusercontent.com/HuguesBrun/cmssw/addTheElecIDMVAoutputCSA14/EgammaAnalysis/ElectronTools/data/CSA14/EIDmva_EE_10_50ns_BDT.weights.xml
+wget https://raw.githubusercontent.com/HuguesBrun/cmssw/addTheElecIDMVAoutputCSA14/EgammaAnalysis/ElectronTools/data/CSA14/EIDmva_EE_5_25ns_BDT.weights.xml
+wget https://raw.githubusercontent.com/HuguesBrun/cmssw/addTheElecIDMVAoutputCSA14/EgammaAnalysis/ElectronTools/data/CSA14/EIDmva_EE_5_50ns_BDT.weights.xml
+wget https://raw.githubusercontent.com/HuguesBrun/cmssw/addTheElecIDMVAoutputCSA14/EgammaAnalysis/ElectronTools/data/CSA14/TrigIDMVA_25ns_EB_BDT.weights.xml
+wget https://raw.githubusercontent.com/HuguesBrun/cmssw/addTheElecIDMVAoutputCSA14/EgammaAnalysis/ElectronTools/data/CSA14/TrigIDMVA_25ns_EE_BDT.weights.xml
+wget https://raw.githubusercontent.com/HuguesBrun/cmssw/addTheElecIDMVAoutputCSA14/EgammaAnalysis/ElectronTools/data/CSA14/TrigIDMVA_50ns_EB_BDT.weights.xml
+wget https://raw.githubusercontent.com/HuguesBrun/cmssw/addTheElecIDMVAoutputCSA14/EgammaAnalysis/ElectronTools/data/CSA14/TrigIDMVA_50ns_EE_BDT.weights.xml
+
+cd $OLDPWD


### PR DESCRIPTION
* addition of some variables for lepton reconstruction
 * mini-isolation
 * muon medium-ID
 * electron MVA

* important: updates tested in CMSSW_7_4_3 (on top of the compilation instructions in the UHH2/ twiki)

* mini-isolation:
 * mini-isolation deposits are calculated using 2 plugins (located in core/plugins/):

  * MUONS: plugin="CandIsolatorFromDepositsMINIISO": minimal generalization of the standard plugin "PhysicsTools/IsolationAlgos/plugins/CandIsolatorFromDeposits.*", which is used for the standard (fixed-cone) calculation of the isolation deposits for muons (see RecoMuon.MuonIsolation.muonPFIsolationValues_cff).

  * ELECTRONS: plugin="PFCandIsolatorFromDepositsMINIISO": minimal generalization of the standard plugin "CommonTools/ParticleFlow/plugins/PFCandIsolatorFromDeposit.*", which is used for the standard (fixed-cone) calculation of the isolation deposits for muons (see RecoParticleFlow.PFProducer.electronPFIsolationValues_cff).

 * value-maps for the mini-isolation deposits are loaded in core/python/*_pfMiniIsolation_cff.py
  * this is done in a way that (aside for handling the cone size) the configuration of the standard modules for the isolation deposits is used (minimum pt threshold on the candidates, geometrical vetos etc)
  * the 3 parameters for the mini-isolation cone can be configured from arguments of the python function. the default values are those proposed in the SUSY PAG from their first studies on mini-isolation (see https://indico.cern.ch/event/388718/contribution/5/material/slides/0.pdf).

 * 6 values are computed for each lepton: sum_pT deposits for charged-hadrons ("CH"), neutral-hadrons ("NH"), photons ("Ph"), charged pileup ("PU"), neutral-hadrons with PF-reweighting ("NH_pfwgt"), photons with PF-reweighting ("Ph_pfwgt"). PF-reweighting is a new method proposed for PU mitigation (see, for example, https://github.com/cms-sw/cmssw/pull/4131 and refs therein)
 * added new float members to Muon and Electron classes for mini-iso sum-pT deposits

* muon medium-ID:
 * value taken from pat::Muon::isMediumMuon()
 * added via the tag mechanism in Muon class

* electron MVA:
 * added via to collection of pat::Electron via the addUserFloat method
 * implementation taken from example in https://github.com/HuguesBrun/ExampleElectronMVAid/blob/addMVAfromMiniAOD/plugins/ExampleElectronMVAid.cc (as https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2)
 * added to Electron class through the (already present) float members "mvaNonTrigV0" and "mvaTrigV0"
 * .xml files for the MVA calculation have to be downloaded by hand (as far as i know) before running. a script that does that can be found under core/env.sh
