### PR TITLE
put PrimaryLepton into own file to make code clearer

### DIFF
--- a/common/include/PrimaryLepton.h
+++ b/common/include/PrimaryLepton.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "UHH2/core/include/AnalysisModule.h"
+#include "UHH2/core/include/Event.h"
+
+/** \brief Search the highest-pt lepton (electron or muon)
+ *
+ * The found lepton is written to the event as FlavourParticle
+ * with name "PrimaryLepton". Should be called after proper cleaning
+ * modules for electron and muon ID.
+ *
+ */
+class PrimaryLepton: public uhh2::AnalysisModule {
+public:
+    explicit PrimaryLepton(uhh2::Context & ctx, const std::string & h_name="PrimaryLepton");
+
+    virtual bool process(uhh2::Event & event) override;
+
+    virtual ~PrimaryLepton();
+
+private:
+    uhh2::Event::Handle<FlavorParticle> h_primlep;
+};

--- a/common/include/TTbarReconstruction.h
+++ b/common/include/TTbarReconstruction.h
@@ -6,28 +6,10 @@
 #include "UHH2/core/include/Event.h"
 #include "UHH2/common/include/ObjectIdUtils.h"
 #include "UHH2/common/include/TopJetIds.h"
+#include "UHH2/common/include/PrimaryLepton.h"
+
 
 typedef std::function< std::vector<LorentzVector>  (const LorentzVector & lepton, const LorentzVector & met)> NeutrinoReconstructionMethod;
-
-
-/** \brief Search the highest-pt lepton (electron or muon)
- *
- * The found lepton is written to the event as FlavourParticle
- * with name "PrimaryLepton". Should be called after proper cleaning
- * modules for electron and muon ID.
- *
- */
-class PrimaryLepton: public uhh2::AnalysisModule {
-public:
-    explicit PrimaryLepton(uhh2::Context & ctx, const std::string & h_name="PrimaryLepton");
-
-    virtual bool process(uhh2::Event & event) override;
-
-    virtual ~PrimaryLepton();
-
-private:
-    uhh2::Event::Handle<FlavorParticle> h_primlep;
-};
 
 
 /** \brief Make a list of ttbar reconstruction hypotheses as used in high-mass semileptonic ttbar 8 TeV analysis

--- a/common/src/PrimaryLepton.cxx
+++ b/common/src/PrimaryLepton.cxx
@@ -1,0 +1,35 @@
+#include "UHH2/common/include/PrimaryLepton.h"
+#include "UHH2/core/include/Utils.h"
+
+using namespace uhh2;
+using namespace std;
+
+PrimaryLepton::PrimaryLepton(Context & ctx, const std::string & h_name) {
+    h_primlep = ctx.get_handle<FlavorParticle>(h_name);
+}
+
+bool PrimaryLepton::process(uhh2::Event & event) {
+    assert(event.muons || event.electrons);
+    double ptmax = -infinity;
+    FlavorParticle primlep;
+    if(event.electrons) {
+        for(const auto & ele : *event.electrons) {
+            if(ele.pt() > ptmax) {
+                ptmax = ele.pt();
+                primlep = ele;
+            }
+        }
+    }
+    if(event.muons) {
+        for(const auto & mu : *event.muons) {
+            if(mu.pt() > ptmax) {
+                ptmax = mu.pt();
+                primlep = mu;
+            }
+        }
+    }
+    event.set(h_primlep, std::move(primlep));
+    return true;
+}
+
+PrimaryLepton::~PrimaryLepton() {}

--- a/common/src/TTbarReconstruction.cxx
+++ b/common/src/TTbarReconstruction.cxx
@@ -8,36 +8,6 @@
 using namespace uhh2;
 using namespace std;
 
-PrimaryLepton::PrimaryLepton(Context & ctx, const std::string & h_name) {
-    h_primlep = ctx.get_handle<FlavorParticle>(h_name);
-}
-
-bool PrimaryLepton::process(uhh2::Event & event) {
-    assert(event.muons || event.electrons);
-    double ptmax = -infinity;
-    FlavorParticle primlep;
-    if(event.electrons) {
-        for(const auto & ele : *event.electrons) {
-            if(ele.pt() > ptmax) {
-                ptmax = ele.pt();
-                primlep = ele;
-            }
-        }
-    }
-    if(event.muons) {
-        for(const auto & mu : *event.muons) {
-            if(mu.pt() > ptmax) {
-                ptmax = mu.pt();
-                primlep = mu;
-            }
-        }
-    }
-    event.set(h_primlep, std::move(primlep));
-    return true;
-}
-
-PrimaryLepton::~PrimaryLepton() {}
-
 HighMassTTbarReconstruction::HighMassTTbarReconstruction(Context & ctx, const NeutrinoReconstructionMethod & neutrinofunction, const string & label): m_neutrinofunction(neutrinofunction) {
     h_recohyps = ctx.declare_event_output<vector<ReconstructionHypothesis>>(label);
     h_primlep = ctx.get_handle<FlavorParticle>("PrimaryLepton");


### PR DESCRIPTION
I put the PrimaryLepton class into a file on its own because I think it can be used outside of ttbar reconstruction (e.g. for the semi-leptonic VLQ searches) as well and I repeatedly had a hard time to find the definition of this class since it was "hidden" in the TTbarReconstruction header file^^