### PR TITLE
signal files and multi-xml creation script

### DIFF
--- a/common/datasets/MC_TpB_TH_LH_M1000.xml
+++ b/common/datasets/MC_TpB_TH_LH_M1000.xml
@@ -1,0 +1,11 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1000_35_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1000_36_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1000_37_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1000_38_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1000_39_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1000_40_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1000_41_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1000_42_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1000_43_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1000_44_Ntuple.root" Lumi="0.0"/>
+<!-- number of events: 100000 -->

--- a/common/datasets/MC_TpB_TH_LH_M1300.xml
+++ b/common/datasets/MC_TpB_TH_LH_M1300.xml
@@ -1,0 +1,11 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1300_66_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1300_67_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1300_68_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1300_69_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1300_70_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1300_71_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1300_72_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1300_73_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1300_74_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1300_75_Ntuple.root" Lumi="0.0"/>
+<!-- number of events: 100000 -->

--- a/common/datasets/MC_TpB_TH_LH_M1500.xml
+++ b/common/datasets/MC_TpB_TH_LH_M1500.xml
@@ -1,0 +1,11 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1500_88_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1500_89_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1500_90_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1500_91_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1500_92_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1500_93_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1500_94_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1500_95_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1500_96_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1500_97_Ntuple.root" Lumi="0.0"/>
+<!-- number of events: 97068 -->

--- a/common/datasets/MC_TpB_TH_LH_M1700.xml
+++ b/common/datasets/MC_TpB_TH_LH_M1700.xml
@@ -1,0 +1,13 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1700_100_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1700_101_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1700_102_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1700_103_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1700_104_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1700_105_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1700_106_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1700_107_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1700_108_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1700_109_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1700_110_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1700_98_Ntuple.root" Lumi="0.0"/>
+<!-- number of events: 95400 -->

--- a/common/datasets/MC_TpB_TH_LH_M1800.xml
+++ b/common/datasets/MC_TpB_TH_LH_M1800.xml
@@ -1,0 +1,14 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1800_111_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1800_112_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1800_113_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1800_114_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1800_115_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1800_116_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1800_117_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1800_118_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1800_119_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1800_120_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1800_121_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1800_122_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M1800_124_Ntuple.root" Lumi="0.0"/>
+<!-- number of events: 98800 -->

--- a/common/datasets/MC_TpB_TH_LH_M700.xml
+++ b/common/datasets/MC_TpB_TH_LH_M700.xml
@@ -1,0 +1,12 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M700_0_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M700_10_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M700_1_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M700_2_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M700_3_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M700_4_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M700_5_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M700_6_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M700_7_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M700_8_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M700_9_Ntuple.root" Lumi="0.0"/>
+<!-- number of events: 98572 -->

--- a/common/datasets/MC_TpB_TH_LH_M800.xml
+++ b/common/datasets/MC_TpB_TH_LH_M800.xml
@@ -1,0 +1,2 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M800_19_Ntuple.root" Lumi="0.0"/>
+<!-- number of events: 3200 -->

--- a/common/datasets/MC_TpB_TH_LH_M900.xml
+++ b/common/datasets/MC_TpB_TH_LH_M900.xml
@@ -1,0 +1,8 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M900_28_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M900_29_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M900_30_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M900_31_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M900_32_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M900_33_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_LH_M900_34_Ntuple.root" Lumi="0.0"/>
+<!-- number of events: 60000 -->

--- a/common/datasets/MC_TpB_TH_RH_M1000.xml
+++ b/common/datasets/MC_TpB_TH_RH_M1000.xml
@@ -1,0 +1,13 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1000_159_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1000_160_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1000_161_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1000_162_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1000_163_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1000_164_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1000_165_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1000_166_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1000_167_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1000_168_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1000_169_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1000_170_Ntuple.root" Lumi="0.0"/>
+<!-- number of events: 98400 -->

--- a/common/datasets/MC_TpB_TH_RH_M1200.xml
+++ b/common/datasets/MC_TpB_TH_RH_M1200.xml
@@ -1,0 +1,15 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1200_181_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1200_182_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1200_183_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1200_184_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1200_185_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1200_186_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1200_187_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1200_188_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1200_189_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1200_190_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1200_191_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1200_192_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1200_193_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1200_194_Ntuple.root" Lumi="0.0"/>
+<!-- number of events: 100000 -->

