### PR TITLE
changed some histograms inTopJetHists, added TopJetIds: HepTopTagV2, Type2TopJet, Tau2/Tau1

### DIFF
--- a/common/include/JetHists.h
+++ b/common/include/JetHists.h
@@ -98,7 +98,7 @@ class TopJetHists: public JetHistsBase{
   std::vector<jetHist> usertopjets;
   std::vector<subjetHist> usersubjets;
   TH1F *number;
-   TH1F *deltaRmin_1, *deltaRmin_2, *tau32,*tau21,*deltaRmin_ak4jet,*invmass_topjetnexak4jet;
+   TH1F *deltaRmin_1, *deltaRmin_2, *tau32,*tau21,*deltaR_ak4jet,*invmass_topjetak4jet,*HTT_mass,*fRec;
 
   jetHist alljets;
   subjetHist allsubjets;

--- a/common/include/TopJetIds.h
+++ b/common/include/TopJetIds.h
@@ -35,6 +35,11 @@ public:
   MassType m_typeOfMass;
 };
 
+/** \type-2 top tag 
+ * Cuts on the ungrommed 'fat jet mass' or on the groomed 'fat jet mass'.  
+ *  
+ */
+
 class Type2TopTag {
 public:
   
@@ -69,6 +74,12 @@ public:
   double m_cutCondition3;
 };
 
+/** \Hep top tag V2
+ * 
+ * Cuts on the HTT mass and fRec
+ * 
+ * The default values of the constructor correspond to the 40% efficiency WP presented in the top tagging talk on https://indico.cern.ch/event/393337/#preview:1078843.
+ */
 
 class HEPTopTagV2{
 public:

--- a/common/include/TopJetIds.h
+++ b/common/include/TopJetIds.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "UHH2/core/include/Event.h"
+#include "UHH2/core/include/Tags.h"
 #include "UHH2/common/include/ObjectIdUtils.h"
 #include "UHH2/common/include/JetIds.h"
 
@@ -34,6 +35,25 @@ public:
   MassType m_typeOfMass;
 };
 
+class Type2TopTag {
+public:
+  
+  enum class MassType {groomed, ungroomed};
+
+  explicit Type2TopTag(double mjetLower=60., double mjetUpper=100., MassType typeOfMass = MassType::ungroomed);
+  explicit Type2TopTag(MassType typeOfMass);
+  
+  bool operator()(const TopJet & topjet, const uhh2::Event & event) const;
+
+ private:
+   double m_mjetLower;
+   double m_mjetUpper;
+   MassType m_typeOfMass;
+};
+
+
+
+
 class HEPTopTag{
 public:
   
@@ -47,6 +67,20 @@ public:
   double m_massWindowUpper;
   double m_cutCondition2;
   double m_cutCondition3;
+};
+
+
+class HEPTopTagV2{
+public:
+  
+  explicit HEPTopTagV2(double minHTTmass=128., double maxHTTmass=171., double maxfRec=0.18);
+  
+  bool operator()(const TopJet & topjet, const uhh2::Event & event) const;
+
+ private:
+   double m_minHTTmass;
+   double m_maxHTTmass;
+   double m_maxfRec;
 };
 
 
@@ -64,6 +98,22 @@ public:
 private:
     double threshold;
 };
+
+/** \brief Cut on tau2/tau1 < threshold
+ * 
+ */
+class Tau21 {
+public:
+    explicit Tau21(double threshold_ = 0.6): threshold(threshold_){}
+    
+    bool operator()(const TopJet & topjet, const uhh2::Event & event) const;
+    
+private:
+    double threshold;
+};
+
+
+
 
 /** \brief Higgs tagger as e.g. used in Rebekka's analysis
  * 

--- a/common/src/LuminosityHists.cxx
+++ b/common/src/LuminosityHists.cxx
@@ -81,11 +81,13 @@ LuminosityHists::LuminosityHists(uhh2::Context & ctx,
     }
     int nbins = upper_binborders.size() + 1; // add one for the partial bin
     hlumi = book<TH1D>("luminosity", "Events over time divided in equal lumi-size bins", nbins, 0, (total_lumi / lumi_per_bin + 1)*lumi_per_bin);
+    //hlumi = book<TH1D>("luminosity", "Events over time divided in equal lumi-size bins", nbins, 0, nbins);
 }
     
 void LuminosityHists::fill(const uhh2::Event & ev){
     if(!ev.isRealData) return;
 
+    
     bool trigger_accepted = true;
     if (!triggername_.empty()) {
         auto trg_index = ev.get_trigger_index(triggername_);
@@ -98,5 +100,6 @@ void LuminosityHists::fill(const uhh2::Event & ev){
         int ibin = distance(upper_binborders.begin(), it)+1; // can be upper_bounds.size() at most, which is nbins and thus Ok.
         hlumi->Fill(ibin*lumi_per_bin, ev.weight); // weight is usually 1.0 anyway, but who knows ...
     }
+
 }
 

--- a/common/src/TopJetIds.cxx
+++ b/common/src/TopJetIds.cxx
@@ -30,6 +30,28 @@ CMSTopTag::CMSTopTag(double mminLower, double mjetLower, double mjetUpper, MassT
 CMSTopTag::CMSTopTag(MassType typeOfMass): m_mminLower(50.), m_mjetLower(140.), m_mjetUpper(250.), m_typeOfMass(typeOfMass){}
 
 
+bool Type2TopTag::operator()(const TopJet & topjet, const uhh2::Event &) const {
+   float mjet = 0.0;
+   switch(m_typeOfMass)
+    {
+    case MassType::ungroomed : mjet=topjet.v4().M(); break;
+    case MassType::groomed : mjet=m_groomed(topjet); break;
+    default: std::cout<<"Type2TopTag Mass type not valid"<<std::endl;
+    }
+    if(mjet < m_mjetLower) return false;
+    if(mjet > m_mjetUpper) return false;
+
+    return true;
+}
+
+Type2TopTag::Type2TopTag(double mjetLower, double mjetUpper, MassType typeOfMass):
+    m_mjetLower(mjetLower), m_mjetUpper(mjetUpper), m_typeOfMass(typeOfMass){}
+
+Type2TopTag::Type2TopTag(MassType typeOfMass): m_mjetLower(60.), m_mjetUpper(100.), m_typeOfMass(typeOfMass){}
+
+
+
+
 bool HEPTopTag::operator()(const TopJet & topjet, const uhh2::Event &) const{
     
   double mjet;
@@ -101,8 +123,19 @@ bool HEPTopTag::operator()(const TopJet & topjet, const uhh2::Event &) const{
   return true; 
 }
 
-HEPTopTag::HEPTopTag(double ptJetMin, double massWindowLower, double massWindowUpper, double cutCondition2, double cutCondition3): m_ptJetMin(ptJetMin),
-  m_massWindowLower(massWindowLower), m_massWindowUpper(massWindowUpper), m_cutCondition2(cutCondition2), m_cutCondition3(cutCondition3){}
+//uses WP with 40% signal efficiency as default (see https://indico.cern.ch/event/393337/#preview:1078843)
+HEPTopTagV2::HEPTopTagV2(double minHTTmass, double maxHTTmass, double maxfRec):m_minHTTmass(minHTTmass), m_maxHTTmass(maxHTTmass), m_maxfRec(maxfRec){}
+bool HEPTopTagV2::operator()(const TopJet & topjet, const uhh2::Event &) const{
+   if (!topjet.has_tag(topjet.tagname2tag("mass"))) return false;
+   if (!topjet.has_tag(topjet.tagname2tag("fRec"))) return false;
+   
+   double fRec = topjet.get_tag(topjet.tagname2tag("fRec"));
+   double HTTmass = topjet.get_tag(topjet.tagname2tag("mass"));
+   
+   if (HTTmass > m_minHTTmass && HTTmass < m_maxHTTmass && fRec <m_maxfRec) return true;
+
+   return false;
+}
 
 
     
@@ -113,6 +146,16 @@ bool Tau32::operator()(const TopJet & topjet, const uhh2::Event &) const {
     if(!std::isfinite(tau3)) return false;
     return tau3 / tau2 < threshold;
 }
+
+
+bool Tau21::operator()(const TopJet & topjet, const uhh2::Event &) const {
+    auto tau1 = topjet.tau1();
+    if(!std::isfinite(tau1) || tau1 == 0.0) return false;
+    auto tau2= topjet.tau2();
+    if(!std::isfinite(tau2)) return false;
+    return tau2 / tau1 < threshold;
+}
+
 
 
 bool HiggsTag::operator()(TopJet const & topjet, uhh2::Event const & event) const {

--- a/common/src/TopJetIds.cxx
+++ b/common/src/TopJetIds.cxx
@@ -123,6 +123,10 @@ bool HEPTopTag::operator()(const TopJet & topjet, const uhh2::Event &) const{
   return true; 
 }
 
+HEPTopTag::HEPTopTag(double ptJetMin, double massWindowLower, double massWindowUpper, double cutCondition2, double cutCondition3): m_ptJetMin(ptJetMin),
+  m_massWindowLower(massWindowLower), m_massWindowUpper(massWindowUpper), m_cutCondition2(cutCondition2), m_cutCondition3(cutCondition3){}
+
+
 //uses WP with 40% signal efficiency as default (see https://indico.cern.ch/event/393337/#preview:1078843)
 HEPTopTagV2::HEPTopTagV2(double minHTTmass, double maxHTTmass, double maxfRec):m_minHTTmass(minHTTmass), m_maxHTTmass(maxHTTmass), m_maxfRec(maxfRec){}
 bool HEPTopTagV2::operator()(const TopJet & topjet, const uhh2::Event &) const{

--- a/core/include/TopJet.h
+++ b/core/include/TopJet.h
@@ -45,6 +45,8 @@ public:
   const std::vector<Jet> & subjets() const{return m_subjets;}
   
   float get_tag(tag t) const{ return tags.get_tag(static_cast<int>(t)); }
+  float has_tag(tag t) const{ return tags.has_tag(static_cast<int>(t)); }
+ 
 
   // setters
   void set_qjets_volatility(float x){m_qjets_volatility = x;}


### PR DESCRIPTION
For the HepTopTagV2 TopJetId I used the cuts for the 40% efficiency WP given in the talk about top tagging in this B2G meeting: https://indico.cern.ch/event/393337/#preview:1078843. The cuts have to be updated when there are new recommendations.