### PR TITLE
updates for Muon class in core/

### DIFF
--- a/core/include/Electron.h
+++ b/core/include/Electron.h
@@ -8,6 +8,8 @@ class Electron: public Particle {
 
  public:
   enum tag {
+    twodcut_dRmin,
+    twodcut_pTrel,
     heepElectronID_HEEPV60,				    
   };
 

--- a/core/include/Muon.h
+++ b/core/include/Muon.h
@@ -8,8 +8,8 @@
 class Muon: public Particle{
  public:
   enum bool_id {
-      soft = 0, loose, medium, tight, highpt,
-      tracker, pf, global, standalone
+    soft = 0, loose, medium, tight, highpt,
+    tracker, pf, global, standalone
   };
 
   enum tag {
@@ -17,52 +17,70 @@ class Muon: public Particle{
   };
 
   bool get_bool(bool_id i) const {
-      return (id_bits & (uint64_t(1) << static_cast<uint64_t>(i)));
+    return (id_bits & (uint64_t(1) << static_cast<uint64_t>(i)));
   }
 
   void set_bool(bool_id i, bool value) {
-      if(value){
-          id_bits |= uint64_t(1) << static_cast<uint64_t>(i);
-      }
-      else{
-          id_bits &= ~(uint64_t(1) << static_cast<uint64_t>(i));
-      }
+    if(value) id_bits |=   uint64_t(1) << static_cast<uint64_t>(i);
+    else      id_bits &= ~(uint64_t(1) << static_cast<uint64_t>(i));
   }
 
   Muon(){
-      id_bits = 0;
-      
-      m_dxy = 0;
-      m_dxy_error = 0;
-      m_dz = 0;
-      m_dz_error = 0;
-      
-      m_sumChargedHadronPt = 0;
-      m_sumNeutralHadronEt = 0;
-      m_sumPhotonEt = 0;
-      m_sumPUPt = 0;
 
-      m_pfMINIIso_CH       = 0;
-      m_pfMINIIso_NH       = 0;
-      m_pfMINIIso_Ph       = 0;
-      m_pfMINIIso_PU       = 0;
-      m_pfMINIIso_NH_pfwgt = 0;
-      m_pfMINIIso_Ph_pfwgt = 0;
+    id_bits = 0;
+
+    m_dxy = 0;
+    m_dxy_error = 0;
+    m_dz = 0;
+    m_dz_error = 0;
+
+    m_globalTrack_normalizedChi2 = 0;
+    m_globalTrack_numberOfValidMuonHits = 0;
+    m_numberOfMatchedStations = 0;
+    m_innerTrack_trackerLayersWithMeasurement = 0;
+    m_innerTrack_numberOfValidPixelHits = 0;
+    m_innerTrack_validFraction = 0;
+    m_combinedQuality_chi2LocalPosition = 0;
+    m_combinedQuality_trkKink = 0;
+    m_segmentCompatibility = 0;
+
+    m_sumChargedHadronPt = 0;
+    m_sumNeutralHadronEt = 0;
+    m_sumPhotonEt = 0;
+    m_sumPUPt = 0;
+
+    m_pfMINIIso_CH       = 0;
+    m_pfMINIIso_NH       = 0;
+    m_pfMINIIso_Ph       = 0;
+    m_pfMINIIso_PU       = 0;
+    m_pfMINIIso_NH_pfwgt = 0;
+    m_pfMINIIso_Ph_pfwgt = 0;
   }
   
   float dxy() const{return m_dxy;}
   float dxy_error() const{return m_dxy_error;}
   float dz() const{return m_dz;}
   float dz_error() const{return m_dz_error;}
-  float sumChargedHadronPt() const{return m_sumChargedHadronPt;} 
-  float sumNeutralHadronEt() const{return m_sumNeutralHadronEt;} 
-  float sumPhotonEt() const{return m_sumPhotonEt;}
-  float sumPUPt() const{return m_sumPUPt;}
 
-  float pfMINIIso_CH      () const { return m_pfMINIIso_CH; }
-  float pfMINIIso_NH      () const { return m_pfMINIIso_NH; }
-  float pfMINIIso_Ph      () const { return m_pfMINIIso_Ph; }
-  float pfMINIIso_PU      () const { return m_pfMINIIso_PU; }
+  float globalTrack_normalizedChi2()              const { return m_globalTrack_normalizedChi2; }
+  int   globalTrack_numberOfValidMuonHits()       const { return m_globalTrack_numberOfValidMuonHits; }
+  int   numberOfMatchedStations()                 const { return m_numberOfMatchedStations; }
+  int   innerTrack_trackerLayersWithMeasurement() const { return m_innerTrack_trackerLayersWithMeasurement; }
+  int   innerTrack_numberOfValidPixelHits()       const { return m_innerTrack_numberOfValidPixelHits; }
+  float innerTrack_validFraction()                const { return m_innerTrack_validFraction; }
+  float combinedQuality_chi2LocalPosition()       const { return m_combinedQuality_chi2LocalPosition; }
+  float combinedQuality_trkKink()                 const { return m_combinedQuality_trkKink; }
+  float segmentCompatibility()                    const { return m_segmentCompatibility; }
+
+  float sumChargedHadronPt() const{ return m_sumChargedHadronPt; } 
+  float sumNeutralHadronEt() const{ return m_sumNeutralHadronEt; } 
+  float sumPhotonEt()        const{ return m_sumPhotonEt; }
+  float sumPUPt()            const{ return m_sumPUPt; }
+
+  float pfMINIIso_CH()       const { return m_pfMINIIso_CH; }
+  float pfMINIIso_NH()       const { return m_pfMINIIso_NH; }
+  float pfMINIIso_Ph()       const { return m_pfMINIIso_Ph; }
+  float pfMINIIso_PU()       const { return m_pfMINIIso_PU; }
   float pfMINIIso_NH_pfwgt() const { return m_pfMINIIso_NH_pfwgt; }
   float pfMINIIso_Ph_pfwgt() const { return m_pfMINIIso_Ph_pfwgt; }
 
@@ -70,6 +88,17 @@ class Muon: public Particle{
   void set_dxy_error(float x){m_dxy_error=x;}
   void set_dz(float x){m_dz=x;} 
   void set_dz_error(float x){m_dz_error=x;} 
+
+  void set_globalTrack_normalizedChi2             (float x){ m_globalTrack_normalizedChi2 = x; }
+  void set_globalTrack_numberOfValidMuonHits      (int   x){ m_globalTrack_numberOfValidMuonHits = x; }
+  void set_numberOfMatchedStations                (int   x){ m_numberOfMatchedStations = x; }
+  void set_innerTrack_trackerLayersWithMeasurement(int   x){ m_innerTrack_trackerLayersWithMeasurement = x; }
+  void set_innerTrack_numberOfValidPixelHits      (int   x){ m_innerTrack_numberOfValidPixelHits = x; }
+  void set_innerTrack_validFraction               (float x){ m_innerTrack_validFraction = x; }
+  void set_combinedQuality_chi2LocalPosition      (float x){ m_combinedQuality_chi2LocalPosition = x; }
+  void set_combinedQuality_trkKink                (float x){ m_combinedQuality_trkKink = x; }
+  void set_segmentCompatibility                   (float x){ m_segmentCompatibility = x; }
+
   void set_sumChargedHadronPt(float x){m_sumChargedHadronPt=x;} 
   void set_sumNeutralHadronEt(float x){m_sumNeutralHadronEt=x;} 
   void set_sumPhotonEt(float x){m_sumPhotonEt=x;}
@@ -82,14 +111,16 @@ class Muon: public Particle{
   void set_pfMINIIso_NH_pfwgt(float x){ m_pfMINIIso_NH_pfwgt = x; }
   void set_pfMINIIso_Ph_pfwgt(float x){ m_pfMINIIso_Ph_pfwgt = x; }
 
+  bool  has_tag(tag t) const { return tags.has_tag(static_cast<int>(t)); }
   float get_tag(tag t) const { return tags.get_tag(static_cast<int>(t)); }
-  void set_tag(tag t, float value) { tags.set_tag(static_cast<int>(t), value); }
+  void  set_tag(tag t, float value) { tags.set_tag(static_cast<int>(t), value); }
 
   float relIso() const{
     return ( m_sumChargedHadronPt + std::max( 0.0, m_sumNeutralHadronEt + m_sumPhotonEt - 0.5*m_sumPUPt) ) / pt();
   }
 
   operator FlavorParticle() const{
+
     FlavorParticle fp;
     fp.set_charge(this->charge());
     fp.set_pt(this->pt());
@@ -97,6 +128,7 @@ class Muon: public Particle{
     fp.set_phi(this->phi());
     fp.set_energy(this->energy());
     fp.set_pdgId(-13*this->charge());
+
     return fp;
   }
 
@@ -107,6 +139,17 @@ class Muon: public Particle{
   float m_dxy_error;
   float m_dz;
   float m_dz_error;
+
+  float m_globalTrack_normalizedChi2;
+  int   m_globalTrack_numberOfValidMuonHits;
+  int   m_numberOfMatchedStations;
+  int   m_innerTrack_trackerLayersWithMeasurement;
+  int   m_innerTrack_numberOfValidPixelHits;
+  float m_innerTrack_validFraction;
+  float m_combinedQuality_chi2LocalPosition;
+  float m_combinedQuality_trkKink;
+  float m_segmentCompatibility;
+
   float m_sumChargedHadronPt;
   float m_sumNeutralHadronEt;
   float m_sumPhotonEt;

--- a/core/include/Muon.h
+++ b/core/include/Muon.h
@@ -13,7 +13,8 @@ class Muon: public Particle{
   };
 
   enum tag {
-    dummy = 0 /* for future use */
+    twodcut_dRmin,
+    twodcut_pTrel,
   };
 
   bool get_bool(bool_id i) const {

--- a/core/plugins/NtupleWriterLeptons.cxx
+++ b/core/plugins/NtupleWriterLeptons.cxx
@@ -1,8 +1,11 @@
 #include "UHH2/core/plugins/NtupleWriterLeptons.h"
 #include "UHH2/core/include/AnalysisModule.h"
+
 #include "DataFormats/PatCandidates/interface/Electron.h"
 #include "DataFormats/PatCandidates/interface/Muon.h"
 #include "DataFormats/PatCandidates/interface/Tau.h"
+
+#include "DataFormats/MuonReco/interface/MuonSelectors.h"
 
 using namespace uhh2;
 using namespace std;
@@ -114,26 +117,39 @@ void NtupleWriterMuons::process(const edm::Event & event, uhh2::Event & uevent){
      mu.set_phi( pat_mu.phi());
      mu.set_energy( pat_mu.energy());
 
-     mu.set_dxy(pat_mu.muonBestTrack()->dxy(PV.position()));
-     mu.set_dxy_error(pat_mu.muonBestTrack()->dxyError());
-     mu.set_dz(pat_mu.muonBestTrack()->dz(PV.position()));
-     mu.set_dz_error(pat_mu.muonBestTrack()->dzError());
-
-     mu.set_bool(Muon::global, pat_mu.isGlobalMuon());
-     mu.set_bool(Muon::pf, pat_mu.isPFMuon());
-     mu.set_bool(Muon::tracker, pat_mu.isTrackerMuon());
+     mu.set_bool(Muon::global    , pat_mu.isGlobalMuon());
+     mu.set_bool(Muon::pf        , pat_mu.isPFMuon());
+     mu.set_bool(Muon::tracker   , pat_mu.isTrackerMuon());
      mu.set_bool(Muon::standalone, pat_mu.isStandAloneMuon());
+     mu.set_bool(Muon::soft      , pat_mu.isSoftMuon(PV));
+     mu.set_bool(Muon::loose     , pat_mu.isLooseMuon());
+     mu.set_bool(Muon::medium    , pat_mu.isMediumMuon());
+     mu.set_bool(Muon::tight     , pat_mu.isTightMuon(PV));
+     mu.set_bool(Muon::highpt    , pat_mu.isHighPtMuon(PV));
 
-     mu.set_bool(Muon::soft  , pat_mu.isSoftMuon(PV));
-     mu.set_bool(Muon::loose , pat_mu.isLooseMuon());
-     mu.set_bool(Muon::medium, pat_mu.isMediumMuon());
-     mu.set_bool(Muon::tight , pat_mu.isTightMuon(PV));
-     mu.set_bool(Muon::highpt, pat_mu.isHighPtMuon(PV));
+     mu.set_dxy      (pat_mu.muonBestTrack()->dxy(PV.position()));
+     mu.set_dxy_error(pat_mu.muonBestTrack()->dxyError());
+     mu.set_dz       (pat_mu.muonBestTrack()->dz(PV.position()));
+     mu.set_dz_error (pat_mu.muonBestTrack()->dzError());
+
+     mu.set_globalTrack_normalizedChi2       ( pat_mu.globalTrack().isNonnull() ? pat_mu.globalTrack()->normalizedChi2() : -999.);
+     mu.set_globalTrack_numberOfValidMuonHits( pat_mu.globalTrack().isNonnull() ? pat_mu.globalTrack()->hitPattern().numberOfValidMuonHits() : -1);
+
+     mu.set_numberOfMatchedStations(pat_mu.numberOfMatchedStations());
+
+     mu.set_innerTrack_trackerLayersWithMeasurement(pat_mu.innerTrack().isNonnull() ? pat_mu.innerTrack()->hitPattern().trackerLayersWithMeasurement() : -1);
+     mu.set_innerTrack_numberOfValidPixelHits      (pat_mu.innerTrack().isNonnull() ? pat_mu.innerTrack()->hitPattern().numberOfValidPixelHits() : -1);
+     mu.set_innerTrack_validFraction               (pat_mu.innerTrack().isNonnull() ? pat_mu.innerTrack()->validFraction() : -999.);
+
+     mu.set_combinedQuality_chi2LocalPosition(pat_mu.combinedQuality().chi2LocalPosition);
+     mu.set_combinedQuality_trkKink          (pat_mu.combinedQuality().trkKink);
+
+     mu.set_segmentCompatibility(muon::segmentCompatibility(pat_mu));
 
      mu.set_sumChargedHadronPt(pat_mu.pfIsolationR04().sumChargedHadronPt);
      mu.set_sumNeutralHadronEt(pat_mu.pfIsolationR04().sumNeutralHadronEt);
-     mu.set_sumPhotonEt(pat_mu.pfIsolationR04().sumPhotonEt);
-     mu.set_sumPUPt(pat_mu.pfIsolationR04().sumPUPt);
+     mu.set_sumPhotonEt       (pat_mu.pfIsolationR04().sumPhotonEt);
+     mu.set_sumPUPt           (pat_mu.pfIsolationR04().sumPUPt);
 
      mu.set_pfMINIIso_CH      (pat_mu.hasUserFloat("muPFMiniIsoValueCHSTAND") ? pat_mu.userFloat("muPFMiniIsoValueCHSTAND") : -999.);
      mu.set_pfMINIIso_NH      (pat_mu.hasUserFloat("muPFMiniIsoValueNHSTAND") ? pat_mu.userFloat("muPFMiniIsoValueNHSTAND") : -999.);

--- a/core/plugins/PATMuonUserData.cc
+++ b/core/plugins/PATMuonUserData.cc
@@ -1,9 +1,7 @@
-// system include files
 #include <memory>
 #include <vector>
 #include <string>
 
-// user include files
 #include <FWCore/Framework/interface/Frameworkfwd.h>
 #include <FWCore/Framework/interface/EDProducer.h>
 #include <FWCore/Framework/interface/Event.h>
@@ -12,11 +10,10 @@
 
 #include <DataFormats/PatCandidates/interface/Muon.h>
 
-// class declaration
 class PATMuonUserData : public edm::EDProducer {
  public:
   explicit PATMuonUserData(const edm::ParameterSet&);
-  ~PATMuonUserData() {}
+  virtual ~PATMuonUserData() {}
 
  private:
   virtual void produce(edm::Event&, const edm::EventSetup&);


### PR DESCRIPTION
* [commit_#1] added reconstruction-related variables to the Muon class in order to be able to reproduce/validate the Loose, Medium and TIght muon IDs (similarly to what is done for the electron class) [https://twiki.cern.ch/twiki/bin/view/CMS/SWGuideMuonIdRun2]

* [commit_#2] enabled tags in Muon and Electron classes to save 2dcut-related variables
  * motivation: in the analysis, the 2d-cut variables (minimum delta-R and pTrel) are calculated with respect to a "looser" collection of jets. when the jets are cleaned (with the final pt-eta cuts), the jet collection changes and there is no way to re-obtain the floats used in the 2d-cut evaluation. this change gives the possibility to save these variables in muon/electron objects on-the-fly at the analysis level (and does not really change the class format).
