### PR TITLE
added selectors for electron IDs [MVA-notrig; Spring15-25ns;]

### DIFF
--- a/common/include/ElectronIds.h
+++ b/common/include/ElectronIds.h
@@ -38,30 +38,33 @@ bool ElectronID_PHYS14_25ns_loose_noIso (const Electron&, const uhh2::Event&);
 bool ElectronID_PHYS14_25ns_medium_noIso(const Electron&, const uhh2::Event&);
 bool ElectronID_PHYS14_25ns_tight_noIso (const Electron&, const uhh2::Event&);
 
-bool ElectronID_Spring15_25ns_veto (const Electron&, const uhh2::Event&);
+bool ElectronID_Spring15_25ns_veto  (const Electron&, const uhh2::Event&);
 bool ElectronID_Spring15_25ns_loose (const Electron&, const uhh2::Event&);
-bool ElectronID_Spring15_25ns_medium (const Electron&, const uhh2::Event&);
+bool ElectronID_Spring15_25ns_medium(const Electron&, const uhh2::Event&);
 bool ElectronID_Spring15_25ns_tight (const Electron&, const uhh2::Event&);
 
-bool ElectronID_Spring15_25ns_veto_noIso (const Electron&, const uhh2::Event&);
+bool ElectronID_Spring15_25ns_veto_noIso  (const Electron&, const uhh2::Event&);
 bool ElectronID_Spring15_25ns_loose_noIso (const Electron&, const uhh2::Event&);
-bool ElectronID_Spring15_25ns_medium_noIso (const Electron&, const uhh2::Event&);
+bool ElectronID_Spring15_25ns_medium_noIso(const Electron&, const uhh2::Event&);
 bool ElectronID_Spring15_25ns_tight_noIso (const Electron&, const uhh2::Event&);
 
-bool ElectronID_Spring15_50ns_veto (const Electron&, const uhh2::Event&);
+bool ElectronID_Spring15_50ns_veto  (const Electron&, const uhh2::Event&);
 bool ElectronID_Spring15_50ns_loose (const Electron&, const uhh2::Event&);
-bool ElectronID_Spring15_50ns_medium (const Electron&, const uhh2::Event&);
+bool ElectronID_Spring15_50ns_medium(const Electron&, const uhh2::Event&);
 bool ElectronID_Spring15_50ns_tight (const Electron&, const uhh2::Event&);
 
-bool ElectronID_Spring15_50ns_veto_noIso (const Electron&, const uhh2::Event&);
+bool ElectronID_Spring15_50ns_veto_noIso  (const Electron&, const uhh2::Event&);
 bool ElectronID_Spring15_50ns_loose_noIso (const Electron&, const uhh2::Event&);
-bool ElectronID_Spring15_50ns_medium_noIso (const Electron&, const uhh2::Event&);
+bool ElectronID_Spring15_50ns_medium_noIso(const Electron&, const uhh2::Event&);
 bool ElectronID_Spring15_50ns_tight_noIso (const Electron&, const uhh2::Event&);
 
 // Electron MVA ID
 // REF https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2
 bool ElectronID_MVAnotrig_PHYS14_loose(const Electron&, const uhh2::Event&);
 bool ElectronID_MVAnotrig_PHYS14_tight(const Electron&, const uhh2::Event&);
+
+bool ElectronID_MVAnotrig_Spring15_25ns_loose(const Electron&, const uhh2::Event&);
+bool ElectronID_MVAnotrig_Spring15_25ns_tight(const Electron&, const uhh2::Event&);
 
 // Electron selectors for PF MINI-Isolation
 class Electron_MINIIso {

--- a/common/src/ElectronIds.cxx
+++ b/common/src/ElectronIds.cxx
@@ -862,6 +862,50 @@ bool ElectronID_MVAnotrig_PHYS14_tight(const Electron& electron, const uhh2::Eve
 
   return pass;
 }
+
+bool ElectronID_MVAnotrig_Spring15_25ns_loose(const Electron& electron, const uhh2::Event&){
+
+  bool pass(false);
+
+  const float MVA(electron.mvaNonTrigV0()), pt(electron.pt()), abs_etaSC(std::abs(electron.supercluster_eta()));
+
+  if(5. < pt && pt <= 10.){
+
+    if                         (abs_etaSC < 0.8)   pass = (MVA > -0.083313);
+    else if(0.8 <= abs_etaSC && abs_etaSC < 1.479) pass = (MVA > -0.235222);
+    else if                    (abs_etaSC < 2.5)   pass = (MVA > -0.670990);
+  }
+  else if(pt > 10.){
+
+    if                         (abs_etaSC < 0.8)   pass = (MVA >  0.913286);
+    else if(0.8 <= abs_etaSC && abs_etaSC < 1.479) pass = (MVA >  0.805013);
+    else if                    (abs_etaSC < 2.5)   pass = (MVA >  0.358969);
+  }
+
+  return pass;
+}
+
+bool ElectronID_MVAnotrig_Spring15_25ns_tight(const Electron& electron, const uhh2::Event&){
+
+  bool pass(false);
+
+  const float MVA(electron.mvaNonTrigV0()), pt(electron.pt()), abs_etaSC(std::abs(electron.supercluster_eta()));
+
+  if(5. < pt && pt <= 10.){
+
+    if                         (abs_etaSC < 0.8)   pass = (MVA >  0.287435);
+    else if(0.8 <= abs_etaSC && abs_etaSC < 1.479) pass = (MVA >  0.221846);
+    else if                    (abs_etaSC < 2.5)   pass = (MVA > -0.303263);
+  }
+  else if(pt > 10.){
+
+    if                         (abs_etaSC < 0.8)   pass = (MVA >  0.967083);
+    else if(0.8 <= abs_etaSC && abs_etaSC < 1.479) pass = (MVA >  0.929117);
+    else if                    (abs_etaSC < 2.5)   pass = (MVA >  0.726311);
+  }
+
+  return pass;
+}
 ///
 
 bool Electron_MINIIso::operator()(const Electron& ele, const uhh2::Event&) const {


### PR DESCRIPTION
* added electron-ID selectors for non-triggering MVA ID [Spring15-25ns working points]
* https://twiki.cern.ch/twiki/bin/viewauth/CMS/MultivariateElectronIdentificationRun2
