### PR TITLE
updates for electron IDs

### DIFF
--- a/common/src/ElectronIds.cxx
+++ b/common/src/ElectronIds.cxx
@@ -8,7 +8,7 @@ namespace {
 // The only difference to the twiki tables is the passes_conversion_rejection flag which replaces the 'Conversion rejection: vertex fit probability'
 // and is treated as a boolean here.
   struct ele_cutvalues {
-    float abs_dEtaIn, abs_dPhiIn, full5x5_sigmaIetaIeta, HoverE, fabs_d0, fabs_dz, fabs_1oE_1op, pfiso_dbeta_dr03, passes_conversion_rejection, cr_misshits;
+    float abs_dEtaIn, abs_dPhiIn, full5x5_sigmaIetaIeta, HoverE, fabs_d0, fabs_dz, fabs_1oE_1op, pfiso, passes_conversion_rejection, cr_misshits;
   };
 
   ele_cutvalues cv_from_ele(const Electron& ele, const uhh2::Event& event){
@@ -29,7 +29,7 @@ namespace {
     result.fabs_d0 = std::abs(ele.gsfTrack_dxy_vertex(pv.x(), pv.y()));
     result.fabs_dz = std::abs(ele.gsfTrack_dz_vertex(pv.x(), pv.y(), pv.z()));
     result.fabs_1oE_1op = (ele.EcalEnergy() > 0. ? (std::abs(1.0f/ele.EcalEnergy() - ele.EoverPIn()/ele.EcalEnergy())) : std::numeric_limits<float>::infinity());
-    result.pfiso_dbeta_dr03 = ele.relIsodb();
+    result.pfiso = ele.relIsorho(event.rho);
     result.cr_misshits = ele.gsfTrack_trackerExpectedHitsInner_numberOfLostHits();
     result.passes_conversion_rejection = ele.passconversionveto() ? 2.0f : 0.0f;
 
@@ -45,7 +45,7 @@ namespace {
     if(vals.fabs_d0 >= thresholds.fabs_d0) return false;
     if(vals.fabs_dz >= thresholds.fabs_dz) return false;
     if(vals.fabs_1oE_1op >= thresholds.fabs_1oE_1op) return false;
-    if(vals.pfiso_dbeta_dr03 >= thresholds.pfiso_dbeta_dr03) return false;
+    if(vals.pfiso >= thresholds.pfiso) return false;
     if(vals.passes_conversion_rejection < thresholds.passes_conversion_rejection) return false; // note: for passes conversion rejection, comparison is inverted
     if(vals.cr_misshits > thresholds.cr_misshits) return false; // note for missing hits: >, not >=
 
@@ -76,7 +76,7 @@ bool ElectronID_PHYS14_25ns_veto(const Electron& electron, const uhh2::Event& ev
     .fabs_d0                     = 0.094095,
     .fabs_dz                     = 0.713070,
     .fabs_1oE_1op                = 0.295751,
-    .pfiso_dbeta_dr03            = 0.158721,
+    .pfiso                       = 0.158721,
     .passes_conversion_rejection = 1.      ,
     .cr_misshits                 = 2.      
   };
@@ -89,7 +89,7 @@ bool ElectronID_PHYS14_25ns_veto(const Electron& electron, const uhh2::Event& ev
     .fabs_d0                     = 0.342293,
     .fabs_dz                     = 0.953461,
     .fabs_1oE_1op                = 0.155501,
-    .pfiso_dbeta_dr03            = 0.177032,
+    .pfiso                       = 0.177032,
     .passes_conversion_rejection = 1.      ,
     .cr_misshits                 = 3.      
   };
@@ -107,7 +107,7 @@ bool ElectronID_PHYS14_25ns_loose(const Electron& electron, const uhh2::Event& e
     .fabs_d0                     = 0.035904,
     .fabs_dz                     = 0.075496,
     .fabs_1oE_1op                = 0.189968,
-    .pfiso_dbeta_dr03            = 0.130136,
+    .pfiso                       = 0.130136,
     .passes_conversion_rejection = 1.      ,
     .cr_misshits                 = 1.      
   };
@@ -120,7 +120,7 @@ bool ElectronID_PHYS14_25ns_loose(const Electron& electron, const uhh2::Event& e
     .fabs_d0                     = 0.099266,
     .fabs_dz                     = 0.197897,
     .fabs_1oE_1op                = 0.140662,
-    .pfiso_dbeta_dr03            = 0.163368,
+    .pfiso                       = 0.163368,
     .passes_conversion_rejection = 1.      ,
     .cr_misshits                 = 1.      
   };
@@ -139,7 +139,7 @@ bool ElectronID_PHYS14_25ns_medium(const Electron& electron, const uhh2::Event& 
     .fabs_d0                     = 0.012235,
     .fabs_dz                     = 0.042020,
     .fabs_1oE_1op                = 0.091942,
-    .pfiso_dbeta_dr03            = 0.107587,
+    .pfiso                       = 0.107587,
     .passes_conversion_rejection = 1.      ,
     .cr_misshits                 = 1.      
   };
@@ -152,7 +152,7 @@ bool ElectronID_PHYS14_25ns_medium(const Electron& electron, const uhh2::Event& 
     .fabs_d0                     = 0.036719,
     .fabs_dz                     = 0.138142,
     .fabs_1oE_1op                = 0.100683,
-    .pfiso_dbeta_dr03            = 0.113254,
+    .pfiso                       = 0.113254,
     .passes_conversion_rejection = 1.      ,
     .cr_misshits                 = 1.      
   };
@@ -171,7 +171,7 @@ bool ElectronID_PHYS14_25ns_tight(const Electron& electron, const uhh2::Event& e
     .fabs_d0                     = 0.008790,
     .fabs_dz                     = 0.021226,
     .fabs_1oE_1op                = 0.020118,
-    .pfiso_dbeta_dr03            = 0.069537,
+    .pfiso                       = 0.069537,
     .passes_conversion_rejection = 1.      ,
     .cr_misshits                 = 1.      
   };
@@ -184,7 +184,7 @@ bool ElectronID_PHYS14_25ns_tight(const Electron& electron, const uhh2::Event& e
     .fabs_d0                     = 0.027984,
     .fabs_dz                     = 0.133431,
     .fabs_1oE_1op                = 0.098919,
-    .pfiso_dbeta_dr03            = 0.078265,
+    .pfiso                       = 0.078265,
     .passes_conversion_rejection = 1.      ,
     .cr_misshits                 = 1.      
   };
@@ -204,7 +204,7 @@ bool ElectronID_PHYS14_25ns_veto_noIso(const Electron& electron, const uhh2::Eve
     .fabs_d0                     = 0.094095,
     .fabs_dz                     = 0.713070,
     .fabs_1oE_1op                = 0.295751,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
+    .pfiso                       = std::numeric_limits<float>::infinity(),
     .passes_conversion_rejection = 1.      ,
     .cr_misshits                 = 2.      
   };
@@ -217,7 +217,7 @@ bool ElectronID_PHYS14_25ns_veto_noIso(const Electron& electron, const uhh2::Eve
     .fabs_d0                     = 0.342293,
     .fabs_dz                     = 0.953461,
     .fabs_1oE_1op                = 0.155501,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
+    .pfiso                       = std::numeric_limits<float>::infinity(),
     .passes_conversion_rejection = 1.      ,
     .cr_misshits                 = 3.      
   };
@@ -235,7 +235,7 @@ bool ElectronID_PHYS14_25ns_loose_noIso(const Electron& electron, const uhh2::Ev
     .fabs_d0                     = 0.035904,
     .fabs_dz                     = 0.075496,
     .fabs_1oE_1op                = 0.189968,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
+    .pfiso                       = std::numeric_limits<float>::infinity(),
     .passes_conversion_rejection = 1.      ,
     .cr_misshits                 = 1.      
   };
@@ -248,7 +248,7 @@ bool ElectronID_PHYS14_25ns_loose_noIso(const Electron& electron, const uhh2::Ev
     .fabs_d0                     = 0.099266,
     .fabs_dz                     = 0.197897,
     .fabs_1oE_1op                = 0.140662,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
+    .pfiso                       = std::numeric_limits<float>::infinity(),
     .passes_conversion_rejection = 1.      ,
     .cr_misshits                 = 1.      
   };
@@ -267,7 +267,7 @@ bool ElectronID_PHYS14_25ns_medium_noIso(const Electron& electron, const uhh2::E
     .fabs_d0                     = 0.012235,
     .fabs_dz                     = 0.042020,
     .fabs_1oE_1op                = 0.091942,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
+    .pfiso                       = std::numeric_limits<float>::infinity(),
     .passes_conversion_rejection = 1.      ,
     .cr_misshits                 = 1.      
   };
@@ -280,7 +280,7 @@ bool ElectronID_PHYS14_25ns_medium_noIso(const Electron& electron, const uhh2::E
     .fabs_d0                     = 0.036719,
     .fabs_dz                     = 0.138142,
     .fabs_1oE_1op                = 0.100683,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
+    .pfiso                       = std::numeric_limits<float>::infinity(),
     .passes_conversion_rejection = 1.      ,
     .cr_misshits                 = 1.      
   };
@@ -298,7 +298,7 @@ bool ElectronID_PHYS14_25ns_tight_noIso(const Electron& electron, const uhh2::Ev
     .fabs_d0                     = 0.008790,
     .fabs_dz                     = 0.021226,
     .fabs_1oE_1op                = 0.020118,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
+    .pfiso                       = std::numeric_limits<float>::infinity(),
     .passes_conversion_rejection = 1.      ,
     .cr_misshits                 = 1.      
   };
@@ -311,7 +311,7 @@ bool ElectronID_PHYS14_25ns_tight_noIso(const Electron& electron, const uhh2::Ev
     .fabs_d0                     = 0.027984,
     .fabs_dz                     = 0.133431,
     .fabs_1oE_1op                = 0.098919,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
+    .pfiso                       = std::numeric_limits<float>::infinity(),
     .passes_conversion_rejection = 1.      ,
     .cr_misshits                 = 1.      
   };
@@ -323,27 +323,27 @@ bool ElectronID_Spring15_25ns_veto(const Electron& electron, const uhh2::Event& 
 
   static constexpr const auto thresholds_barrel = ele_cutvalues{
     .abs_dEtaIn                  = 0.0152,
-    .abs_dPhiIn                  = 0.216,
+    .abs_dPhiIn                  = 0.216 ,
     .full5x5_sigmaIetaIeta       = 0.0114,
-    .HoverE                      = 0.181,
+    .HoverE                      = 0.181 ,
     .fabs_d0                     = 0.0564,
-    .fabs_dz                     = 0.472,
-    .fabs_1oE_1op                = 0.207,
-    .pfiso_dbeta_dr03            = 0.126,
+    .fabs_dz                     = 0.472 ,
+    .fabs_1oE_1op                = 0.207 ,
+    .pfiso                       = 0.126 ,
     .passes_conversion_rejection = 1.    ,
     .cr_misshits                 = 2.
   };
 
   static constexpr const auto thresholds_endcap = ele_cutvalues{
     .abs_dEtaIn                  = 0.0113,
-    .abs_dPhiIn                  = 0.237,
+    .abs_dPhiIn                  = 0.237 ,
     .full5x5_sigmaIetaIeta       = 0.0352,
-    .HoverE                      = 0.116,
-    .fabs_d0                     = 0.222,
-    .fabs_dz                     = 0.921,
-    .fabs_1oE_1op                = 0.174,
-    .pfiso_dbeta_dr03            = 0.144,
-    .passes_conversion_rejection = 1.      ,
+    .HoverE                      = 0.116 ,
+    .fabs_d0                     = 0.222 ,
+    .fabs_dz                     = 0.921 ,
+    .fabs_1oE_1op                = 0.174 ,
+    .pfiso                       = 0.144 ,
+    .passes_conversion_rejection = 1.    ,
     .cr_misshits                 = 3.
   };
 
@@ -354,27 +354,27 @@ bool ElectronID_Spring15_25ns_loose(const Electron& electron, const uhh2::Event&
 
   static constexpr const auto thresholds_barrel = ele_cutvalues{
     .abs_dEtaIn                  = 0.0105,
-    .abs_dPhiIn                  = 0.115,
+    .abs_dPhiIn                  = 0.115 ,
     .full5x5_sigmaIetaIeta       = 0.0103,
-    .HoverE                      = 0.104,
+    .HoverE                      = 0.104 ,
     .fabs_d0                     = 0.0261,
-    .fabs_dz                     = 0.41,
-    .fabs_1oE_1op                = 0.102,
-    .pfiso_dbeta_dr03            = 0.0893,
+    .fabs_dz                     = 0.41  ,
+    .fabs_1oE_1op                = 0.102 ,
+    .pfiso                       = 0.0893,
     .passes_conversion_rejection = 1.    ,
     .cr_misshits                 = 2.
   };
 
   static constexpr const auto thresholds_endcap = ele_cutvalues{
     .abs_dEtaIn                  = 0.00814,
-    .abs_dPhiIn                  = 0.182,
-    .full5x5_sigmaIetaIeta       = 0.0301,
-    .HoverE                      = 0.0897,
-    .fabs_d0                     = 0.118,
-    .fabs_dz                     = 0.822,
-    .fabs_1oE_1op                = 0.126,
-    .pfiso_dbeta_dr03            = 0.121,
-    .passes_conversion_rejection = 1.      ,
+    .abs_dPhiIn                  = 0.182  ,
+    .full5x5_sigmaIetaIeta       = 0.0301 ,
+    .HoverE                      = 0.0897 ,
+    .fabs_d0                     = 0.118  ,
+    .fabs_dz                     = 0.822  ,
+    .fabs_1oE_1op                = 0.126  ,
+    .pfiso                       = 0.121  ,
+    .passes_conversion_rejection = 1.     ,
     .cr_misshits                 = 1.
   };
 
@@ -389,23 +389,23 @@ bool ElectronID_Spring15_25ns_medium(const Electron& electron, const uhh2::Event
     .full5x5_sigmaIetaIeta       = 0.0101,
     .HoverE                      = 0.0876,
     .fabs_d0                     = 0.0118,
-    .fabs_dz                     = 0.373,
+    .fabs_dz                     = 0.373 ,
     .fabs_1oE_1op                = 0.0174,
-    .pfiso_dbeta_dr03            = 0.0766,
+    .pfiso                       = 0.0766,
     .passes_conversion_rejection = 1.    ,
     .cr_misshits                 = 2.
   };
 
   static constexpr const auto thresholds_endcap = ele_cutvalues{
     .abs_dEtaIn                  = 0.00733,
-    .abs_dPhiIn                  = 0.114,
-    .full5x5_sigmaIetaIeta       = 0.0283,
-    .HoverE                      = 0.0678,
-    .fabs_d0                     = 0.0739,
-    .fabs_dz                     = 0.602,
-    .fabs_1oE_1op                = 0.0898,
-    .pfiso_dbeta_dr03            = 0.0678,
-    .passes_conversion_rejection = 1.      ,
+    .abs_dPhiIn                  = 0.114  ,
+    .full5x5_sigmaIetaIeta       = 0.0283 ,
+    .HoverE                      = 0.0678 ,
+    .fabs_d0                     = 0.0739 ,
+    .fabs_dz                     = 0.602  ,
+    .fabs_1oE_1op                = 0.0898 ,
+    .pfiso                       = 0.0678 ,
+    .passes_conversion_rejection = 1.     ,
     .cr_misshits                 = 1.
   };
 
@@ -416,27 +416,27 @@ bool ElectronID_Spring15_25ns_tight(const Electron& electron, const uhh2::Event&
 
   static constexpr const auto thresholds_barrel = ele_cutvalues{
     .abs_dEtaIn                  = 0.00926,
-    .abs_dPhiIn                  = 0.0336,
-    .full5x5_sigmaIetaIeta       = 0.0101,
-    .HoverE                      = 0.0597,
-    .fabs_d0                     = 0.0111,
-    .fabs_dz                     = 0.0466,
-    .fabs_1oE_1op                = 0.012,
-    .pfiso_dbeta_dr03            = 0.0354,
-    .passes_conversion_rejection = 1.    ,
+    .abs_dPhiIn                  = 0.0336 ,
+    .full5x5_sigmaIetaIeta       = 0.0101 ,
+    .HoverE                      = 0.0597 ,
+    .fabs_d0                     = 0.0111 ,
+    .fabs_dz                     = 0.0466 ,
+    .fabs_1oE_1op                = 0.012  ,
+    .pfiso                       = 0.0354 ,
+    .passes_conversion_rejection = 1.     ,
     .cr_misshits                 = 2.
   };
 
   static constexpr const auto thresholds_endcap = ele_cutvalues{
     .abs_dEtaIn                  = 0.00724,
-    .abs_dPhiIn                  = 0.0918,
-    .full5x5_sigmaIetaIeta       = 0.0279,
-    .HoverE                      = 0.0615,
-    .fabs_d0                     = 0.0351,
-    .fabs_dz                     = 0.417,
+    .abs_dPhiIn                  = 0.0918 ,
+    .full5x5_sigmaIetaIeta       = 0.0279 ,
+    .HoverE                      = 0.0615 ,
+    .fabs_d0                     = 0.0351 ,
+    .fabs_dz                     = 0.417  ,
     .fabs_1oE_1op                = 0.00999,
-    .pfiso_dbeta_dr03            = 0.0646,
-    .passes_conversion_rejection = 1.      ,
+    .pfiso                       = 0.0646 ,
+    .passes_conversion_rejection = 1.     ,
     .cr_misshits                 = 1.
   };
 
@@ -447,27 +447,27 @@ bool ElectronID_Spring15_25ns_veto_noIso(const Electron& electron, const uhh2::E
 
   static constexpr const auto thresholds_barrel = ele_cutvalues{
     .abs_dEtaIn                  = 0.0152,
-    .abs_dPhiIn                  = 0.216,
+    .abs_dPhiIn                  = 0.216 ,
     .full5x5_sigmaIetaIeta       = 0.0114,
-    .HoverE                      = 0.181,
+    .HoverE                      = 0.181 ,
     .fabs_d0                     = 0.0564,
-    .fabs_dz                     = 0.472,
-    .fabs_1oE_1op                = 0.207,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
+    .fabs_dz                     = 0.472 ,
+    .fabs_1oE_1op                = 0.207 ,
+    .pfiso                       = std::numeric_limits<float>::infinity(),
     .passes_conversion_rejection = 1.    ,
     .cr_misshits                 = 2.
   };
 
   static constexpr const auto thresholds_endcap = ele_cutvalues{
     .abs_dEtaIn                  = 0.0113,
-    .abs_dPhiIn                  = 0.237,
+    .abs_dPhiIn                  = 0.237 ,
     .full5x5_sigmaIetaIeta       = 0.0352,
-    .HoverE                      = 0.116,
-    .fabs_d0                     = 0.222,
-    .fabs_dz                     = 0.921,
-    .fabs_1oE_1op                = 0.174,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
-    .passes_conversion_rejection = 1.      ,
+    .HoverE                      = 0.116 ,
+    .fabs_d0                     = 0.222 ,
+    .fabs_dz                     = 0.921 ,
+    .fabs_1oE_1op                = 0.174 ,
+    .pfiso                       = std::numeric_limits<float>::infinity(),
+    .passes_conversion_rejection = 1.    ,
     .cr_misshits                 = 3.
   };
 
@@ -478,27 +478,27 @@ bool ElectronID_Spring15_25ns_loose_noIso(const Electron& electron, const uhh2::
 
   static constexpr const auto thresholds_barrel = ele_cutvalues{
     .abs_dEtaIn                  = 0.0105,
-    .abs_dPhiIn                  = 0.115,
+    .abs_dPhiIn                  = 0.115 ,
     .full5x5_sigmaIetaIeta       = 0.0103,
-    .HoverE                      = 0.104,
+    .HoverE                      = 0.104 ,
     .fabs_d0                     = 0.0261,
-    .fabs_dz                     = 0.41,
-    .fabs_1oE_1op                = 0.102,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
+    .fabs_dz                     = 0.41  ,
+    .fabs_1oE_1op                = 0.102 ,
+    .pfiso                       = std::numeric_limits<float>::infinity(),
     .passes_conversion_rejection = 1.    ,
     .cr_misshits                 = 2.
   };
 
   static constexpr const auto thresholds_endcap = ele_cutvalues{
     .abs_dEtaIn                  = 0.00814,
-    .abs_dPhiIn                  = 0.182,
-    .full5x5_sigmaIetaIeta       = 0.0301,
-    .HoverE                      = 0.0897,
-    .fabs_d0                     = 0.118,
-    .fabs_dz                     = 0.822,
-    .fabs_1oE_1op                = 0.126,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
-    .passes_conversion_rejection = 1.      ,
+    .abs_dPhiIn                  = 0.182  ,
+    .full5x5_sigmaIetaIeta       = 0.0301 ,
+    .HoverE                      = 0.0897 ,
+    .fabs_d0                     = 0.118  ,
+    .fabs_dz                     = 0.822  ,
+    .fabs_1oE_1op                = 0.126  ,
+    .pfiso                       = std::numeric_limits<float>::infinity(),
+    .passes_conversion_rejection = 1.     ,
     .cr_misshits                 = 1.
   };
 
@@ -513,23 +513,23 @@ bool ElectronID_Spring15_25ns_medium_noIso(const Electron& electron, const uhh2:
     .full5x5_sigmaIetaIeta       = 0.0101,
     .HoverE                      = 0.0876,
     .fabs_d0                     = 0.0118,
-    .fabs_dz                     = 0.373,
+    .fabs_dz                     = 0.373 ,
     .fabs_1oE_1op                = 0.0174,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
+    .pfiso                       = std::numeric_limits<float>::infinity(),
     .passes_conversion_rejection = 1.    ,
     .cr_misshits                 = 2.
   };
 
   static constexpr const auto thresholds_endcap = ele_cutvalues{
     .abs_dEtaIn                  = 0.00733,
-    .abs_dPhiIn                  = 0.114,
-    .full5x5_sigmaIetaIeta       = 0.0283,
-    .HoverE                      = 0.0678,
-    .fabs_d0                     = 0.0739,
-    .fabs_dz                     = 0.602,
-    .fabs_1oE_1op                = 0.0898,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
-    .passes_conversion_rejection = 1.      ,
+    .abs_dPhiIn                  = 0.114  ,
+    .full5x5_sigmaIetaIeta       = 0.0283 ,
+    .HoverE                      = 0.0678 ,
+    .fabs_d0                     = 0.0739 ,
+    .fabs_dz                     = 0.602  ,
+    .fabs_1oE_1op                = 0.0898 ,
+    .pfiso                       = std::numeric_limits<float>::infinity(),
+    .passes_conversion_rejection = 1.     ,
     .cr_misshits                 = 1.
   };
 
@@ -540,27 +540,27 @@ bool ElectronID_Spring15_25ns_tight_noIso(const Electron& electron, const uhh2::
 
   static constexpr const auto thresholds_barrel = ele_cutvalues{
     .abs_dEtaIn                  = 0.00926,
-    .abs_dPhiIn                  = 0.0336,
-    .full5x5_sigmaIetaIeta       = 0.0101,
-    .HoverE                      = 0.0597,
-    .fabs_d0                     = 0.0111,
-    .fabs_dz                     = 0.0466,
-    .fabs_1oE_1op                = 0.012,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
-    .passes_conversion_rejection = 1.    ,
+    .abs_dPhiIn                  = 0.0336 ,
+    .full5x5_sigmaIetaIeta       = 0.0101 ,
+    .HoverE                      = 0.0597 ,
+    .fabs_d0                     = 0.0111 ,
+    .fabs_dz                     = 0.0466 ,
+    .fabs_1oE_1op                = 0.012  ,
+    .pfiso                       = std::numeric_limits<float>::infinity(),
+    .passes_conversion_rejection = 1.     ,
     .cr_misshits                 = 2.
   };
 
   static constexpr const auto thresholds_endcap = ele_cutvalues{
     .abs_dEtaIn                  = 0.00724,
-    .abs_dPhiIn                  = 0.0918,
-    .full5x5_sigmaIetaIeta       = 0.0279,
-    .HoverE                      = 0.0615,
-    .fabs_d0                     = 0.0351,
-    .fabs_dz                     = 0.417,
+    .abs_dPhiIn                  = 0.0918 ,
+    .full5x5_sigmaIetaIeta       = 0.0279 ,
+    .HoverE                      = 0.0615 ,
+    .fabs_d0                     = 0.0351 ,
+    .fabs_dz                     = 0.417  ,
     .fabs_1oE_1op                = 0.00999,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
-    .passes_conversion_rejection = 1.      ,
+    .pfiso                       = std::numeric_limits<float>::infinity(),
+    .passes_conversion_rejection = 1.     ,
     .cr_misshits                 = 1.
   };
 
@@ -571,27 +571,27 @@ bool ElectronID_Spring15_50ns_veto(const Electron& electron, const uhh2::Event& 
 
   static constexpr const auto thresholds_barrel = ele_cutvalues{
     .abs_dEtaIn                  = 0.0126,
-    .abs_dPhiIn                  = 0.107,
-    .full5x5_sigmaIetaIeta       = 0.012,
-    .HoverE                      = 0.186,
+    .abs_dPhiIn                  = 0.107 ,
+    .full5x5_sigmaIetaIeta       = 0.012 ,
+    .HoverE                      = 0.186 ,
     .fabs_d0                     = 0.0621,
-    .fabs_dz                     = 0.613,
-    .fabs_1oE_1op                = 0.239,
-    .pfiso_dbeta_dr03            = 0.161,
+    .fabs_dz                     = 0.613 ,
+    .fabs_1oE_1op                = 0.239 ,
+    .pfiso                       = 0.161 ,
     .passes_conversion_rejection = 1.    ,
     .cr_misshits                 = 2.
   };
 
   static constexpr const auto thresholds_endcap = ele_cutvalues{
     .abs_dEtaIn                  = 0.0109,
-    .abs_dPhiIn                  = 0.219,
+    .abs_dPhiIn                  = 0.219 ,
     .full5x5_sigmaIetaIeta       = 0.0339,
     .HoverE                      = 0.0962,
-    .fabs_d0                     = 0.279,
-    .fabs_dz                     = 0.947,
-    .fabs_1oE_1op                = 0.141,
-    .pfiso_dbeta_dr03            = 0.193,
-    .passes_conversion_rejection = 1.      ,
+    .fabs_d0                     = 0.279 ,
+    .fabs_dz                     = 0.947 ,
+    .fabs_1oE_1op                = 0.141 ,
+    .pfiso                       = 0.193 ,
+    .passes_conversion_rejection = 1.    ,
     .cr_misshits                 = 3.
   };
 
@@ -603,27 +603,27 @@ bool ElectronID_Spring15_50ns_loose(const Electron& electron, const uhh2::Event&
 
   static constexpr const auto thresholds_barrel = ele_cutvalues{
     .abs_dEtaIn                  = 0.00976,
-    .abs_dPhiIn                  = 0.0929,
-    .full5x5_sigmaIetaIeta       = 0.0105,
-    .HoverE                      = 0.0765,
-    .fabs_d0                     = 0.0227,
-    .fabs_dz                     = 0.379,
-    .fabs_1oE_1op                = 0.184,
-    .pfiso_dbeta_dr03            = 0.118,
-    .passes_conversion_rejection = 1.    ,
+    .abs_dPhiIn                  = 0.0929 ,
+    .full5x5_sigmaIetaIeta       = 0.0105 ,
+    .HoverE                      = 0.0765 ,
+    .fabs_d0                     = 0.0227 ,
+    .fabs_dz                     = 0.379  ,
+    .fabs_1oE_1op                = 0.184  ,
+    .pfiso                       = 0.118  ,
+    .passes_conversion_rejection = 1.     ,
     .cr_misshits                 = 2.
   };
 
   static constexpr const auto thresholds_endcap = ele_cutvalues{
     .abs_dEtaIn                  = 0.00952,
-    .abs_dPhiIn                  = 0.181,
-    .full5x5_sigmaIetaIeta       = 0.0318,
-    .HoverE                      = 0.0824,
-    .fabs_d0                     = 0.242,
-    .fabs_dz                     = 0.921,
-    .fabs_1oE_1op                = 0.125,
-    .pfiso_dbeta_dr03            = 0.118,
-    .passes_conversion_rejection = 1.      ,
+    .abs_dPhiIn                  = 0.181  ,
+    .full5x5_sigmaIetaIeta       = 0.0318 ,
+    .HoverE                      = 0.0824 ,
+    .fabs_d0                     = 0.242  ,
+    .fabs_dz                     = 0.921  ,
+    .fabs_1oE_1op                = 0.125  ,
+    .pfiso                       = 0.118  ,
+    .passes_conversion_rejection = 1.     ,
     .cr_misshits                 = 1.
   };
 
@@ -638,23 +638,23 @@ bool ElectronID_Spring15_50ns_medium(const Electron& electron, const uhh2::Event
     .full5x5_sigmaIetaIeta       = 0.0101,
     .HoverE                      = 0.0372,
     .fabs_d0                     = 0.0151,
-    .fabs_dz                     = 0.238,
-    .fabs_1oE_1op                = 0.118,
-    .pfiso_dbeta_dr03            = 0.0987,
+    .fabs_dz                     = 0.238 ,
+    .fabs_1oE_1op                = 0.118 ,
+    .pfiso                       = 0.0987,
     .passes_conversion_rejection = 1.    ,
     .cr_misshits                 = 2.
   };
 
   static constexpr const auto thresholds_endcap = ele_cutvalues{
     .abs_dEtaIn                  = 0.00773,
-    .abs_dPhiIn                  = 0.148,
-    .full5x5_sigmaIetaIeta       = 0.0287,
-    .HoverE                      = 0.0546,
-    .fabs_d0                     = 0.0535,
-    .fabs_dz                     = 0.572,
-    .fabs_1oE_1op                = 0.104,
-    .pfiso_dbeta_dr03            = 0.0902,
-    .passes_conversion_rejection = 1.      ,
+    .abs_dPhiIn                  = 0.148  ,
+    .full5x5_sigmaIetaIeta       = 0.0287 ,
+    .HoverE                      = 0.0546 ,
+    .fabs_d0                     = 0.0535 ,
+    .fabs_dz                     = 0.572  ,
+    .fabs_1oE_1op                = 0.104  ,
+    .pfiso                       = 0.0902 ,
+    .passes_conversion_rejection = 1.     ,
     .cr_misshits                 = 1.
   };
 
@@ -669,23 +669,23 @@ bool ElectronID_Spring15_50ns_tight(const Electron& electron, const uhh2::Event&
     .full5x5_sigmaIetaIeta       = 0.0101,
     .HoverE                      = 0.0372,
     .fabs_d0                     = 0.0144,
-    .fabs_dz                     = 0.323,
+    .fabs_dz                     = 0.323 ,
     .fabs_1oE_1op                = 0.0174,
-    .pfiso_dbeta_dr03            = 0.0468,
+    .pfiso                       = 0.0468,
     .passes_conversion_rejection = 1.    ,
     .cr_misshits                 = 2.
   };
 
   static constexpr const auto thresholds_endcap = ele_cutvalues{
     .abs_dEtaIn                  = 0.00762,
-    .abs_dPhiIn                  = 0.0439,
-    .full5x5_sigmaIetaIeta       = 0.0287,
-    .HoverE                      = 0.0544,
-    .fabs_d0                     = 0.0377,
-    .fabs_dz                     = 0.571,
-    .fabs_1oE_1op                = 0.01,
-    .pfiso_dbeta_dr03            = 0.0759,
-    .passes_conversion_rejection = 1.      ,
+    .abs_dPhiIn                  = 0.0439 ,
+    .full5x5_sigmaIetaIeta       = 0.0287 ,
+    .HoverE                      = 0.0544 ,
+    .fabs_d0                     = 0.0377 ,
+    .fabs_dz                     = 0.571  ,
+    .fabs_1oE_1op                = 0.01   ,
+    .pfiso                       = 0.0759 ,
+    .passes_conversion_rejection = 1.     ,
     .cr_misshits                 = 1.
   };
 
@@ -696,27 +696,27 @@ bool ElectronID_Spring15_50ns_veto_noIso(const Electron& electron, const uhh2::E
 
   static constexpr const auto thresholds_barrel = ele_cutvalues{
     .abs_dEtaIn                  = 0.0126,
-    .abs_dPhiIn                  = 0.107,
-    .full5x5_sigmaIetaIeta       = 0.012,
-    .HoverE                      = 0.186,
+    .abs_dPhiIn                  = 0.107 ,
+    .full5x5_sigmaIetaIeta       = 0.012 ,
+    .HoverE                      = 0.186 ,
     .fabs_d0                     = 0.0621,
-    .fabs_dz                     = 0.613,
-    .fabs_1oE_1op                = 0.239,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
+    .fabs_dz                     = 0.613 ,
+    .fabs_1oE_1op                = 0.239 ,
+    .pfiso                       = std::numeric_limits<float>::infinity(),
     .passes_conversion_rejection = 1.    ,
     .cr_misshits                 = 2.
   };
 
   static constexpr const auto thresholds_endcap = ele_cutvalues{
     .abs_dEtaIn                  = 0.0109,
-    .abs_dPhiIn                  = 0.219,
+    .abs_dPhiIn                  = 0.219 ,
     .full5x5_sigmaIetaIeta       = 0.0339,
     .HoverE                      = 0.0962,
-    .fabs_d0                     = 0.279,
-    .fabs_dz                     = 0.947,
-    .fabs_1oE_1op                = 0.141,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
-    .passes_conversion_rejection = 1.      ,
+    .fabs_d0                     = 0.279 ,
+    .fabs_dz                     = 0.947 ,
+    .fabs_1oE_1op                = 0.141 ,
+    .pfiso                       = std::numeric_limits<float>::infinity(),
+    .passes_conversion_rejection = 1.    ,
     .cr_misshits                 = 3.
   };
 
@@ -728,27 +728,27 @@ bool ElectronID_Spring15_50ns_loose_noIso(const Electron& electron, const uhh2::
 
   static constexpr const auto thresholds_barrel = ele_cutvalues{
     .abs_dEtaIn                  = 0.00976,
-    .abs_dPhiIn                  = 0.0929,
-    .full5x5_sigmaIetaIeta       = 0.0105,
-    .HoverE                      = 0.0765,
-    .fabs_d0                     = 0.0227,
-    .fabs_dz                     = 0.379,
-    .fabs_1oE_1op                = 0.184,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
-    .passes_conversion_rejection = 1.    ,
+    .abs_dPhiIn                  = 0.0929 ,
+    .full5x5_sigmaIetaIeta       = 0.0105 ,
+    .HoverE                      = 0.0765 ,
+    .fabs_d0                     = 0.0227 ,
+    .fabs_dz                     = 0.379  ,
+    .fabs_1oE_1op                = 0.184  ,
+    .pfiso                       = std::numeric_limits<float>::infinity(),
+    .passes_conversion_rejection = 1.     ,
     .cr_misshits                 = 2.
   };
 
   static constexpr const auto thresholds_endcap = ele_cutvalues{
     .abs_dEtaIn                  = 0.00952,
-    .abs_dPhiIn                  = 0.181,
-    .full5x5_sigmaIetaIeta       = 0.0318,
-    .HoverE                      = 0.0824,
-    .fabs_d0                     = 0.242,
-    .fabs_dz                     = 0.921,
-    .fabs_1oE_1op                = 0.125,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
-    .passes_conversion_rejection = 1.      ,
+    .abs_dPhiIn                  = 0.181  ,
+    .full5x5_sigmaIetaIeta       = 0.0318 ,
+    .HoverE                      = 0.0824 ,
+    .fabs_d0                     = 0.242  ,
+    .fabs_dz                     = 0.921  ,
+    .fabs_1oE_1op                = 0.125  ,
+    .pfiso                       = std::numeric_limits<float>::infinity(),
+    .passes_conversion_rejection = 1.     ,
     .cr_misshits                 = 1.
   };
 
@@ -763,23 +763,23 @@ bool ElectronID_Spring15_50ns_medium_noIso(const Electron& electron, const uhh2:
     .full5x5_sigmaIetaIeta       = 0.0101,
     .HoverE                      = 0.0372,
     .fabs_d0                     = 0.0151,
-    .fabs_dz                     = 0.238,
-    .fabs_1oE_1op                = 0.118,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
+    .fabs_dz                     = 0.238 ,
+    .fabs_1oE_1op                = 0.118 ,
+    .pfiso                       = std::numeric_limits<float>::infinity(),
     .passes_conversion_rejection = 1.    ,
     .cr_misshits                 = 2.
   };
 
   static constexpr const auto thresholds_endcap = ele_cutvalues{
     .abs_dEtaIn                  = 0.00773,
-    .abs_dPhiIn                  = 0.148,
-    .full5x5_sigmaIetaIeta       = 0.0287,
-    .HoverE                      = 0.0546,
-    .fabs_d0                     = 0.0535,
-    .fabs_dz                     = 0.572,
-    .fabs_1oE_1op                = 0.104,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
-    .passes_conversion_rejection = 1.      ,
+    .abs_dPhiIn                  = 0.148  ,
+    .full5x5_sigmaIetaIeta       = 0.0287 ,
+    .HoverE                      = 0.0546 ,
+    .fabs_d0                     = 0.0535 ,
+    .fabs_dz                     = 0.572  ,
+    .fabs_1oE_1op                = 0.104  ,
+    .pfiso                       = std::numeric_limits<float>::infinity(),
+    .passes_conversion_rejection = 1.     ,
     .cr_misshits                 = 1.
   };
 
@@ -794,23 +794,23 @@ bool ElectronID_Spring15_50ns_tight_noIso(const Electron& electron, const uhh2::
     .full5x5_sigmaIetaIeta       = 0.0101,
     .HoverE                      = 0.0372,
     .fabs_d0                     = 0.0144,
-    .fabs_dz                     = 0.323,
+    .fabs_dz                     = 0.323 ,
     .fabs_1oE_1op                = 0.0174,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
+    .pfiso                       = std::numeric_limits<float>::infinity(),
     .passes_conversion_rejection = 1.    ,
     .cr_misshits                 = 2.
   };
 
   static constexpr const auto thresholds_endcap = ele_cutvalues{
     .abs_dEtaIn                  = 0.00762,
-    .abs_dPhiIn                  = 0.0439,
-    .full5x5_sigmaIetaIeta       = 0.0287,
-    .HoverE                      = 0.0544,
-    .fabs_d0                     = 0.0377,
-    .fabs_dz                     = 0.571,
-    .fabs_1oE_1op                = 0.01,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
-    .passes_conversion_rejection = 1.      ,
+    .abs_dPhiIn                  = 0.0439 ,
+    .full5x5_sigmaIetaIeta       = 0.0287 ,
+    .HoverE                      = 0.0544 ,
+    .fabs_d0                     = 0.0377 ,
+    .fabs_dz                     = 0.571  ,
+    .fabs_1oE_1op                = 0.01   ,
+    .pfiso                       = std::numeric_limits<float>::infinity(),
+    .passes_conversion_rejection = 1.     ,
     .cr_misshits                 = 1.
   };
 

--- a/common/src/PrintingModules.cxx
+++ b/common/src/PrintingModules.cxx
@@ -43,14 +43,14 @@ void ElectronPrinter::print(std::ostream & out, const Electron & ele, const Even
         fabs_1oE_1op = std::abs(1.0f/ele.EcalEnergy() - ele.EoverPIn()/ele.EcalEnergy());
     }
     const char * medium_id = "<N/A>";
-    if(ele.has_tag(Electron::eid_PHYS14_20x25_medium)){
-        if(ele.get_tag(Electron::eid_PHYS14_20x25_medium) > 0.5f){
-            medium_id = "pass";
-        }
-        else{
-            medium_id = "fail";
-        }
-    }
+//    if(ele.has_tag(Electron::eid_PHYS14_20x25_medium)){
+//      if(ele.get_tag(Electron::eid_PHYS14_20x25_medium) > 0.5f){
+//        medium_id = "pass";
+//      }
+//      else{
+//        medium_id = "fail";
+//      }
+//    }
     out << "E=" << ele.energy() << "; pt=" << ele.pt() << ", eta=" << ele.eta() << "; phi=" << ele.phi() << "; reliso_db03=" << ele.relIsodb()
         << "; dEtaIn=" << ele.dEtaIn() << "; dPhiIn=" << ele.dPhiIn() << "; sigma_ieie=" << ele.sigmaIEtaIEta() << "; H/E=" << ele.HoverE()
         << "; d0=" << pv_d0 << "; dz=" << pv_dz << "; |1/E-1/p|=" << fabs_1oE_1op << "; n_misshits=" << ele.gsfTrack_trackerExpectedHitsInner_numberOfLostHits()

--- a/core/include/Electron.h
+++ b/core/include/Electron.h
@@ -8,23 +8,11 @@ class Electron: public Particle {
 
  public:
   enum tag {
-    eid_PHYS14_20x25_veto,
-    eid_PHYS14_20x25_loose,
-    eid_PHYS14_20x25_medium,
-    eid_PHYS14_20x25_tight,
     heepElectronID_HEEPV60,				    
-    mvaEleID_PHYS14_PU20bx25_nonTrig_V1_wp80,		    
-    mvaEleID_PHYS14_PU20bx25_nonTrig_V1_wp90,               
   };
 
   static tag tagname2tag(const std::string & tagname){
-    if(tagname == "cutBasedElectronID_PHYS14_PU20bx25_V2_standalone_veto")   return eid_PHYS14_20x25_veto;
-    if(tagname == "cutBasedElectronID_PHYS14_PU20bx25_V2_standalone_loose")  return eid_PHYS14_20x25_loose;
-    if(tagname == "cutBasedElectronID_PHYS14_PU20bx25_V2_standalone_medium") return eid_PHYS14_20x25_medium;
-    if(tagname == "cutBasedElectronID_PHYS14_PU20bx25_V2_standalone_tight")  return eid_PHYS14_20x25_tight;
     if(tagname == "heepElectronID_HEEPV60")                                  return heepElectronID_HEEPV60;
-    if(tagname == "mvaEleID_PHYS14_PU20bx25_nonTrig_V1_wp80")                return mvaEleID_PHYS14_PU20bx25_nonTrig_V1_wp80;
-    if(tagname == "mvaEleID_PHYS14_PU20bx25_nonTrig_V1_wp90")                return mvaEleID_PHYS14_PU20bx25_nonTrig_V1_wp90;
 
     throw std::runtime_error("unknown Electron::tag '" + tagname + "'");
   }
@@ -55,6 +43,7 @@ class Electron: public Particle {
    m_EcalEnergy = 0;
    m_mvaNonTrigV0 = 0;
    m_mvaTrigV0 = 0;
+   m_AEff = 0;
 
    m_pfMINIIso_CH       = 0;
    m_pfMINIIso_NH       = 0;
@@ -89,6 +78,7 @@ class Electron: public Particle {
   float EcalEnergy() const{return m_EcalEnergy;}
   float mvaNonTrigV0() const{return m_mvaNonTrigV0;}
   float mvaTrigV0() const{return m_mvaTrigV0;}
+  float effArea() const{return m_AEff;}
 
   float pfMINIIso_CH      () const { return m_pfMINIIso_CH; }
   float pfMINIIso_NH      () const { return m_pfMINIIso_NH; }
@@ -125,6 +115,7 @@ class Electron: public Particle {
   void set_EcalEnergy(float x){m_EcalEnergy=x;}
   void set_mvaNonTrigV0(float x){m_mvaNonTrigV0=x;}
   void set_mvaTrigV0(float x){m_mvaTrigV0=x;}
+  void set_effArea(float x){m_AEff=x;}
 
   void set_pfMINIIso_CH      (float x){ m_pfMINIIso_CH       = x; }
   void set_pfMINIIso_NH      (float x){ m_pfMINIIso_NH       = x; }

--- a/core/plugins/NtupleWriterLeptons.cxx
+++ b/core/plugins/NtupleWriterLeptons.cxx
@@ -59,6 +59,8 @@ void NtupleWriterElectrons::process(const edm::Event & event, uhh2::Event & ueve
         ele.set_mvaNonTrigV0(pat_ele.hasUserFloat("mvaNoTrig") ? pat_ele.userFloat("mvaNoTrig") : -999.);
         ele.set_mvaTrigV0   (pat_ele.hasUserFloat("mvaTrig")   ? pat_ele.userFloat("mvaTrig")   : -999.);
 
+        ele.set_effArea(pat_ele.hasUserFloat("EffArea") ? pat_ele.userFloat("EffArea") : -999.);
+
         ele.set_pfMINIIso_CH      (pat_ele.hasUserFloat("elPFMiniIsoValueCHSTAND") ? pat_ele.userFloat("elPFMiniIsoValueCHSTAND") : -999.);
         ele.set_pfMINIIso_NH      (pat_ele.hasUserFloat("elPFMiniIsoValueNHSTAND") ? pat_ele.userFloat("elPFMiniIsoValueNHSTAND") : -999.);
         ele.set_pfMINIIso_Ph      (pat_ele.hasUserFloat("elPFMiniIsoValuePhSTAND") ? pat_ele.userFloat("elPFMiniIsoValuePhSTAND") : -999.);

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -590,8 +590,9 @@ process.electronMVAValueMapProducer.srcMiniAOD = cms.InputTag('slimmedElectrons'
 process.egmGsfElectronIDs.physicsObjectSrc = cms.InputTag('slimmedElectrons')
 
 elecID_mod_ls = [
-#  'RecoEgamma.ElectronIdentification.Identification.mvaElectronID_PHYS14_PU20bx25_nonTrig_V1_cff',
-#  'RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_PHYS14_PU20bx25_V2_cff',
+  'RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Spring15_25ns_V1_cff',
+  'RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Spring15_50ns_V1_cff',
+  'RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Spring15_25ns_nonTrig_V1_cff',
   'RecoEgamma.ElectronIdentification.Identification.heepElectronID_HEEPV60_cff',
 ]
 
@@ -603,26 +604,36 @@ process.slimmedElectronsUSER = cms.EDProducer('PATElectronUserData',
   src = cms.InputTag('slimmedElectrons'),
 
   vmaps_bool = cms.PSet(
-#    cutBasedElectronID_PHYS14_PU20bx25_V2_standalone_veto   = cms.InputTag('egmGsfElectronIDs:cutBasedElectronID-PHYS14-PU20bx25-V2-standalone-veto'),
-#    cutBasedElectronID_PHYS14_PU20bx25_V2_standalone_loose  = cms.InputTag('egmGsfElectronIDs:cutBasedElectronID-PHYS14-PU20bx25-V2-standalone-loose'),
-#    cutBasedElectronID_PHYS14_PU20bx25_V2_standalone_medium = cms.InputTag('egmGsfElectronIDs:cutBasedElectronID-PHYS14-PU20bx25-V2-standalone-medium'),
-#    cutBasedElectronID_PHYS14_PU20bx25_V2_standalone_tight  = cms.InputTag('egmGsfElectronIDs:cutBasedElectronID-PHYS14-PU20bx25-V2-standalone-tight'),
-    heepElectronID_HEEPV60                                  = cms.InputTag('egmGsfElectronIDs:heepElectronID-HEEPV60'),
-#    mvaEleID_PHYS14_PU20bx25_nonTrig_V1_wp80                = cms.InputTag('egmGsfElectronIDs:mvaEleID_PHYS14_PU20bx25_nonTrig_V1_wp80'),
-#    mvaEleID_PHYS14_PU20bx25_nonTrig_V1_wp90                = cms.InputTag('egmGsfElectronIDs:mvaEleID_PHYS14_PU20bx25_nonTrig_V1_wp90'),
+
+    cutBasedElectronID_Spring15_25ns_V1_standalone_veto   = cms.InputTag('egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-veto'),
+    cutBasedElectronID_Spring15_25ns_V1_standalone_loose  = cms.InputTag('egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-loose'),
+    cutBasedElectronID_Spring15_25ns_V1_standalone_medium = cms.InputTag('egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-medium'),
+    cutBasedElectronID_Spring15_25ns_V1_standalone_tight  = cms.InputTag('egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-tight'),
+
+    cutBasedElectronID_Spring15_50ns_V1_standalone_veto   = cms.InputTag('egmGsfElectronIDs:cutBasedElectronID-Spring15-50ns-V1-standalone-veto'),
+    cutBasedElectronID_Spring15_50ns_V1_standalone_loose  = cms.InputTag('egmGsfElectronIDs:cutBasedElectronID-Spring15-50ns-V1-standalone-loose'),
+    cutBasedElectronID_Spring15_50ns_V1_standalone_medium = cms.InputTag('egmGsfElectronIDs:cutBasedElectronID-Spring15-50ns-V1-standalone-medium'),
+    cutBasedElectronID_Spring15_50ns_V1_standalone_tight  = cms.InputTag('egmGsfElectronIDs:cutBasedElectronID-Spring15-50ns-V1-standalone-tight'),
+
+    mvaEleID_Spring15_25ns_nonTrig_V1_wp90                = cms.InputTag('egmGsfElectronIDs:mvaEleID-Spring15-25ns-nonTrig-V1-wp90'),
+    mvaEleID_Spring15_25ns_nonTrig_V1_wp80                = cms.InputTag('egmGsfElectronIDs:mvaEleID-Spring15-25ns-nonTrig-V1-wp80'),
+
+    heepElectronID_HEEPV60                                = cms.InputTag('egmGsfElectronIDs:heepElectronID-HEEPV60'),
   ),
 
   vmaps_float = cms.PSet(
-        #ElectronMVAEstimatorRun2Phys14NonTrigValues = cms.InputTag('electronMVAValueMapProducer:ElectronMVAEstimatorRun2Phys14NonTrigValues')
-        ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values = cms.InputTag('electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values')
+    ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values = cms.InputTag('electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values'),
   ),
 
   vmaps_double = cms.vstring(el_isovals),
+
+  effAreas_file = cms.FileInPath('RecoEgamma/ElectronIdentification/data/Spring15/effAreaElectrons_cone03_pfNeuHadronsAndPhotons_50ns.txt'),
 
   mva_NoTrig = cms.string('ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values'),
   mva_Trig   = cms.string('ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values'),
 )
 
+if use25ns: process.slimmedElectronsUSER.effAreas_file = cms.FileInPath('RecoEgamma/ElectronIdentification/data/Spring15/effAreaElectrons_cone03_pfNeuHadronsAndPhotons_25ns.txt')
 
 ### NtupleWriter
 
@@ -656,13 +667,20 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
           # each string should correspond to a variable saved
           # via the "userInt" method in the pat::Electron collection used 'electron_source'
           # [the configuration of the pat::Electron::userInt variables should be done in PATElectronUserData]
-         # 'cutBasedElectronID_PHYS14_PU20bx25_V2_standalone_veto',
-         # 'cutBasedElectronID_PHYS14_PU20bx25_V2_standalone_loose',
-         # 'cutBasedElectronID_PHYS14_PU20bx25_V2_standalone_medium',
-         # 'cutBasedElectronID_PHYS14_PU20bx25_V2_standalone_tight',
+#          'cutBasedElectronID_Spring15_25ns_V1_standalone_veto',
+#          'cutBasedElectronID_Spring15_25ns_V1_standalone_loose',
+#          'cutBasedElectronID_Spring15_25ns_V1_standalone_medium',
+#          'cutBasedElectronID_Spring15_25ns_V1_standalone_tight',
+#
+#          'cutBasedElectronID_Spring15_50ns_V1_standalone_veto',
+#          'cutBasedElectronID_Spring15_50ns_V1_standalone_loose',
+#          'cutBasedElectronID_Spring15_50ns_V1_standalone_medium',
+#          'cutBasedElectronID_Spring15_50ns_V1_standalone_tight',
+#
+#          'mvaEleID_Spring15_25ns_nonTrig_V1_wp90',
+#          'mvaEleID_Spring15_25ns_nonTrig_V1_wp80',
+#
           'heepElectronID_HEEPV60',
-         # 'mvaEleID_PHYS14_PU20bx25_nonTrig_V1_wp80',
-         # 'mvaEleID_PHYS14_PU20bx25_nonTrig_V1_wp90',
         ),
         doMuons = cms.bool(True),
         muon_sources = cms.vstring("slimmedMuonsUSER"),


### PR DESCRIPTION
* updates for electron reco in UHH2 for latest recipe in CMSSW_7_4_9

  * fixed electron ID references in core/python/ntuplewriter.py

  * removed PHYS14 tags from Electron class

  * added setter and getter for effective-area variable in Electron class

  * fixed isolation variable used in Electron CutBased-IDs (effective-area correction, instead of delta-beta correction), following the procedure used by the EGamma POG, see
    * https://github.com/ikrav/cmssw/blob/egm_id_747_v2/RecoEgamma/ElectronIdentification/python/Identification/cutBasedElectronID_tools.py#L262
    * https://github.com/ikrav/cmssw/blob/egm_id_747_v2/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleEffAreaPFIsoCut.cc
