### PR TITLE
Force weight=1 for data

### DIFF
--- a/core/src/AnalysisModuleRunner.cxx
+++ b/core/src/AnalysisModuleRunner.cxx
@@ -702,7 +702,7 @@ void AnalysisModuleRunner::ExecuteEvent(const SInputData&, Double_t w) throw (SE
     uhh2::Event & event = *pimpl->event;
     
     // setup weight depending on the "use_sframe_weight" configuration option:
-    if(pimpl->use_sframe_weight){
+    if(pimpl->use_sframe_weight && !event.isRealData){
         event.weight = w;
     }
     else{


### PR DESCRIPTION
Data are given weight 1 regardless of the sample lumi value (it doesn't have to match the lumi in the cycle block).
It used to be like this in the old UHHAnalysis. It is useful when one wants to run over different data streams, or split big chunks of data.