### PR TITLE
Bug in event.genInfo->weights

### DIFF
--- a/core/src/AnalysisModuleRunner.cxx
+++ b/core/src/AnalysisModuleRunner.cxx
@@ -708,13 +708,13 @@ void AnalysisModuleRunner::ExecuteEvent(const SInputData&, Double_t w) throw (SE
     else{
         event.weight = 1.0;
     }
-
+    /*
     if(event.genInfo){
           for (unsigned int i=0; i<event.genInfo->weights().size(); i++){
 	      event.weight *= event.genInfo->weights().at(i);
 	  }
     }
-
+    */
     bool keep = pimpl->analysis->process(event);
 
     if (!keep) {


### PR DESCRIPTION
I observe a bug in the way this is filled for at least the WJets sample and also other samples seem to be affected. 
event.genInfo->weights can be negativ and for W+Jets it is   -/+225892 (negativ ?!)
If I normalise my PreSelection and my Selection the weight is multiplied such that if the weight in the PreSelection [0,1] the values become smaller & if 1> the weight are higher.
This need some more investigation. This is just an shortterm solution