--- a/common/datasets/MC_TpB_TH_RH_M1300.xml
+++ b/common/datasets/MC_TpB_TH_RH_M1300.xml
@@ -1,0 +1,17 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1300_195_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1300_196_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1300_197_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1300_198_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1300_199_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1300_200_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1300_201_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1300_202_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1300_203_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1300_204_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1300_205_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1300_206_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1300_207_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1300_208_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1300_209_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1300_210_Ntuple.root" Lumi="0.0"/>
+<!-- number of events: 100000 -->

--- a/common/datasets/MC_TpB_TH_RH_M1400.xml
+++ b/common/datasets/MC_TpB_TH_RH_M1400.xml
@@ -1,0 +1,13 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1400_211_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1400_212_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1400_213_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1400_214_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1400_215_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1400_216_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1400_217_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1400_218_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1400_219_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1400_220_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1400_221_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1400_222_Ntuple.root" Lumi="0.0"/>
+<!-- number of events: 100000 -->

--- a/common/datasets/MC_TpB_TH_RH_M1500.xml
+++ b/common/datasets/MC_TpB_TH_RH_M1500.xml
@@ -1,0 +1,12 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1500_223_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1500_224_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1500_225_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1500_226_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1500_227_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1500_228_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1500_229_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1500_230_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1500_231_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1500_232_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1500_233_Ntuple.root" Lumi="0.0"/>
+<!-- number of events: 99800 -->

--- a/common/datasets/MC_TpB_TH_RH_M1600.xml
+++ b/common/datasets/MC_TpB_TH_RH_M1600.xml
@@ -1,0 +1,12 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1600_234_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1600_235_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1600_236_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1600_237_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1600_238_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1600_239_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1600_240_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1600_241_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1600_242_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1600_243_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1600_244_Ntuple.root" Lumi="0.0"/>
+<!-- number of events: 100000 -->

--- a/common/datasets/MC_TpB_TH_RH_M1700.xml
+++ b/common/datasets/MC_TpB_TH_RH_M1700.xml
@@ -1,0 +1,12 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1700_245_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1700_246_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1700_247_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1700_248_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1700_249_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1700_250_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1700_251_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1700_252_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1700_253_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1700_254_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1700_255_Ntuple.root" Lumi="0.0"/>
+<!-- number of events: 99200 -->

--- a/common/datasets/MC_TpB_TH_RH_M1800.xml
+++ b/common/datasets/MC_TpB_TH_RH_M1800.xml
@@ -1,0 +1,11 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1800_256_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1800_257_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1800_258_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1800_259_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1800_260_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1800_261_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1800_262_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1800_263_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1800_264_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M1800_265_Ntuple.root" Lumi="0.0"/>
+<!-- number of events: 73600 -->

--- a/common/datasets/MC_TpB_TH_RH_M700.xml
+++ b/common/datasets/MC_TpB_TH_RH_M700.xml
@@ -1,0 +1,11 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M700_127_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M700_128_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M700_129_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M700_130_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M700_131_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M700_132_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M700_133_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M700_134_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M700_135_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M700_136_Ntuple.root" Lumi="0.0"/>
+<!-- number of events: 82600 -->

--- a/common/datasets/MC_TpB_TH_RH_M800.xml
+++ b/common/datasets/MC_TpB_TH_RH_M800.xml
@@ -1,0 +1,12 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M800_137_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M800_138_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M800_139_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M800_140_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M800_141_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M800_142_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M800_143_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M800_144_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M800_145_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M800_146_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M800_147_Ntuple.root" Lumi="0.0"/>
+<!-- number of events: 100000 -->

--- a/common/datasets/MC_TpB_TH_RH_M900.xml
+++ b/common/datasets/MC_TpB_TH_RH_M900.xml
@@ -1,0 +1,12 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M900_148_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M900_149_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M900_150_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M900_151_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M900_152_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M900_153_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M900_154_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M900_155_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M900_156_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M900_157_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpB_TH_RH_M900_158_Ntuple.root" Lumi="0.0"/>
+<!-- number of events: 100000 -->

--- a/common/datasets/MC_TpT_TH_LH_M1200.xml
+++ b/common/datasets/MC_TpT_TH_LH_M1200.xml
@@ -1,0 +1,12 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1200_314_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1200_315_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1200_316_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1200_317_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1200_318_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1200_319_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1200_320_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1200_321_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1200_322_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1200_323_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1200_324_Ntuple.root" Lumi="0.0"/>
+<!-- number of events: 96000 -->

--- a/common/datasets/MC_TpT_TH_LH_M1300.xml
+++ b/common/datasets/MC_TpT_TH_LH_M1300.xml
@@ -1,0 +1,13 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1300_325_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1300_326_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1300_327_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1300_328_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1300_329_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1300_330_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1300_331_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1300_332_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1300_333_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1300_334_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1300_335_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1300_336_Ntuple.root" Lumi="0.0"/>
+<!-- number of events: 98800 -->

