### PR TITLE
Lumi tools added

### DIFF
--- a/common/include/CommonModules.h
+++ b/common/include/CommonModules.h
@@ -2,7 +2,7 @@
 
 #include "UHH2/core/include/AnalysisModule.h"
 #include "UHH2/common/include/ObjectIdUtils.h"
-
+#include "UHH2/common/include/NSelections.h"
 
 /** \brief Run a configurable list commonly used modules
  *
@@ -14,6 +14,7 @@
  * The AnalysisModules run are (in this order):
  *  - MCLumiWeight (for MC only; only has an effect if "use_sframe_weight" is set to false)
  *  - MCPileupReweight (for MC only)
+ *  - good run selection (for data only) based on lumi_file defined in xml input
  *  - JetCorrector using the latest PHYS14 corrections for MC
  *  - JetResolutionSmearer  (for MC only)
  *  - JetCleaner
@@ -50,6 +51,7 @@ public:
     void disable_mcpileupreweight();
     void disable_jec();
     void disable_jersmear();
+    void disable_lumisel();
 
     void set_jet_id(const JetId & jetid_){
         fail_if_init();
@@ -81,8 +83,10 @@ private:
     MuonId muid;
     TauId tauid;
     
-    bool mclumiweight = true, mcpileupreweight = true, jersmear = true, jec = true;
+    bool mclumiweight = true, mcpileupreweight = true, jersmear = true, jec = true, lumisel=true;
 
     bool init_done = false;
+
+    std::unique_ptr<Selection> lumi_selection;
 };
 

--- a/common/include/LumiSelection.h
+++ b/common/include/LumiSelection.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "UHH2/core/include/Selection.h"
+#include "UHH2/core/include/Event.h"
+#include "UHH2/common/include/LuminosityHists.h"
+
+#include <string>
+
+//This module removes all data events that are not given in the run/lumisection list given in the lumi_file.
+//The lumi file is defined with "lumi_file" in the xml configuration
+
+class LumiSelection: public uhh2::Selection{
+ public:
+  explicit LumiSelection(uhh2::Context & ctx);
+  virtual bool passes(const uhh2::Event & event);
+
+ private:
+  //list of good run-lumiblock entries from lumi file
+  std::vector<run_lumi> rls;
+
+};

--- a/common/include/LuminosityHists.h
+++ b/common/include/LuminosityHists.h
@@ -5,9 +5,15 @@
 /** \brief Create the "lumi plot", i.e. event yield vs. time in bins of equal integrated luminosity
  * 
  * Configuration from context:
- *  - "lumihists_lumi_file": path to root file with luminosity information
+ *  - "lumi_file": path to root file with luminosity information
  *  - "lumihists_lumi_per_bin": integrated luminosity per bin in the histogram (optional; default: 50.0)
  */
