### PR TITLE
MET without HF added

### DIFF
--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -109,6 +109,64 @@ if useData:
 
 
 ###############################################
+# MET without HF for 50ns run II data in CMSSW_74X
+
+#configurable options =======================================================================
+useHFCandidates=False #create an additionnal NoHF slimmed MET collection if the option is set to false
+applyResiduals=False #application of residual corrections. Have to be set to True once the 13 TeV residual corrections are available. False to be kept meanwhile. Can be kept to False later for private tests or for analysis checks and developments (not the official recommendation!).
+#===================================================================
+
+### ---------------------------------------------------------------------------
+### Removing the HF from the MET computation
+### ---------------------------------------------------------------------------
+if not useHFCandidates:
+    process.noHFCands = cms.EDFilter("CandPtrSelector",
+                                     src=cms.InputTag("packedPFCandidates"),
+                                     cut=cms.string("abs(pdgId)!=1 && abs(pdgId)!=2 && abs(eta)<3.0")
+                                     )
+
+#jets are rebuilt from those candidates by the tools, no need to do anything else
+### =================================================================================
+
+from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMetCorAndUncFromMiniAOD
+
+#default configuration for miniAOD reprocessing, change the isData flag to run on data
+#for a full met computation, remove the pfCandColl input
+runMetCorAndUncFromMiniAOD(process,
+                           isData=useData,
+                           )
+
+if not useHFCandidates:
+    runMetCorAndUncFromMiniAOD(process,
+                               isData=useData,
+                               pfCandColl=cms.InputTag("noHFCands"),
+                               postfix="NoHF"
+                               )
+
+### -------------------------------------------------------------------
+### the lines below remove the L2L3 residual corrections when processing data
+### -------------------------------------------------------------------
+if not applyResiduals:
+    process.patPFMetT1T2Corr.jetCorrLabelRes = cms.InputTag("L3Absolute")
+    process.patPFMetT1T2SmearCorr.jetCorrLabelRes = cms.InputTag("L3Absolute")
+    process.patPFMetT2Corr.jetCorrLabelRes = cms.InputTag("L3Absolute")
+    process.patPFMetT2SmearCorr.jetCorrLabelRes = cms.InputTag("L3Absolute")
+    process.shiftedPatJetEnDown.jetCorrLabelUpToL3Res = cms.InputTag("ak4PFCHSL1FastL2L3Corrector")
+    process.shiftedPatJetEnUp.jetCorrLabelUpToL3Res = cms.InputTag("ak4PFCHSL1FastL2L3Corrector")
+
+    if not useHFCandidates:
+          process.patPFMetT1T2CorrNoHF.jetCorrLabelRes = cms.InputTag("L3Absolute")
+          process.patPFMetT1T2SmearCorrNoHF.jetCorrLabelRes = cms.InputTag("L3Absolute")
+          process.patPFMetT2CorrNoHF.jetCorrLabelRes = cms.InputTag("L3Absolute")
+          process.patPFMetT2SmearCorrNoHF.jetCorrLabelRes = cms.InputTag("L3Absolute")
+          process.shiftedPatJetEnDownNoHF.jetCorrLabelUpToL3Res = cms.InputTag("ak4PFCHSL1FastL2L3Corrector")
+          process.shiftedPatJetEnUpNoHF.jetCorrLabelUpToL3Res = cms.InputTag("ak4PFCHSL1FastL2L3Corrector")
+### ------------------------------------------------------------------
+
+
+
+
+###############################################
 # GEN PARTICLES
 #
 # The 13TeV samples mainly use Pythia8 for showering, which stores information in another way compared to Pythia6; in particular,
@@ -564,7 +622,7 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
         jet_etamax = cms.double(999.0),
         
         doMET = cms.bool(True),
-        met_sources =  cms.vstring("slimmedMETs","slimmedMETsPuppi"),
+        met_sources =  cms.vstring("slimmedMETs","slimmedMETsPuppi","slimmedMETsNoHF"),
         
         
         doTopJets = cms.bool(True),


### PR DESCRIPTION
I have added a new MET collection (slimmedMETsNoHF) according to the new recipe (see https://hypernews.cern.ch/HyperNews/CMS/get/JetMET/1622/1.html). 

The L2L3 residual corrections have been removed from slimmedMETs and slimmedMETsNoHF for the moment. This has to be updated as soon as the new corrections are available.