--- a/common/datasets/MC_TpT_TH_LH_M1500.xml
+++ b/common/datasets/MC_TpT_TH_LH_M1500.xml
@@ -1,0 +1,12 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1500_349_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1500_350_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1500_352_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1500_353_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1500_354_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1500_355_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1500_356_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1500_357_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1500_358_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1500_359_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1500_360_Ntuple.root" Lumi="0.0"/>
+<!-- number of events: 94800 -->

--- a/common/datasets/MC_TpT_TH_LH_M1700.xml
+++ b/common/datasets/MC_TpT_TH_LH_M1700.xml
@@ -1,0 +1,12 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1700_373_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1700_374_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1700_375_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1700_376_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1700_377_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1700_378_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1700_379_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1700_380_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1700_381_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1700_382_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1700_383_Ntuple.root" Lumi="0.0"/>
+<!-- number of events: 99800 -->

--- a/common/datasets/MC_TpT_TH_LH_M1800.xml
+++ b/common/datasets/MC_TpT_TH_LH_M1800.xml
@@ -1,0 +1,11 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1800_384_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1800_385_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1800_386_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1800_387_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1800_388_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1800_389_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1800_390_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1800_391_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1800_392_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1800_393_Ntuple.root" Lumi="0.0"/>
+<!-- number of events: 100000 -->

--- a/common/datasets/MC_TpT_TH_LH_M1T00.xml
+++ b/common/datasets/MC_TpT_TH_LH_M1T00.xml
@@ -1,0 +1,12 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1T00_303_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1T00_304_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1T00_305_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1T00_306_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1T00_307_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1T00_308_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1T00_309_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1T00_310_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1T00_311_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1T00_312_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M1T00_313_Ntuple.root" Lumi="0.0"/>
+<!-- number of events: 98600 -->

--- a/common/datasets/MC_TpT_TH_LH_M700.xml
+++ b/common/datasets/MC_TpT_TH_LH_M700.xml
@@ -1,0 +1,12 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M700_269_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M700_270_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M700_271_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M700_272_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M700_273_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M700_274_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M700_275_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M700_276_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M700_277_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M700_278_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M700_279_Ntuple.root" Lumi="0.0"/>
+<!-- number of events: 99600 -->

--- a/common/datasets/MC_TpT_TH_LH_M800.xml
+++ b/common/datasets/MC_TpT_TH_LH_M800.xml
@@ -1,0 +1,11 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M800_280_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M800_281_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M800_282_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M800_283_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M800_284_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M800_285_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M800_286_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M800_287_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M800_288_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M800_289_Ntuple.root" Lumi="0.0"/>
+<!-- number of events: 100000 -->

--- a/common/datasets/MC_TpT_TH_LH_M900.xml
+++ b/common/datasets/MC_TpT_TH_LH_M900.xml
@@ -1,0 +1,14 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M900_290_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M900_291_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M900_292_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M900_293_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M900_294_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M900_295_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M900_296_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M900_297_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M900_298_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M900_299_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M900_300_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M900_301_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_LH_M900_302_Ntuple.root" Lumi="0.0"/>
+<!-- number of events: 94800 -->

--- a/common/datasets/MC_TpT_TH_RH_M1100.xml
+++ b/common/datasets/MC_TpT_TH_RH_M1100.xml
@@ -1,0 +1,6 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M1100_426_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M1100_427_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M1100_428_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M1100_429_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M1100_430_Ntuple.root" Lumi="0.0"/>
+<!-- number of events: 37800 -->

--- a/common/datasets/MC_TpT_TH_RH_M1300.xml
+++ b/common/datasets/MC_TpT_TH_RH_M1300.xml
@@ -1,0 +1,2 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M1300_449_Ntuple.root" Lumi="0.0"/>
+<!-- number of events: 4000 -->

--- a/common/datasets/MC_TpT_TH_RH_M1500.xml
+++ b/common/datasets/MC_TpT_TH_RH_M1500.xml
@@ -1,0 +1,13 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M1500_462_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M1500_463_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M1500_464_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M1500_465_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M1500_466_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M1500_467_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M1500_468_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M1500_469_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M1500_470_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M1500_471_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M1500_472_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M1500_473_Ntuple.root" Lumi="0.0"/>
+<!-- number of events: 100000 -->