+
+struct run_lumi {
+  int run;
+  int lumiblock;
+};
+
 class LuminosityHists: public uhh2::Hists {
 public:
     LuminosityHists(uhh2::Context & ctx, const std::string & dirname);
@@ -15,10 +21,6 @@ public:
     virtual void fill(const uhh2::Event & ev) override;
     
 private:
-    struct run_lumi {
-        int run;
-        int lumiblock;
-    };
     
     friend bool operator<(const run_lumi &, const run_lumi & rl2);
     

--- a/common/src/EventVariables.cxx
+++ b/common/src/EventVariables.cxx
@@ -10,9 +10,11 @@ HTCalculator::HTCalculator(Context & ctx, const boost::optional<JetId> & jetid_,
 
 bool HTCalculator::process(Event & event){
     double ht = 0.0;
-    for(const auto & jet : *event.jets){
-        if(jetid && !(*jetid)(jet, event)) continue;
-        ht += jet.pt();
+    if(event.jets){
+        for(const auto & jet : *event.jets){
+            if(jetid && !(*jetid)(jet, event)) continue;
+	    ht += jet.pt();
+	}
     }
     event.set(h_ht, ht);
     return true;

--- a/common/src/LumiSelection.cxx
+++ b/common/src/LumiSelection.cxx
@@ -1,0 +1,43 @@
+#include "UHH2/common/include/LumiSelection.h"
+
+#include "TFile.h"
+#include "TTree.h"
+
+using namespace uhh2;
+using namespace std;
+
+
+LumiSelection::LumiSelection(uhh2::Context & ctx){
+
+  string lumifile = ctx.get("lumi_file");
+  std::unique_ptr<TFile> file(TFile::Open(lumifile.c_str(), "read"));
+  TTree * tree = dynamic_cast<TTree*>(file->Get("AnalysisTree"));
+  if(!tree){
+    throw runtime_error("LuminosityHists: Did not find TTree 'AnalysisTree' in file ;" + lumifile + "'");
+  }
+  // only fetch branches we really need:
+  TBranch * brun = tree->GetBranch("run");
+  TBranch * blumiblock = tree->GetBranch("luminosityBlock");
+  run_lumi rl;
+  brun->SetAddress(&rl.run);
+  blumiblock->SetAddress(&rl.lumiblock);
+
+  auto ientries = tree->GetEntries();
+  for(auto ientry = 0l; ientry < ientries; ientry++){
+    for(auto b : {brun, blumiblock}){
+      b->GetEntry(ientry);
+    }
+    rls.push_back(rl);
+  }
+
+}
+
+bool LumiSelection::passes(const Event & event){
+
+  for(size_t i=0; i< rls.size(); i++){
+    if(rls[i].run==event.run && rls[i].lumiblock==event.luminosityBlock) return true;
+  }
+
+  return false;
+}
+

--- a/common/src/LuminosityHists.cxx
+++ b/common/src/LuminosityHists.cxx
@@ -10,7 +10,7 @@ using namespace uhh2;
 using namespace std;
 
     
-bool operator<(const LuminosityHists::run_lumi & rl1, const LuminosityHists::run_lumi & rl2){
+bool operator<(const run_lumi & rl1, const run_lumi & rl2){
     if(rl1.run == rl2.run){
         return rl1.lumiblock < rl2.lumiblock;
     }
@@ -26,7 +26,7 @@ LuminosityHists::LuminosityHists(uhh2::Context & ctx, const std::string & dirnam
         throw runtime_error("lumihists_lumi_per_bin is <= 0.0; this is not allowed");
     }
     
-    string lumifile = ctx.get("lumihists_lumi_file");
+    string lumifile = ctx.get("lumi_file");
     std::unique_ptr<TFile> file(TFile::Open(lumifile.c_str(), "read"));
     TTree * tree = dynamic_cast<TTree*>(file->Get("AnalysisTree"));
     if(!tree){
@@ -81,7 +81,7 @@ LuminosityHists::LuminosityHists(uhh2::Context & ctx, const std::string & dirnam
 void LuminosityHists::fill(const uhh2::Event & ev){
     run_lumi rl{ev.run, ev.luminosityBlock};
     auto it = upper_bound(upper_binborders.begin(), upper_binborders.end(), rl);
-    int ibin = distance(upper_binborders.begin(), it) + 1; // can be upper_bounds.size() + 1 at most, which is nbins and thus Ok.
+    int ibin = distance(upper_binborders.begin(), it); // can be upper_bounds.size() at most, which is nbins and thus Ok.
     hlumi->Fill(ibin, ev.weight); // weight is usually 1.0 anyway, but who knows ...
 }
 

--- a/common/test/LumiHists.xml
+++ b/common/test/LumiHists.xml
@@ -1,21 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE JobConfiguration PUBLIC "" "JobConfig.dtd">
+<!DOCTYPE JobConfiguration PUBLIC "" "JobConfig.dtd" [
+<!ENTITY DATA_SingleMu SYSTEM "../../common/datasets/DATA_SingleMu.xml">
+<!ENTITY DATA_SingleElectron SYSTEM "../../common/datasets/DATA_SingleElectron.xml">
+]>
 <JobConfiguration JobName="ExampleCycleJob" OutputLevel="INFO">
    <Library Name="libTestSUHH2common"/>
    <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="./" PostFix="" TargetLumi="1" >
-        <InputData Lumi="1" NEventsMax="-1" Type="DATA" Version="TestLumiHists" Cacheable="False">
-            <In FileName="/nfs/dust/cms/user/peiffer/Analysis53X_v3/PreSelectionMuon/ZprimePreSelectionCycle.DATA.DATA_A.root" Lumi="0.0"/> 
-            <In FileName="/nfs/dust/cms/user/peiffer/Analysis53X_v3/PreSelectionMuon/ZprimePreSelectionCycle.DATA.DATA_B.root" Lumi="0.0"/> 
-            <In FileName="/nfs/dust/cms/user/peiffer/Analysis53X_v3/PreSelectionMuon/ZprimePreSelectionCycle.DATA.DATA_C.root" Lumi="0.0"/> 
-            <In FileName="/nfs/dust/cms/user/peiffer/Analysis53X_v3/PreSelectionMuon/ZprimePreSelectionCycle.DATA.DATA_D.root" Lumi="0.0"/> 
+
+        <InputData Lumi="1" NEventsMax="-1" Type="DATA" Version="SingleMu" Cacheable="False">
+	    &DATA_SingleMu;
             <InputTree Name="AnalysisTree" /> 
         </InputData>
-            
+
+	<InputData Lumi="1" NEventsMax="-1" Type="DATA" Version="SingleElectron" Cacheable="False">
+	    &DATA_SingleElectron;
+            <InputTree Name="AnalysisTree" /> 
+        </InputData>  
+
         <UserConfig>
             
-            <Item Name="lumihists_lumi_file" Value="/nfs/dust/cms/user/peiffer/Analysis53X_v3/LumiFiles/Mu40_pixel.root" />
-            
+            <Item Name="lumi_file" Value="/nfs/dust/cms/user/peiffer/NtupleWriter/Ntuples/RunII_v1/Lumifile.root" />
+            <Item Name="lumihists_lumi_per_bin" Value="0.2"/>
+
             <Item Name="AnalysisModule" Value="TestLumiHists" /> 
-        </UserConfig>
+	</UserConfig>
     </Cycle>
 </JobConfiguration>

--- a/common/test/TestLumiHists.cpp
+++ b/common/test/TestLumiHists.cpp
@@ -1,5 +1,7 @@
 #include "UHH2/core/include/AnalysisModule.h"
 #include "UHH2/common/include/LuminosityHists.h"
+#include "UHH2/common/include/NSelections.h"
+#include "UHH2/common/include/LumiSelection.h"
 
 using namespace uhh2;
 using namespace std;
@@ -8,15 +10,20 @@ class TestLumiHists: public uhh2::AnalysisModule {
 public:
     explicit TestLumiHists(Context & ctx) {
         lumihists.reset(new LuminosityHists(ctx, "lumi"));
+	lumi_selection.reset(new LumiSelection(ctx));
     }
     
     virtual bool process(Event & e) override{
+      if(lumi_selection->passes(e)){
         lumihists->fill(e);
-        return true;
+	return true;
+      }
+      return false;
     }
     
 private:
     std::unique_ptr<Hists> lumihists;
+    std::unique_ptr<Selection> lumi_selection;
 };
 
 

--- a/core/python/myLumiCalc.py
+++ b/core/python/myLumiCalc.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+
+#usage:
+#1. run lcr2.py:
+#  cd /afs/cern.ch/user/m/marlow/public/lcr2
+#  python lcr2.py -i /afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions15/13TeV/Cert_246908-251252_13TeV_PromptReco_Collisions15_JSON.txt --lumibyls -o /afs/desy.de/user/p/peiffer/xxl-af-cms/CMSSW_7_4_7/src/UHH2/core/python/TempOut.csv
+#
+# 2. run myLumiCalc.py:
+#  cd /afs/desy.de/user/p/peiffer/xxl-af-cms/CMSSW_7_4_7/src/UHH2/core/python
+#  ./myLumiCalc.py outfilename=Out.root infilename=TempOut.csv
+
+
+import os,sys,time
+import coral
+
+from ROOT import gROOT, TFile, TTree, AddressOf, TString, std
+from ctypes import *
+
+gROOT.Reset()
+
+
+gROOT.ProcessLine(\
+       "struct MyStruct{\
+       UInt_t runnr;\
+       UInt_t luminosityBlock;\
+       Double_t intgRecLumi;\
+       Double_t HLTpresc;\
+       Double_t L1presc;\
+       };")
+from ROOT import MyStruct
+
+
+
+from FWCore.ParameterSet.VarParsing import VarParsing
+options = VarParsing ('python')
+
+options.register ('outfilename',
+                  'OutFile.root',
+                  VarParsing.multiplicity.singleton,
+                  VarParsing.varType.string,
+                  'name of output root file')
+
+options.register ('infilename',
+                  'TempOut.csv',
+                  VarParsing.multiplicity.singleton,
+                  VarParsing.varType.string,
+                  'name of input file from lcr2.py')
+
+options.parseArguments()
+
+   
+ofile = TFile(options.outfilename,"RECREATE")
+tr = TTree("AnalysisTree","AnalysisTree")
+    
+s = MyStruct()
+
+hltpath = TString("")
+    
+
+tr.Branch('run',AddressOf(s,'runnr'),'runnr/i')
+tr.Branch('luminosityBlock',AddressOf(s,'luminosityBlock'),'luminosityBlock/i')
+#tr.Branch("HLTpath","TString",hltpath)
+#tr.Branch('L1bit','TString',l1bit)
+tr.Branch('intgRecLumi',AddressOf(s,'intgRecLumi'),'intgRecLumi/D')   
+#tr.Branch('HLTpresc',AddressOf(s,'HLTpresc'),'HLTpresc/D')
+#tr.Branch('L1presc',AddressOf(s,'L1presc'),'L1presc/D')
+
+infile = open("TempOut.csv", "r")
+
+infile.readline()
+for line in infile:
+    #print line
+    run = line[0:line.find(":")]
+    s.runnr = int(run)
+    line = line[len(run)+1:]
+    fill = line[0:line.find(",")]
+    line = line[len(fill)+1:]
+    lb = line[0:line.find(":")]
+    s.luminosityBlock = int(lb)
+    line = line[2*len(lb)+2:]
+    utctime = line[0:line.find(",")]
+    line = line[len(utctime)+1:]
+    status =  line[0:line.find(",")]
+    line = line[len(status)+1:]
+    energy = line[0:line.find(",")]
+    line = line[len(energy)+1:]
+    intLumiDeliv = line[0:line.find(",")]
+    line = line[len(intLumiDeliv)+1:]
+    intLumi = line[0:line.find(",")]
+    s.intgRecLumi = float(intLumi)
+    line = line[len(intLumi)+1:]
+    
+    tr.Fill()
+
+    
+ofile.Write()
+ofile.Close()  
+
+
+    
+
+


### PR DESCRIPTION
Added tool to create lumifile (myLumiCalc.py).

Added selection module to select only good data events according to lumifile (LumiSelection).

Example how to use the lumifile and LumiSelection can be found in TestLumiHists.cpp.

LumiSelection is automatically called by CommonModules.

Important note: 
If you want to use the LumiSelection in CommonModules, you have to use CommonModules as a selection in your own module. I.e., replace code like

common->process(event);

by

bool pass_common = common->process(event);
if(!pass_common) return false;

in the process routine of your module.