### PR TITLE
added selectors for muon IDs

### DIFF
--- a/common/include/MuonIds.h
+++ b/common/include/MuonIds.h
@@ -5,12 +5,20 @@
 
 // see also ElectronIds.h for general comments
 
+// https://twiki.cern.ch/twiki/bin/view/CMS/SWGuideMuonIdRun2
+class MuonIDLoose {
+ public:
+  bool operator()(const Muon&, const uhh2::Event&) const;
+};
 
-// the tight muon id according to
-// https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideMuonId
+class MuonIDMedium {
+ public:
+  bool operator()(const Muon&, const uhh2::Event&) const;
+};
+
 class MuonIDTight {
-public:
-    bool operator()(const Muon & muon, const uhh2::Event & event) const;
+ public:
+  bool operator()(const Muon&, const uhh2::Event&) const;
 };
 
 // only kinematic cuts, with no further id

--- a/common/src/MuonIds.cxx
+++ b/common/src/MuonIds.cxx
@@ -7,10 +7,10 @@ MuonIDKinematic::MuonIDKinematic(double ptmin_, double etamax_): ptmin(ptmin_), 
 bool MuonIDKinematic::operator()(const Muon & muon, const Event &) const {
     return muon.pt() > ptmin and fabs(muon.eta()) < etamax;
 }
-    
-bool MuonIDTight::operator()(const Muon & muon, const Event &) const {
-    return muon.get_bool(Muon::tight);
-}
+
+bool MuonIDLoose ::operator()(const Muon& muo, const Event&) const { return muo.get_bool(Muon::loose);  }
+bool MuonIDMedium::operator()(const Muon& muo, const Event&) const { return muo.get_bool(Muon::medium); }
+bool MuonIDTight ::operator()(const Muon& muo, const Event&) const { return muo.get_bool(Muon::tight);  }
 
 MuonIso::MuonIso(double iso_):iso(iso_){}
 


### PR DESCRIPTION
* added routines for some muon IDs (loose and medium)
* https://twiki.cern.ch/twiki/bin/view/CMS/SWGuideMuonIdRun2