--- a/common/datasets/MC_TpT_TH_RH_M1600.xml
+++ b/common/datasets/MC_TpT_TH_RH_M1600.xml
@@ -1,0 +1,12 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M1600_474_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M1600_475_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M1600_476_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M1600_477_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M1600_478_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M1600_479_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M1600_480_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M1600_481_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M1600_482_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M1600_483_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M1600_484_Ntuple.root" Lumi="0.0"/>
+<!-- number of events: 100000 -->

--- a/common/datasets/MC_TpT_TH_RH_M1700.xml
+++ b/common/datasets/MC_TpT_TH_RH_M1700.xml
@@ -1,0 +1,13 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M1700_485_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M1700_486_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M1700_487_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M1700_488_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M1700_489_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M1700_490_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M1700_491_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M1700_492_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M1700_493_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M1700_494_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M1700_495_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M1700_496_Ntuple.root" Lumi="0.0"/>
+<!-- number of events: 97400 -->

--- a/common/datasets/MC_TpT_TH_RH_M700.xml
+++ b/common/datasets/MC_TpT_TH_RH_M700.xml
@@ -1,0 +1,13 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M700_394_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M700_395_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M700_396_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M700_397_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M700_398_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M700_399_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M700_400_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M700_401_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M700_402_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M700_403_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M700_404_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M700_405_Ntuple.root" Lumi="0.0"/>
+<!-- number of events: 100000 -->

--- a/common/datasets/MC_TpT_TH_RH_M900.xml
+++ b/common/datasets/MC_TpT_TH_RH_M900.xml
@@ -1,0 +1,11 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M900_406_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M900_407_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M900_408_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M900_409_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M900_410_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M900_411_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M900_412_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M900_413_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M900_414_Ntuple.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/htholen/sframe-ntuples/RunII-ntuple-v1/signals/MC_TpT_TH_RH_M900_415_Ntuple.root" Lumi="0.0"/>
+<!-- number of events: 100000 -->

--- a/scripts/create-multi-dataset-xmlfiles.py
+++ b/scripts/create-multi-dataset-xmlfiles.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+
+import os, sys, glob, ROOT
+
+if len(sys.argv) < 2:
+   print "Usage: %s <rootfile pattern with full path> " \
+         "<optional: xml output file POSTFIX> \n" \
+         "(it's a good idea to try this script in a test directory)"
+   sys.exit(1)
+
+if len(sys.argv) >= 3:
+    postfix = '_' + sys.argv[2]
+else:
+    postfix = ''
+
+# glob files
+pattern = sys.argv[1]
+files = glob.glob(pattern)
+print "Found %d files matching pattern" % len(files)
+files.sort()
+
+### find common element in filenames
+# get filenames without ext and path
+basenames = map(lambda p: os.path.basename(os.path.splitext(p)[0]), files)
+# remove jobnumber and 'Ntuple' and make a set
+basenames = set('_'.join(tok for tok in name.split('_')[:-2])
+                for name in basenames)
+basenames = sorted(basenames)
+print "Found these basenames: %s " % basenames
+
+# write out
+entity_template = """\
+<!ENTITY %s SYSTEM  "../../common/datasets/%s.xml">
+"""
+
+conf_template = """
+<InputData Lumi="%d" NEventsMax="-1" Type="MC" Version="%s" Cacheable="True">
+    &%s;
+    <InputTree Name="AnalysisTree" />
+    <OutputTree Name="AnalysisTree" />
+</InputData>
+"""
+
+entity_lines = []
+config_lines = []
+for basename in basenames:
+    n_events = 0
+    with open(basename + postfix + '.xml', 'w') as out:
+        for fname in files:
+            if not os.path.basename(fname).startswith(basename):
+                continue
+            out.write('<In FileName="%s" Lumi="0.0"/>\n' % fname)
+
+            f = ROOT.TFile(fname)
+            n_events += f.Get('AnalysisTree').GetEntriesFast()
+
+        out.write('<!-- number of events: %d -->\n' % n_events)
+        entity_lines.append(entity_template % (basename, basename))
+        config_lines.append(conf_template % (n_events, basename, basename))
+        print '%s: %d events' % (basename, n_events)
+
+
+with open('TEMPLATE_CONFIG%s.xml' % postfix, 'w') as out:
+    out.writelines(entity_lines)
+    out.writelines(config_lines)
+


### PR DESCRIPTION
The multi-xml creation script groups the datasets by name (only removing the job number and 'Ntuple.root') and creates a dataset file for every group. It also counts the number of events and makes a template file for inclusion in an sframe config, where lumi is set to the number of events. The script is particularly useful for signal samples.