### PR TITLE
updates for common/ElectronIds [UHH2:RunII_50ns]

### DIFF
--- a/common/include/ElectronIds.h
+++ b/common/include/ElectronIds.h
@@ -1,6 +1,9 @@
 #pragma once
 
-#include "UHH2/core/include/Event.h"
+#include <unordered_map>
+#include <vector>
+
+#include <UHH2/core/include/Event.h>
 
 // Note that the electronIds are implemented not by inheriting from a common base class, but
 // rather as 'something' that can be used as function with the signature
@@ -14,6 +17,7 @@
 // ids require pileup density event.rho to calculate corrected PF isolation, or the jet-lepton
 // DeltaR and ptrel, etc.
 
+// Electron selector for "pT + supercluster_eta" cuts ----------------
 class PtEtaSCCut {
  public:
   PtEtaSCCut(float min_pt_, float max_etaSC_): min_pt(min_pt_), max_etaSC(max_etaSC_) {}
@@ -26,47 +30,7 @@ class PtEtaSCCut {
   float min_pt, max_etaSC;
 };
 
-// Electron Cut-Based ID
-// REF https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedElectronIdentificationRun2
-bool ElectronID_PHYS14_25ns_veto  (const Electron&, const uhh2::Event&);
-bool ElectronID_PHYS14_25ns_loose (const Electron&, const uhh2::Event&);
-bool ElectronID_PHYS14_25ns_medium(const Electron&, const uhh2::Event&);
-bool ElectronID_PHYS14_25ns_tight (const Electron&, const uhh2::Event&);
-
-bool ElectronID_PHYS14_25ns_veto_noIso  (const Electron&, const uhh2::Event&);
-bool ElectronID_PHYS14_25ns_loose_noIso (const Electron&, const uhh2::Event&);
-bool ElectronID_PHYS14_25ns_medium_noIso(const Electron&, const uhh2::Event&);
-bool ElectronID_PHYS14_25ns_tight_noIso (const Electron&, const uhh2::Event&);
-
-bool ElectronID_Spring15_25ns_veto  (const Electron&, const uhh2::Event&);
-bool ElectronID_Spring15_25ns_loose (const Electron&, const uhh2::Event&);
-bool ElectronID_Spring15_25ns_medium(const Electron&, const uhh2::Event&);
-bool ElectronID_Spring15_25ns_tight (const Electron&, const uhh2::Event&);
-
-bool ElectronID_Spring15_25ns_veto_noIso  (const Electron&, const uhh2::Event&);
-bool ElectronID_Spring15_25ns_loose_noIso (const Electron&, const uhh2::Event&);
-bool ElectronID_Spring15_25ns_medium_noIso(const Electron&, const uhh2::Event&);
-bool ElectronID_Spring15_25ns_tight_noIso (const Electron&, const uhh2::Event&);
-
-bool ElectronID_Spring15_50ns_veto  (const Electron&, const uhh2::Event&);
-bool ElectronID_Spring15_50ns_loose (const Electron&, const uhh2::Event&);
-bool ElectronID_Spring15_50ns_medium(const Electron&, const uhh2::Event&);
-bool ElectronID_Spring15_50ns_tight (const Electron&, const uhh2::Event&);
-
-bool ElectronID_Spring15_50ns_veto_noIso  (const Electron&, const uhh2::Event&);
-bool ElectronID_Spring15_50ns_loose_noIso (const Electron&, const uhh2::Event&);
-bool ElectronID_Spring15_50ns_medium_noIso(const Electron&, const uhh2::Event&);
-bool ElectronID_Spring15_50ns_tight_noIso (const Electron&, const uhh2::Event&);
-
-// Electron MVA ID
-// REF https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2
-bool ElectronID_MVAnotrig_PHYS14_loose(const Electron&, const uhh2::Event&);
-bool ElectronID_MVAnotrig_PHYS14_tight(const Electron&, const uhh2::Event&);
-
-bool ElectronID_MVAnotrig_Spring15_25ns_loose(const Electron&, const uhh2::Event&);
-bool ElectronID_MVAnotrig_Spring15_25ns_tight(const Electron&, const uhh2::Event&);
-
-// Electron selectors for PF MINI-Isolation
+// Electron selector for PF MINI-Isolation ---------------------------
 class Electron_MINIIso {
 
  public:
@@ -79,3 +43,210 @@ class Electron_MINIIso {
   float iso_cut_;
   std::string iso_key_;
 };
+
+// Electron IDs ------------------------------------------------------
+
+// --- Cut-Based ID
+bool Electron_CutBasedID(const Electron&, const uhh2::Event&, const std::string&, const std::string&, const bool);
+bool Electron_CutBasedID(const Electron&, const uhh2::Event&, const std::string&, const std::string&, const int, const bool);
+
+// --- Cut-Based ID: PHYS14 25ns
+bool ElectronID_PHYS14_25ns_veto        (const Electron&, const uhh2::Event&);
+bool ElectronID_PHYS14_25ns_veto_noIso  (const Electron&, const uhh2::Event&);
+bool ElectronID_PHYS14_25ns_loose       (const Electron&, const uhh2::Event&);
+bool ElectronID_PHYS14_25ns_loose_noIso (const Electron&, const uhh2::Event&);
+bool ElectronID_PHYS14_25ns_medium      (const Electron&, const uhh2::Event&);
+bool ElectronID_PHYS14_25ns_medium_noIso(const Electron&, const uhh2::Event&);
+bool ElectronID_PHYS14_25ns_tight       (const Electron&, const uhh2::Event&);
+bool ElectronID_PHYS14_25ns_tight_noIso (const Electron&, const uhh2::Event&);
+
+// --- Cut-Based ID: Spring15 50ns
+bool ElectronID_Spring15_50ns_veto        (const Electron&, const uhh2::Event&);
+bool ElectronID_Spring15_50ns_veto_noIso  (const Electron&, const uhh2::Event&);
+bool ElectronID_Spring15_50ns_loose       (const Electron&, const uhh2::Event&);
+bool ElectronID_Spring15_50ns_loose_noIso (const Electron&, const uhh2::Event&);
+bool ElectronID_Spring15_50ns_medium      (const Electron&, const uhh2::Event&);
+bool ElectronID_Spring15_50ns_medium_noIso(const Electron&, const uhh2::Event&);
+bool ElectronID_Spring15_50ns_tight       (const Electron&, const uhh2::Event&);
+bool ElectronID_Spring15_50ns_tight_noIso (const Electron&, const uhh2::Event&);
+
+// --- Cut-Based ID: Spring15 25ns
+bool ElectronID_Spring15_25ns_veto        (const Electron&, const uhh2::Event&);
+bool ElectronID_Spring15_25ns_veto_noIso  (const Electron&, const uhh2::Event&);
+bool ElectronID_Spring15_25ns_loose       (const Electron&, const uhh2::Event&);
+bool ElectronID_Spring15_25ns_loose_noIso (const Electron&, const uhh2::Event&);
+bool ElectronID_Spring15_25ns_medium      (const Electron&, const uhh2::Event&);
+bool ElectronID_Spring15_25ns_medium_noIso(const Electron&, const uhh2::Event&);
+bool ElectronID_Spring15_25ns_tight       (const Electron&, const uhh2::Event&);
+bool ElectronID_Spring15_25ns_tight_noIso (const Electron&, const uhh2::Event&);
+
+// --- Cut-Based ID: look-up table for ID working points
+// REF https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedElectronIdentificationRun2
+namespace ElectronID {
+
+  const std::unordered_map<std::string, std::unordered_map<std::string, std::unordered_map<std::string, std::vector<float> > > > CutBased_LUT = {
+
+  /** PHYS14_25ns **/
+    {"PHYS14_25ns", {
+
+      {"barrel", {
+                          /* Veto     , Loose    , Medium   , Tight    */
+        {"sigmaIetaIeta" , { 0.011586 , 0.010331 , 0.009996 , 0.009947 }},
+        {"|dEtaIn|"      , { 0.013625 , 0.009277 , 0.008925 , 0.006046 }},
+        {"|dPhiIn|"      , { 0.230374 , 0.094739 , 0.035973 , 0.028092 }},
+        {"HoverE"        , { 0.181130 , 0.093068 , 0.050537 , 0.045772 }},
+        {"relIsoEA"      , { 0.158721 , 0.130136 , 0.107587 , 0.069537 }},
+        {"|ooEmooP|"     , { 0.295751 , 0.189968 , 0.091942 , 0.020118 }},
+        {"|d0|"          , { 0.094095 , 0.035904 , 0.012235 , 0.008790 }},
+        {"|dz|"          , { 0.713070 , 0.075496 , 0.042020 , 0.021226 }},
+        {"missingHits"   , { 2        , 1        , 1        , 1        }},
+        {"passConvVeto"  , { 1        , 1        , 1        , 1        }},
+       },
+      },
+
+      {"endcap", {
+                          /* Veto     , Loose    , Medium   , Tight    */
+        {"sigmaIetaIeta" , { 0.031849 , 0.031838 , 0.030135 , 0.028237 }},
+        {"|dEtaIn|"      , { 0.011932 , 0.009833 , 0.007429 , 0.007057 }},
+        {"|dPhiIn|"      , { 0.255450 , 0.149934 , 0.067879 , 0.030159 }},
+        {"HoverE"        , { 0.223870 , 0.115754 , 0.086782 , 0.067778 }},
+        {"relIsoEA"      , { 0.177032 , 0.163368 , 0.113254 , 0.078265 }},
+        {"|ooEmooP|"     , { 0.155501 , 0.140662 , 0.100683 , 0.098919 }},
+        {"|d0|"          , { 0.342293 , 0.099266 , 0.036719 , 0.027984 }},
+        {"|dz|"          , { 0.953461 , 0.197897 , 0.138142 , 0.133431 }},
+        {"missingHits"   , { 3        , 1        , 1        , 1        }},
+        {"passConvVeto"  , { 1        , 1        , 1        , 1        }},
+       },
+
+      },
+     },
+    },
+  /*****************/
+
+  /** Spring15_50ns **/
+    {"Spring15_50ns", {
+
+      {"barrel", {
+                          /* Veto   , Loose   , Medium  , Tight   */
+        {"sigmaIetaIeta" , { 0.012  , 0.0105  , 0.0101  , 0.0101  }},
+        {"|dEtaIn|"      , { 0.0126 , 0.00976 , 0.0094  , 0.00864 }},
+        {"|dPhiIn|"      , { 0.107  , 0.0929  , 0.0296  , 0.0286  }},
+        {"HoverE"        , { 0.186  , 0.0765  , 0.0372  , 0.0342  }},
+        {"relIsoEA"      , { 0.161  , 0.118   , 0.0987  , 0.0591  }},
+        {"|ooEmooP|"     , { 0.239  , 0.184   , 0.118   , 0.0116  }},
+        {"|d0|"          , { 0.0621 , 0.0227  , 0.0151  , 0.0103  }},
+        {"|dz|"          , { 0.613  , 0.379   , 0.238   , 0.170   }},
+        {"missingHits"   , { 2      , 2       , 2       , 2       }},
+        {"passConvVeto"  , { 1      , 1       , 1       , 1       }},
+       },
+      },
+
+      {"endcap", {
+                          /* Veto   , Loose   , Medium  , Tight   */
+        {"sigmaIetaIeta" , { 0.0339 , 0.0318  , 0.0287  , 0.0287  }},
+        {"|dEtaIn|"      , { 0.0109 , 0.00952 , 0.00773 , 0.00762 }},
+        {"|dPhiIn|"      , { 0.219  , 0.181   , 0.148   , 0.0439  }},
+        {"HoverE"        , { 0.0962 , 0.0824  , 0.0546  , 0.0544  }},
+        {"relIsoEA"      , { 0.193  , 0.118   , 0.0902  , 0.0759  }},
+        {"|ooEmooP|"     , { 0.141  , 0.125   , 0.104   , 0.01    }},
+        {"|d0|"          , { 0.279  , 0.242   , 0.0535  , 0.0377  }},
+        {"|dz|"          , { 0.947  , 0.921   , 0.572   , 0.571   }},
+        {"missingHits"   , { 3      , 1       , 1       , 1       }},
+        {"passConvVeto"  , { 1      , 1       , 1       , 1       }},
+       },
+
+      },
+     },
+    },
+  /*******************/
+
+  /** Spring15_25ns **/
+    {"Spring15_25ns", {
+
+      {"barrel", {
+                          /* Veto   , Loose   , Medium  , Tight   */
+        {"sigmaIetaIeta" , { 0.0114 , 0.0103  , 0.0101  , 0.0101  }},
+        {"|dEtaIn|"      , { 0.0152 , 0.0105  , 0.0103  , 0.00926 }},
+        {"|dPhiIn|"      , { 0.216  , 0.115   , 0.0336  , 0.0336  }},
+        {"HoverE"        , { 0.181  , 0.104   , 0.0876  , 0.0597  }},
+        {"relIsoEA"      , { 0.126  , 0.0893  , 0.0766  , 0.0354  }},
+        {"|ooEmooP|"     , { 0.207  , 0.102   , 0.0174  , 0.012   }},
+        {"|d0|"          , { 0.0564 , 0.0261  , 0.0118  , 0.0111  }},
+        {"|dz|"          , { 0.472  , 0.41    , 0.373   , 0.0466  }},
+        {"missingHits"   , { 2      , 2       , 2       , 2       }},
+        {"passConvVeto"  , { 1      , 1       , 1       , 1       }},
+       },
+      },
+
+      {"endcap", {
+                          /* Veto   , Loose   , Medium  , Tight   */
+        {"sigmaIetaIeta" , { 0.0352 , 0.0301  , 0.0283  , 0.0279  }},
+        {"|dEtaIn|"      , { 0.0113 , 0.00814 , 0.00733 , 0.00724 }},
+        {"|dPhiIn|"      , { 0.237  , 0.182   , 0.114   , 0.0918  }},
+        {"HoverE"        , { 0.116  , 0.0897  , 0.0678  , 0.0615  }},
+        {"relIsoEA"      , { 0.144  , 0.121   , 0.0678  , 0.0646  }},
+        {"|ooEmooP|"     , { 0.174  , 0.126   , 0.0898  , 0.00999 }},
+        {"|d0|"          , { 0.222  , 0.118   , 0.0739  , 0.0351  }},
+        {"|dz|"          , { 0.921  , 0.822   , 0.602   , 0.417   }},
+        {"missingHits"   , { 3      , 1       , 1       , 1       }},
+        {"passConvVeto"  , { 1      , 1       , 1       , 1       }},
+       },
+
+      },
+     },
+    },
+  /*******************/
+
+  };
+
+}
+
+// Electron MVA IDs
+// REF https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2
+
+// --- Non-Triggering MVA ID
+bool Electron_NonTrigMVAID(const Electron&, const uhh2::Event&, const std::string&, const std::string&);
+
+// --- Non-Triggering MVA ID: PHYS14
+bool ElectronID_MVAnotrig_PHYS14_loose(const Electron&, const uhh2::Event&);
+bool ElectronID_MVAnotrig_PHYS14_tight(const Electron&, const uhh2::Event&);
+
+// --- Non-Triggering MVA ID: Spring15
+bool ElectronID_MVAnotrig_Spring15_25ns_loose(const Electron&, const uhh2::Event&);
+bool ElectronID_MVAnotrig_Spring15_25ns_tight(const Electron&, const uhh2::Event&);
+
+namespace ElectronID {
+
+  const std::unordered_map<std::string, std::unordered_map<std::string, std::vector<float> > > NonTrigMVA_LUT = {
+
+  /** PHYS14 **/
+    {"PHYS14", {
+                         /* 80% SE , 90% SE */
+      {"low-pt_barrel1" , { -0.253 , -0.483 }},
+      {"low-pt_barrel2" , {  0.081 , -0.267 }},
+      {"low-pt_endcap"  , { -0.081 , -0.323 }},
+      {"high-pt_barrel1", {  0.965 ,  0.933 }},
+      {"high-pt_barrel2", {  0.917 ,  0.825 }},
+      {"high-pt_endcap" , {  0.683 ,  0.337 }},
+
+     },
+    },
+  /************/
+
+  /** Spring15 **/
+    {"Spring15", {
+                         /* 80% SE    , 90% SE    */
+      {"low-pt_barrel1" , {  0.287435 , -0.083313 }},
+      {"low-pt_barrel2" , {  0.221846 , -0.235222 }},
+      {"low-pt_endcap"  , { -0.303263 , -0.67099  }},
+      {"high-pt_barrel1", {  0.967083 ,  0.913286 }},
+      {"high-pt_barrel2", {  0.929117 ,  0.805013 }},
+      {"high-pt_endcap" , {  0.726311 ,  0.358969 }},
+
+     },
+    },
+  /**************/
+
+  };
+
+}

--- a/common/src/ElectronIds.cxx
+++ b/common/src/ElectronIds.cxx
@@ -1,912 +1,4 @@
-#include "UHH2/common/include/ElectronIds.h"
-
-namespace {
-
-// The values to cut on. Corresponds to the tables in the twiki:
-// in the tables at https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedElectronIdentificationRun2
-// following the same order of variables as in the CSA14 section.
-// The only difference to the twiki tables is the passes_conversion_rejection flag which replaces the 'Conversion rejection: vertex fit probability'
-// and is treated as a boolean here.
-  struct ele_cutvalues {
-    float abs_dEtaIn, abs_dPhiIn, full5x5_sigmaIetaIeta, HoverE, fabs_d0, fabs_dz, fabs_1oE_1op, pfiso_dbeta_dr03, passes_conversion_rejection, cr_misshits;
-  };
-
-  ele_cutvalues cv_from_ele(const Electron& ele, const uhh2::Event& event){
-
-    ele_cutvalues result;
-    assert(event.pvs);
-    if(event.pvs->size() == 0){
-      result.abs_dEtaIn = std::numeric_limits<float>::infinity();
-      return result;
-    }
-
-    const auto& pv = (*event.pvs)[0];
-
-    result.abs_dEtaIn = std::abs(ele.dEtaIn());
-    result.abs_dPhiIn = std::abs(ele.dPhiIn());
-    result.full5x5_sigmaIetaIeta = ele.sigmaIEtaIEta();
-    result.HoverE = ele.HoverE();
-    result.fabs_d0 = std::abs(ele.gsfTrack_dxy_vertex(pv.x(), pv.y()));
-    result.fabs_dz = std::abs(ele.gsfTrack_dz_vertex(pv.x(), pv.y(), pv.z()));
-    result.fabs_1oE_1op = (ele.EcalEnergy() > 0. ? (std::abs(1.0f/ele.EcalEnergy() - ele.EoverPIn()/ele.EcalEnergy())) : std::numeric_limits<float>::infinity());
-    result.pfiso_dbeta_dr03 = ele.relIsodb();
-    result.cr_misshits = ele.gsfTrack_trackerExpectedHitsInner_numberOfLostHits();
-    result.passes_conversion_rejection = ele.passconversionveto() ? 2.0f : 0.0f;
-
-    return result;
-  }
-
-  bool passes_thresholds(const ele_cutvalues& vals, const ele_cutvalues& thresholds){
-
-    if(vals.abs_dEtaIn >= thresholds.abs_dEtaIn) return false;
-    if(vals.abs_dPhiIn >= thresholds.abs_dPhiIn) return false;
-    if(vals.full5x5_sigmaIetaIeta >= thresholds.full5x5_sigmaIetaIeta) return false;
-    if(vals.HoverE >= thresholds.HoverE) return false;
-    if(vals.fabs_d0 >= thresholds.fabs_d0) return false;
-    if(vals.fabs_dz >= thresholds.fabs_dz) return false;
-    if(vals.fabs_1oE_1op >= thresholds.fabs_1oE_1op) return false;
-    if(vals.pfiso_dbeta_dr03 >= thresholds.pfiso_dbeta_dr03) return false;
-    if(vals.passes_conversion_rejection < thresholds.passes_conversion_rejection) return false; // note: for passes conversion rejection, comparison is inverted
-    if(vals.cr_misshits > thresholds.cr_misshits) return false; // note for missing hits: >, not >=
-
-    return true;
-  }
-
-  // check whether electron passes the given id, based on cut values given for barrel and endcap separately.
-  bool passes_id(const Electron & ele, const uhh2::Event & event, const ele_cutvalues & thresh_barrel, const ele_cutvalues & thresh_endcap){
-
-    bool pass(false);
-
-    auto abs_eta = std::abs(ele.supercluster_eta());
-    if                        (abs_eta <= 1.479) pass = passes_thresholds(cv_from_ele(ele, event), thresh_barrel);
-    else if(1.479 < abs_eta && abs_eta <  2.5  ) pass = passes_thresholds(cv_from_ele(ele, event), thresh_endcap);
-
-    return pass;
-  }
-
-}
-
-bool ElectronID_PHYS14_25ns_veto(const Electron& electron, const uhh2::Event& event){
-
-  static constexpr const auto thresholds_barrel = ele_cutvalues{
-    .abs_dEtaIn                  = 0.013625,
-    .abs_dPhiIn                  = 0.230374,
-    .full5x5_sigmaIetaIeta       = 0.011586,
-    .HoverE                      = 0.181130,
-    .fabs_d0                     = 0.094095,
-    .fabs_dz                     = 0.713070,
-    .fabs_1oE_1op                = 0.295751,
-    .pfiso_dbeta_dr03            = 0.158721,
-    .passes_conversion_rejection = 1.      ,
-    .cr_misshits                 = 2.      
-  };
-
-  static constexpr const auto thresholds_endcap = ele_cutvalues{
-    .abs_dEtaIn                  = 0.011932,
-    .abs_dPhiIn                  = 0.255450,
-    .full5x5_sigmaIetaIeta       = 0.031849,
-    .HoverE                      = 0.223870,
-    .fabs_d0                     = 0.342293,
-    .fabs_dz                     = 0.953461,
-    .fabs_1oE_1op                = 0.155501,
-    .pfiso_dbeta_dr03            = 0.177032,
-    .passes_conversion_rejection = 1.      ,
-    .cr_misshits                 = 3.      
-  };
-
-  return passes_id(electron, event, thresholds_barrel, thresholds_endcap);
-}
-
-bool ElectronID_PHYS14_25ns_loose(const Electron& electron, const uhh2::Event& event){
-
-  static constexpr const auto thresholds_barrel = ele_cutvalues{
-    .abs_dEtaIn                  = 0.009277,
-    .abs_dPhiIn                  = 0.094739,
-    .full5x5_sigmaIetaIeta       = 0.010331,
-    .HoverE                      = 0.093068,
-    .fabs_d0                     = 0.035904,
-    .fabs_dz                     = 0.075496,
-    .fabs_1oE_1op                = 0.189968,
-    .pfiso_dbeta_dr03            = 0.130136,
-    .passes_conversion_rejection = 1.      ,
-    .cr_misshits                 = 1.      
-  };
-
-  static constexpr const auto thresholds_endcap = ele_cutvalues{
-    .abs_dEtaIn                  = 0.009833,
-    .abs_dPhiIn                  = 0.149934,
-    .full5x5_sigmaIetaIeta       = 0.031838,
-    .HoverE                      = 0.115754,
-    .fabs_d0                     = 0.099266,
-    .fabs_dz                     = 0.197897,
-    .fabs_1oE_1op                = 0.140662,
-    .pfiso_dbeta_dr03            = 0.163368,
-    .passes_conversion_rejection = 1.      ,
-    .cr_misshits                 = 1.      
-  };
-
-  return passes_id(electron, event, thresholds_barrel, thresholds_endcap);
-}
-
-
-bool ElectronID_PHYS14_25ns_medium(const Electron& electron, const uhh2::Event& event){
-
-  static constexpr const auto thresholds_barrel = ele_cutvalues{
-    .abs_dEtaIn                  = 0.008925,
-    .abs_dPhiIn                  = 0.035973,
-    .full5x5_sigmaIetaIeta       = 0.009996,
-    .HoverE                      = 0.050537,
-    .fabs_d0                     = 0.012235,
-    .fabs_dz                     = 0.042020,
-    .fabs_1oE_1op                = 0.091942,
-    .pfiso_dbeta_dr03            = 0.107587,
-    .passes_conversion_rejection = 1.      ,
-    .cr_misshits                 = 1.      
-  };
-
-  static constexpr const auto thresholds_endcap = ele_cutvalues{
-    .abs_dEtaIn                  = 0.007429,
-    .abs_dPhiIn                  = 0.067879,
-    .full5x5_sigmaIetaIeta       = 0.030135,
-    .HoverE                      = 0.086782,
-    .fabs_d0                     = 0.036719,
-    .fabs_dz                     = 0.138142,
-    .fabs_1oE_1op                = 0.100683,
-    .pfiso_dbeta_dr03            = 0.113254,
-    .passes_conversion_rejection = 1.      ,
-    .cr_misshits                 = 1.      
-  };
-
-  return passes_id(electron, event, thresholds_barrel, thresholds_endcap);
-}
-
-
-bool ElectronID_PHYS14_25ns_tight(const Electron& electron, const uhh2::Event& event){
-
-  static constexpr const auto thresholds_barrel = ele_cutvalues{
-    .abs_dEtaIn                  = 0.006046,
-    .abs_dPhiIn                  = 0.028092,
-    .full5x5_sigmaIetaIeta       = 0.009947,
-    .HoverE                      = 0.045772,
-    .fabs_d0                     = 0.008790,
-    .fabs_dz                     = 0.021226,
-    .fabs_1oE_1op                = 0.020118,
-    .pfiso_dbeta_dr03            = 0.069537,
-    .passes_conversion_rejection = 1.      ,
-    .cr_misshits                 = 1.      
-  };
-
-  static constexpr const auto thresholds_endcap = ele_cutvalues{
-    .abs_dEtaIn                  = 0.007057,
-    .abs_dPhiIn                  = 0.030159,
-    .full5x5_sigmaIetaIeta       = 0.028237,
-    .HoverE                      = 0.067778,
-    .fabs_d0                     = 0.027984,
-    .fabs_dz                     = 0.133431,
-    .fabs_1oE_1op                = 0.098919,
-    .pfiso_dbeta_dr03            = 0.078265,
-    .passes_conversion_rejection = 1.      ,
-    .cr_misshits                 = 1.      
-  };
-
-  return passes_id(electron, event, thresholds_barrel, thresholds_endcap);
-}
-
-// Electron Cut-Based ID without cut on PF (relative) isolation
-
-bool ElectronID_PHYS14_25ns_veto_noIso(const Electron& electron, const uhh2::Event& event){
-
-  static constexpr const auto thresholds_barrel = ele_cutvalues{
-    .abs_dEtaIn                  = 0.013625,
-    .abs_dPhiIn                  = 0.230374,
-    .full5x5_sigmaIetaIeta       = 0.011586,
-    .HoverE                      = 0.181130,
-    .fabs_d0                     = 0.094095,
-    .fabs_dz                     = 0.713070,
-    .fabs_1oE_1op                = 0.295751,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
-    .passes_conversion_rejection = 1.      ,
-    .cr_misshits                 = 2.      
-  };
-
-  static constexpr const auto thresholds_endcap = ele_cutvalues{
-    .abs_dEtaIn                  = 0.011932,
-    .abs_dPhiIn                  = 0.255450,
-    .full5x5_sigmaIetaIeta       = 0.031849,
-    .HoverE                      = 0.223870,
-    .fabs_d0                     = 0.342293,
-    .fabs_dz                     = 0.953461,
-    .fabs_1oE_1op                = 0.155501,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
-    .passes_conversion_rejection = 1.      ,
-    .cr_misshits                 = 3.      
-  };
-
-  return passes_id(electron, event, thresholds_barrel, thresholds_endcap);
-}
-
-bool ElectronID_PHYS14_25ns_loose_noIso(const Electron& electron, const uhh2::Event& event){
-
-  static constexpr const auto thresholds_barrel = ele_cutvalues{
-    .abs_dEtaIn                  = 0.009277,
-    .abs_dPhiIn                  = 0.094739,
-    .full5x5_sigmaIetaIeta       = 0.010331,
-    .HoverE                      = 0.093068,
-    .fabs_d0                     = 0.035904,
-    .fabs_dz                     = 0.075496,
-    .fabs_1oE_1op                = 0.189968,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
-    .passes_conversion_rejection = 1.      ,
-    .cr_misshits                 = 1.      
-  };
-
-  static constexpr const auto thresholds_endcap = ele_cutvalues{
-    .abs_dEtaIn                  = 0.009833,
-    .abs_dPhiIn                  = 0.149934,
-    .full5x5_sigmaIetaIeta       = 0.031838,
-    .HoverE                      = 0.115754,
-    .fabs_d0                     = 0.099266,
-    .fabs_dz                     = 0.197897,
-    .fabs_1oE_1op                = 0.140662,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
-    .passes_conversion_rejection = 1.      ,
-    .cr_misshits                 = 1.      
-  };
-
-  return passes_id(electron, event, thresholds_barrel, thresholds_endcap);
-}
-
-
-bool ElectronID_PHYS14_25ns_medium_noIso(const Electron& electron, const uhh2::Event& event){
-
-  static constexpr const auto thresholds_barrel = ele_cutvalues{
-    .abs_dEtaIn                  = 0.008925,
-    .abs_dPhiIn                  = 0.035973,
-    .full5x5_sigmaIetaIeta       = 0.009996,
-    .HoverE                      = 0.050537,
-    .fabs_d0                     = 0.012235,
-    .fabs_dz                     = 0.042020,
-    .fabs_1oE_1op                = 0.091942,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
-    .passes_conversion_rejection = 1.      ,
-    .cr_misshits                 = 1.      
-  };
-
-  static constexpr const auto thresholds_endcap = ele_cutvalues{
-    .abs_dEtaIn                  = 0.007429,
-    .abs_dPhiIn                  = 0.067879,
-    .full5x5_sigmaIetaIeta       = 0.030135,
-    .HoverE                      = 0.086782,
-    .fabs_d0                     = 0.036719,
-    .fabs_dz                     = 0.138142,
-    .fabs_1oE_1op                = 0.100683,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
-    .passes_conversion_rejection = 1.      ,
-    .cr_misshits                 = 1.      
-  };
-
-  return passes_id(electron, event, thresholds_barrel, thresholds_endcap);
-}
-
-bool ElectronID_PHYS14_25ns_tight_noIso(const Electron& electron, const uhh2::Event& event){
-
-  static constexpr const auto thresholds_barrel = ele_cutvalues{
-    .abs_dEtaIn                  = 0.006046,
-    .abs_dPhiIn                  = 0.028092,
-    .full5x5_sigmaIetaIeta       = 0.009947,
-    .HoverE                      = 0.045772,
-    .fabs_d0                     = 0.008790,
-    .fabs_dz                     = 0.021226,
-    .fabs_1oE_1op                = 0.020118,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
-    .passes_conversion_rejection = 1.      ,
-    .cr_misshits                 = 1.      
-  };
-
-  static constexpr const auto thresholds_endcap = ele_cutvalues{
-    .abs_dEtaIn                  = 0.007057,
-    .abs_dPhiIn                  = 0.030159,
-    .full5x5_sigmaIetaIeta       = 0.028237,
-    .HoverE                      = 0.067778,
-    .fabs_d0                     = 0.027984,
-    .fabs_dz                     = 0.133431,
-    .fabs_1oE_1op                = 0.098919,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
-    .passes_conversion_rejection = 1.      ,
-    .cr_misshits                 = 1.      
-  };
-
-  return passes_id(electron, event, thresholds_barrel, thresholds_endcap);
-}
-
-bool ElectronID_Spring15_25ns_veto(const Electron& electron, const uhh2::Event& event){
-
-  static constexpr const auto thresholds_barrel = ele_cutvalues{
-    .abs_dEtaIn                  = 0.0152,
-    .abs_dPhiIn                  = 0.216,
-    .full5x5_sigmaIetaIeta       = 0.0114,
-    .HoverE                      = 0.181,
-    .fabs_d0                     = 0.0564,
-    .fabs_dz                     = 0.472,
-    .fabs_1oE_1op                = 0.207,
-    .pfiso_dbeta_dr03            = 0.126,
-    .passes_conversion_rejection = 1.    ,
-    .cr_misshits                 = 2.
-  };
-
-  static constexpr const auto thresholds_endcap = ele_cutvalues{
-    .abs_dEtaIn                  = 0.0113,
-    .abs_dPhiIn                  = 0.237,
-    .full5x5_sigmaIetaIeta       = 0.0352,
-    .HoverE                      = 0.116,
-    .fabs_d0                     = 0.222,
-    .fabs_dz                     = 0.921,
-    .fabs_1oE_1op                = 0.174,
-    .pfiso_dbeta_dr03            = 0.144,
-    .passes_conversion_rejection = 1.      ,
-    .cr_misshits                 = 3.
-  };
-
-  return passes_id(electron, event, thresholds_barrel, thresholds_endcap);
-}
-
-bool ElectronID_Spring15_25ns_loose(const Electron& electron, const uhh2::Event& event){
-
-  static constexpr const auto thresholds_barrel = ele_cutvalues{
-    .abs_dEtaIn                  = 0.0105,
-    .abs_dPhiIn                  = 0.115,
-    .full5x5_sigmaIetaIeta       = 0.0103,
-    .HoverE                      = 0.104,
-    .fabs_d0                     = 0.0261,
-    .fabs_dz                     = 0.41,
-    .fabs_1oE_1op                = 0.102,
-    .pfiso_dbeta_dr03            = 0.0893,
-    .passes_conversion_rejection = 1.    ,
-    .cr_misshits                 = 2.
-  };
-
-  static constexpr const auto thresholds_endcap = ele_cutvalues{
-    .abs_dEtaIn                  = 0.00814,
-    .abs_dPhiIn                  = 0.182,
-    .full5x5_sigmaIetaIeta       = 0.0301,
-    .HoverE                      = 0.0897,
-    .fabs_d0                     = 0.118,
-    .fabs_dz                     = 0.822,
-    .fabs_1oE_1op                = 0.126,
-    .pfiso_dbeta_dr03            = 0.121,
-    .passes_conversion_rejection = 1.      ,
-    .cr_misshits                 = 1.
-  };
-
-  return passes_id(electron, event, thresholds_barrel, thresholds_endcap);
-}
-
-bool ElectronID_Spring15_25ns_medium(const Electron& electron, const uhh2::Event& event){
-
-  static constexpr const auto thresholds_barrel = ele_cutvalues{
-    .abs_dEtaIn                  = 0.0103,
-    .abs_dPhiIn                  = 0.0336,
-    .full5x5_sigmaIetaIeta       = 0.0101,
-    .HoverE                      = 0.0876,
-    .fabs_d0                     = 0.0118,
-    .fabs_dz                     = 0.373,
-    .fabs_1oE_1op                = 0.0174,
-    .pfiso_dbeta_dr03            = 0.0766,
-    .passes_conversion_rejection = 1.    ,
-    .cr_misshits                 = 2.
-  };
-
-  static constexpr const auto thresholds_endcap = ele_cutvalues{
-    .abs_dEtaIn                  = 0.00733,
-    .abs_dPhiIn                  = 0.114,
-    .full5x5_sigmaIetaIeta       = 0.0283,
-    .HoverE                      = 0.0678,
-    .fabs_d0                     = 0.0739,
-    .fabs_dz                     = 0.602,
-    .fabs_1oE_1op                = 0.0898,
-    .pfiso_dbeta_dr03            = 0.0678,
-    .passes_conversion_rejection = 1.      ,
-    .cr_misshits                 = 1.
-  };
-
-  return passes_id(electron, event, thresholds_barrel, thresholds_endcap);
-}
-
-bool ElectronID_Spring15_25ns_tight(const Electron& electron, const uhh2::Event& event){
-
-  static constexpr const auto thresholds_barrel = ele_cutvalues{
-    .abs_dEtaIn                  = 0.00926,
-    .abs_dPhiIn                  = 0.0336,
-    .full5x5_sigmaIetaIeta       = 0.0101,
-    .HoverE                      = 0.0597,
-    .fabs_d0                     = 0.0111,
-    .fabs_dz                     = 0.0466,
-    .fabs_1oE_1op                = 0.012,
-    .pfiso_dbeta_dr03            = 0.0354,
-    .passes_conversion_rejection = 1.    ,
-    .cr_misshits                 = 2.
-  };
-
-  static constexpr const auto thresholds_endcap = ele_cutvalues{
-    .abs_dEtaIn                  = 0.00724,
-    .abs_dPhiIn                  = 0.0918,
-    .full5x5_sigmaIetaIeta       = 0.0279,
-    .HoverE                      = 0.0615,
-    .fabs_d0                     = 0.0351,
-    .fabs_dz                     = 0.417,
-    .fabs_1oE_1op                = 0.00999,
-    .pfiso_dbeta_dr03            = 0.0646,
-    .passes_conversion_rejection = 1.      ,
-    .cr_misshits                 = 1.
-  };
-
-  return passes_id(electron, event, thresholds_barrel, thresholds_endcap);
-}
-
-bool ElectronID_Spring15_25ns_veto_noIso(const Electron& electron, const uhh2::Event& event){
-
-  static constexpr const auto thresholds_barrel = ele_cutvalues{
-    .abs_dEtaIn                  = 0.0152,
-    .abs_dPhiIn                  = 0.216,
-    .full5x5_sigmaIetaIeta       = 0.0114,
-    .HoverE                      = 0.181,
-    .fabs_d0                     = 0.0564,
-    .fabs_dz                     = 0.472,
-    .fabs_1oE_1op                = 0.207,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
-    .passes_conversion_rejection = 1.    ,
-    .cr_misshits                 = 2.
-  };
-
-  static constexpr const auto thresholds_endcap = ele_cutvalues{
-    .abs_dEtaIn                  = 0.0113,
-    .abs_dPhiIn                  = 0.237,
-    .full5x5_sigmaIetaIeta       = 0.0352,
-    .HoverE                      = 0.116,
-    .fabs_d0                     = 0.222,
-    .fabs_dz                     = 0.921,
-    .fabs_1oE_1op                = 0.174,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
-    .passes_conversion_rejection = 1.      ,
-    .cr_misshits                 = 3.
-  };
-
-  return passes_id(electron, event, thresholds_barrel, thresholds_endcap);
-}
-
-bool ElectronID_Spring15_25ns_loose_noIso(const Electron& electron, const uhh2::Event& event){
-
-  static constexpr const auto thresholds_barrel = ele_cutvalues{
-    .abs_dEtaIn                  = 0.0105,
-    .abs_dPhiIn                  = 0.115,
-    .full5x5_sigmaIetaIeta       = 0.0103,
-    .HoverE                      = 0.104,
-    .fabs_d0                     = 0.0261,
-    .fabs_dz                     = 0.41,
-    .fabs_1oE_1op                = 0.102,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
-    .passes_conversion_rejection = 1.    ,
-    .cr_misshits                 = 2.
-  };
-
-  static constexpr const auto thresholds_endcap = ele_cutvalues{
-    .abs_dEtaIn                  = 0.00814,
-    .abs_dPhiIn                  = 0.182,
-    .full5x5_sigmaIetaIeta       = 0.0301,
-    .HoverE                      = 0.0897,
-    .fabs_d0                     = 0.118,
-    .fabs_dz                     = 0.822,
-    .fabs_1oE_1op                = 0.126,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
-    .passes_conversion_rejection = 1.      ,
-    .cr_misshits                 = 1.
-  };
-
-  return passes_id(electron, event, thresholds_barrel, thresholds_endcap);
-}
-
-bool ElectronID_Spring15_25ns_medium_noIso(const Electron& electron, const uhh2::Event& event){
-
-  static constexpr const auto thresholds_barrel = ele_cutvalues{
-    .abs_dEtaIn                  = 0.0103,
-    .abs_dPhiIn                  = 0.0336,
-    .full5x5_sigmaIetaIeta       = 0.0101,
-    .HoverE                      = 0.0876,
-    .fabs_d0                     = 0.0118,
-    .fabs_dz                     = 0.373,
-    .fabs_1oE_1op                = 0.0174,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
-    .passes_conversion_rejection = 1.    ,
-    .cr_misshits                 = 2.
-  };
-
-  static constexpr const auto thresholds_endcap = ele_cutvalues{
-    .abs_dEtaIn                  = 0.00733,
-    .abs_dPhiIn                  = 0.114,
-    .full5x5_sigmaIetaIeta       = 0.0283,
-    .HoverE                      = 0.0678,
-    .fabs_d0                     = 0.0739,
-    .fabs_dz                     = 0.602,
-    .fabs_1oE_1op                = 0.0898,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
-    .passes_conversion_rejection = 1.      ,
-    .cr_misshits                 = 1.
-  };
-
-  return passes_id(electron, event, thresholds_barrel, thresholds_endcap);
-}
-
-bool ElectronID_Spring15_25ns_tight_noIso(const Electron& electron, const uhh2::Event& event){
-
-  static constexpr const auto thresholds_barrel = ele_cutvalues{
-    .abs_dEtaIn                  = 0.00926,
-    .abs_dPhiIn                  = 0.0336,
-    .full5x5_sigmaIetaIeta       = 0.0101,
-    .HoverE                      = 0.0597,
-    .fabs_d0                     = 0.0111,
-    .fabs_dz                     = 0.0466,
-    .fabs_1oE_1op                = 0.012,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
-    .passes_conversion_rejection = 1.    ,
-    .cr_misshits                 = 2.
-  };
-
-  static constexpr const auto thresholds_endcap = ele_cutvalues{
-    .abs_dEtaIn                  = 0.00724,
-    .abs_dPhiIn                  = 0.0918,
-    .full5x5_sigmaIetaIeta       = 0.0279,
-    .HoverE                      = 0.0615,
-    .fabs_d0                     = 0.0351,
-    .fabs_dz                     = 0.417,
-    .fabs_1oE_1op                = 0.00999,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
-    .passes_conversion_rejection = 1.      ,
-    .cr_misshits                 = 1.
-  };
-
-  return passes_id(electron, event, thresholds_barrel, thresholds_endcap);
-}
-
-bool ElectronID_Spring15_50ns_veto(const Electron& electron, const uhh2::Event& event){
-
-  static constexpr const auto thresholds_barrel = ele_cutvalues{
-    .abs_dEtaIn                  = 0.0126,
-    .abs_dPhiIn                  = 0.107,
-    .full5x5_sigmaIetaIeta       = 0.012,
-    .HoverE                      = 0.186,
-    .fabs_d0                     = 0.0621,
-    .fabs_dz                     = 0.613,
-    .fabs_1oE_1op                = 0.239,
-    .pfiso_dbeta_dr03            = 0.161,
-    .passes_conversion_rejection = 1.    ,
-    .cr_misshits                 = 2.
-  };
-
-  static constexpr const auto thresholds_endcap = ele_cutvalues{
-    .abs_dEtaIn                  = 0.0109,
-    .abs_dPhiIn                  = 0.219,
-    .full5x5_sigmaIetaIeta       = 0.0339,
-    .HoverE                      = 0.0962,
-    .fabs_d0                     = 0.279,
-    .fabs_dz                     = 0.947,
-    .fabs_1oE_1op                = 0.141,
-    .pfiso_dbeta_dr03            = 0.193,
-    .passes_conversion_rejection = 1.      ,
-    .cr_misshits                 = 3.
-  };
-
-  return passes_id(electron, event, thresholds_barrel, thresholds_endcap);
-}
-
-
-bool ElectronID_Spring15_50ns_loose(const Electron& electron, const uhh2::Event& event){
-
-  static constexpr const auto thresholds_barrel = ele_cutvalues{
-    .abs_dEtaIn                  = 0.00976,
-    .abs_dPhiIn                  = 0.0929,
-    .full5x5_sigmaIetaIeta       = 0.0105,
-    .HoverE                      = 0.0765,
-    .fabs_d0                     = 0.0227,
-    .fabs_dz                     = 0.379,
-    .fabs_1oE_1op                = 0.184,
-    .pfiso_dbeta_dr03            = 0.118,
-    .passes_conversion_rejection = 1.    ,
-    .cr_misshits                 = 2.
-  };
-
-  static constexpr const auto thresholds_endcap = ele_cutvalues{
-    .abs_dEtaIn                  = 0.00952,
-    .abs_dPhiIn                  = 0.181,
-    .full5x5_sigmaIetaIeta       = 0.0318,
-    .HoverE                      = 0.0824,
-    .fabs_d0                     = 0.242,
-    .fabs_dz                     = 0.921,
-    .fabs_1oE_1op                = 0.125,
-    .pfiso_dbeta_dr03            = 0.118,
-    .passes_conversion_rejection = 1.      ,
-    .cr_misshits                 = 1.
-  };
-
-  return passes_id(electron, event, thresholds_barrel, thresholds_endcap);
-}
-
-bool ElectronID_Spring15_50ns_medium(const Electron& electron, const uhh2::Event& event){
-
-  static constexpr const auto thresholds_barrel = ele_cutvalues{
-    .abs_dEtaIn                  = 0.0094,
-    .abs_dPhiIn                  = 0.0296,
-    .full5x5_sigmaIetaIeta       = 0.0101,
-    .HoverE                      = 0.0372,
-    .fabs_d0                     = 0.0151,
-    .fabs_dz                     = 0.238,
-    .fabs_1oE_1op                = 0.118,
-    .pfiso_dbeta_dr03            = 0.0987,
-    .passes_conversion_rejection = 1.    ,
-    .cr_misshits                 = 2.
-  };
-
-  static constexpr const auto thresholds_endcap = ele_cutvalues{
-    .abs_dEtaIn                  = 0.00773,
-    .abs_dPhiIn                  = 0.148,
-    .full5x5_sigmaIetaIeta       = 0.0287,
-    .HoverE                      = 0.0546,
-    .fabs_d0                     = 0.0535,
-    .fabs_dz                     = 0.572,
-    .fabs_1oE_1op                = 0.104,
-    .pfiso_dbeta_dr03            = 0.0902,
-    .passes_conversion_rejection = 1.      ,
-    .cr_misshits                 = 1.
-  };
-
-  return passes_id(electron, event, thresholds_barrel, thresholds_endcap);
-}
-
-bool ElectronID_Spring15_50ns_tight(const Electron& electron, const uhh2::Event& event){
-
-  static constexpr const auto thresholds_barrel = ele_cutvalues{
-    .abs_dEtaIn                  = 0.0095,
-    .abs_dPhiIn                  = 0.0291,
-    .full5x5_sigmaIetaIeta       = 0.0101,
-    .HoverE                      = 0.0372,
-    .fabs_d0                     = 0.0144,
-    .fabs_dz                     = 0.323,
-    .fabs_1oE_1op                = 0.0174,
-    .pfiso_dbeta_dr03            = 0.0468,
-    .passes_conversion_rejection = 1.    ,
-    .cr_misshits                 = 2.
-  };
-
-  static constexpr const auto thresholds_endcap = ele_cutvalues{
-    .abs_dEtaIn                  = 0.00762,
-    .abs_dPhiIn                  = 0.0439,
-    .full5x5_sigmaIetaIeta       = 0.0287,
-    .HoverE                      = 0.0544,
-    .fabs_d0                     = 0.0377,
-    .fabs_dz                     = 0.571,
-    .fabs_1oE_1op                = 0.01,
-    .pfiso_dbeta_dr03            = 0.0759,
-    .passes_conversion_rejection = 1.      ,
-    .cr_misshits                 = 1.
-  };
-
-  return passes_id(electron, event, thresholds_barrel, thresholds_endcap);
-}
-
-bool ElectronID_Spring15_50ns_veto_noIso(const Electron& electron, const uhh2::Event& event){
-
-  static constexpr const auto thresholds_barrel = ele_cutvalues{
-    .abs_dEtaIn                  = 0.0126,
-    .abs_dPhiIn                  = 0.107,
-    .full5x5_sigmaIetaIeta       = 0.012,
-    .HoverE                      = 0.186,
-    .fabs_d0                     = 0.0621,
-    .fabs_dz                     = 0.613,
-    .fabs_1oE_1op                = 0.239,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
-    .passes_conversion_rejection = 1.    ,
-    .cr_misshits                 = 2.
-  };
-
-  static constexpr const auto thresholds_endcap = ele_cutvalues{
-    .abs_dEtaIn                  = 0.0109,
-    .abs_dPhiIn                  = 0.219,
-    .full5x5_sigmaIetaIeta       = 0.0339,
-    .HoverE                      = 0.0962,
-    .fabs_d0                     = 0.279,
-    .fabs_dz                     = 0.947,
-    .fabs_1oE_1op                = 0.141,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
-    .passes_conversion_rejection = 1.      ,
-    .cr_misshits                 = 3.
-  };
-
-  return passes_id(electron, event, thresholds_barrel, thresholds_endcap);
-}
-
-
-bool ElectronID_Spring15_50ns_loose_noIso(const Electron& electron, const uhh2::Event& event){
-
-  static constexpr const auto thresholds_barrel = ele_cutvalues{
-    .abs_dEtaIn                  = 0.00976,
-    .abs_dPhiIn                  = 0.0929,
-    .full5x5_sigmaIetaIeta       = 0.0105,
-    .HoverE                      = 0.0765,
-    .fabs_d0                     = 0.0227,
-    .fabs_dz                     = 0.379,
-    .fabs_1oE_1op                = 0.184,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
-    .passes_conversion_rejection = 1.    ,
-    .cr_misshits                 = 2.
-  };
-
-  static constexpr const auto thresholds_endcap = ele_cutvalues{
-    .abs_dEtaIn                  = 0.00952,
-    .abs_dPhiIn                  = 0.181,
-    .full5x5_sigmaIetaIeta       = 0.0318,
-    .HoverE                      = 0.0824,
-    .fabs_d0                     = 0.242,
-    .fabs_dz                     = 0.921,
-    .fabs_1oE_1op                = 0.125,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
-    .passes_conversion_rejection = 1.      ,
-    .cr_misshits                 = 1.
-  };
-
-  return passes_id(electron, event, thresholds_barrel, thresholds_endcap);
-}
-
-bool ElectronID_Spring15_50ns_medium_noIso(const Electron& electron, const uhh2::Event& event){
-
-  static constexpr const auto thresholds_barrel = ele_cutvalues{
-    .abs_dEtaIn                  = 0.0094,
-    .abs_dPhiIn                  = 0.0296,
-    .full5x5_sigmaIetaIeta       = 0.0101,
-    .HoverE                      = 0.0372,
-    .fabs_d0                     = 0.0151,
-    .fabs_dz                     = 0.238,
-    .fabs_1oE_1op                = 0.118,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
-    .passes_conversion_rejection = 1.    ,
-    .cr_misshits                 = 2.
-  };
-
-  static constexpr const auto thresholds_endcap = ele_cutvalues{
-    .abs_dEtaIn                  = 0.00773,
-    .abs_dPhiIn                  = 0.148,
-    .full5x5_sigmaIetaIeta       = 0.0287,
-    .HoverE                      = 0.0546,
-    .fabs_d0                     = 0.0535,
-    .fabs_dz                     = 0.572,
-    .fabs_1oE_1op                = 0.104,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
-    .passes_conversion_rejection = 1.      ,
-    .cr_misshits                 = 1.
-  };
-
-  return passes_id(electron, event, thresholds_barrel, thresholds_endcap);
-}
-
-bool ElectronID_Spring15_50ns_tight_noIso(const Electron& electron, const uhh2::Event& event){
-
-  static constexpr const auto thresholds_barrel = ele_cutvalues{
-    .abs_dEtaIn                  = 0.0095,
-    .abs_dPhiIn                  = 0.0291,
-    .full5x5_sigmaIetaIeta       = 0.0101,
-    .HoverE                      = 0.0372,
-    .fabs_d0                     = 0.0144,
-    .fabs_dz                     = 0.323,
-    .fabs_1oE_1op                = 0.0174,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
-    .passes_conversion_rejection = 1.    ,
-    .cr_misshits                 = 2.
-  };
-
-  static constexpr const auto thresholds_endcap = ele_cutvalues{
-    .abs_dEtaIn                  = 0.00762,
-    .abs_dPhiIn                  = 0.0439,
-    .full5x5_sigmaIetaIeta       = 0.0287,
-    .HoverE                      = 0.0544,
-    .fabs_d0                     = 0.0377,
-    .fabs_dz                     = 0.571,
-    .fabs_1oE_1op                = 0.01,
-    .pfiso_dbeta_dr03            = std::numeric_limits<float>::infinity(),
-    .passes_conversion_rejection = 1.      ,
-    .cr_misshits                 = 1.
-  };
-
-  return passes_id(electron, event, thresholds_barrel, thresholds_endcap);
-}
-
-////
-
-bool ElectronID_MVAnotrig_PHYS14_loose(const Electron& electron, const uhh2::Event&){
-
-  bool pass(false);
-
-  const float MVA(electron.mvaNonTrigV0()), pt(electron.pt()), abs_etaSC(std::abs(electron.supercluster_eta()));
-
-  if(5. < pt && pt <= 10.){
-
-    if                         (abs_etaSC < 0.8)   pass = (MVA > -0.483);
-    else if(0.8 <= abs_etaSC && abs_etaSC < 1.479) pass = (MVA > -0.267);
-    else if                    (abs_etaSC < 2.5)   pass = (MVA > -0.323);
-  }
-  else if(pt > 10.){
-
-    if                         (abs_etaSC < 0.8)   pass = (MVA >  0.933);
-    else if(0.8 <= abs_etaSC && abs_etaSC < 1.479) pass = (MVA >  0.825);
-    else if                    (abs_etaSC < 2.5)   pass = (MVA >  0.337);
-  }
-
-  return pass;
-}
-
-bool ElectronID_MVAnotrig_PHYS14_tight(const Electron& electron, const uhh2::Event&){
-
-  bool pass(false);
-
-  const float MVA(electron.mvaNonTrigV0()), pt(electron.pt()), abs_etaSC(std::abs(electron.supercluster_eta()));
-
-  if(5. < pt && pt <= 10.){
-
-    if                         (abs_etaSC < 0.8)   pass = (MVA > -0.253);
-    else if(0.8 <= abs_etaSC && abs_etaSC < 1.479) pass = (MVA >  0.081);
-    else if                    (abs_etaSC < 2.5)   pass = (MVA > -0.081);
-  }
-  else if(pt > 10.){
-
-    if                         (abs_etaSC < 0.8)   pass = (MVA >  0.965);
-    else if(0.8 <= abs_etaSC && abs_etaSC < 1.479) pass = (MVA >  0.917);
-    else if                    (abs_etaSC < 2.5)   pass = (MVA >  0.683);
-  }
-
-  return pass;
-}
-
-bool ElectronID_MVAnotrig_Spring15_25ns_loose(const Electron& electron, const uhh2::Event&){
-
-  bool pass(false);
-
-  const float MVA(electron.mvaNonTrigV0()), pt(electron.pt()), abs_etaSC(std::abs(electron.supercluster_eta()));
-
-  if(5. < pt && pt <= 10.){
-
-    if                         (abs_etaSC < 0.8)   pass = (MVA > -0.083313);
-    else if(0.8 <= abs_etaSC && abs_etaSC < 1.479) pass = (MVA > -0.235222);
-    else if                    (abs_etaSC < 2.5)   pass = (MVA > -0.670990);
-  }
-  else if(pt > 10.){
-
-    if                         (abs_etaSC < 0.8)   pass = (MVA >  0.913286);
-    else if(0.8 <= abs_etaSC && abs_etaSC < 1.479) pass = (MVA >  0.805013);
-    else if                    (abs_etaSC < 2.5)   pass = (MVA >  0.358969);
-  }
-
-  return pass;
-}
-
-bool ElectronID_MVAnotrig_Spring15_25ns_tight(const Electron& electron, const uhh2::Event&){
-
-  bool pass(false);
-
-  const float MVA(electron.mvaNonTrigV0()), pt(electron.pt()), abs_etaSC(std::abs(electron.supercluster_eta()));
-
-  if(5. < pt && pt <= 10.){
-
-    if                         (abs_etaSC < 0.8)   pass = (MVA >  0.287435);
-    else if(0.8 <= abs_etaSC && abs_etaSC < 1.479) pass = (MVA >  0.221846);
-    else if                    (abs_etaSC < 2.5)   pass = (MVA > -0.303263);
-  }
-  else if(pt > 10.){
-
-    if                         (abs_etaSC < 0.8)   pass = (MVA >  0.967083);
-    else if(0.8 <= abs_etaSC && abs_etaSC < 1.479) pass = (MVA >  0.929117);
-    else if                    (abs_etaSC < 2.5)   pass = (MVA >  0.726311);
-  }
-
-  return pass;
-}
-///
+#include <UHH2/common/include/ElectronIds.h>
 
 bool Electron_MINIIso::operator()(const Electron& ele, const uhh2::Event&) const {
 
@@ -921,3 +13,137 @@ bool Electron_MINIIso::operator()(const Electron& ele, const uhh2::Event&) const
 
   return (iso < iso_cut_);
 }
+
+//// Cut-Based ID
+
+bool Electron_CutBasedID(const Electron& ele_, const uhh2::Event& evt_, const std::string& tuning_, const std::string& wp_, const bool apply_iso_cut_){
+
+  bool pass(false);
+
+  int wp_idx(-1);
+  if     (wp_ == "VETO"  ) wp_idx = 0;
+  else if(wp_ == "LOOSE" ) wp_idx = 1;
+  else if(wp_ == "MEDIUM") wp_idx = 2;
+  else if(wp_ == "TIGHT" ) wp_idx = 3;
+  else throw std::runtime_error("Electron_CutBasedID -- undefined working-point tag: "+wp_);
+
+  const float abs_etaSC(fabs(ele_.supercluster_eta()));
+
+  if     (                     abs_etaSC <= 1.479) pass = Electron_CutBasedID(ele_, evt_, tuning_, "barrel", wp_idx, apply_iso_cut_);
+  else if(1.479 < abs_etaSC && abs_etaSC <  2.5  ) pass = Electron_CutBasedID(ele_, evt_, tuning_, "endcap", wp_idx, apply_iso_cut_);
+
+  return pass;
+}
+
+bool Electron_CutBasedID(const Electron& ele_, const uhh2::Event& evt_, const std::string& tuning_, const std::string& eleSC_pos_, const int wp_idx_, const bool apply_iso_cut_){
+
+  assert(evt_.pvs);
+  if(!evt_.pvs->size()) return false;
+  const auto& pv = (*evt_.pvs)[0];
+
+  const float abs_d0 = fabs(ele_.gsfTrack_dxy_vertex(pv.x(), pv.y()));
+  const float abs_dz = fabs(ele_.gsfTrack_dz_vertex (pv.x(), pv.y(), pv.z()));
+
+  if(ele_.EcalEnergy() <= 0.) return false;
+  const float abs_ooEmooP = fabs(1./ele_.EcalEnergy() - ele_.EoverPIn()/ele_.EcalEnergy());
+
+  const int expMissingHits = ele_.gsfTrack_trackerExpectedHitsInner_numberOfLostHits();
+
+  const int passConvVeto = int(ele_.passconversionveto());
+
+  if(!( ele_.sigmaIEtaIEta() < ElectronID::CutBased_LUT.at(tuning_).at(eleSC_pos_).at("sigmaIetaIeta").at(wp_idx_)  )) return false;// sigmaIetaIeta
+  if(!( fabs(ele_.dEtaIn())  < ElectronID::CutBased_LUT.at(tuning_).at(eleSC_pos_).at("|dEtaIn|")     .at(wp_idx_)  )) return false;// |dEtaIn|
+  if(!( fabs(ele_.dPhiIn())  < ElectronID::CutBased_LUT.at(tuning_).at(eleSC_pos_).at("|dPhiIn|")     .at(wp_idx_)  )) return false;// |dPhiIn|
+  if(!( ele_.HoverE()        < ElectronID::CutBased_LUT.at(tuning_).at(eleSC_pos_).at("HoverE")       .at(wp_idx_)  )) return false;// HoverE
+  if(!( abs_ooEmooP          < ElectronID::CutBased_LUT.at(tuning_).at(eleSC_pos_).at("|ooEmooP|")    .at(wp_idx_)  )) return false;// |ooEmooP|
+  if(!( abs_d0               < ElectronID::CutBased_LUT.at(tuning_).at(eleSC_pos_).at("|d0|")         .at(wp_idx_)  )) return false;// |d0|
+  if(!( abs_dz               < ElectronID::CutBased_LUT.at(tuning_).at(eleSC_pos_).at("|dz|")         .at(wp_idx_)  )) return false;// |dz|
+  if(!( expMissingHits  <= int(ElectronID::CutBased_LUT.at(tuning_).at(eleSC_pos_).at("missingHits")  .at(wp_idx_)) )) return false;// expected missing inner hits
+  if(!( passConvVeto    >= int(ElectronID::CutBased_LUT.at(tuning_).at(eleSC_pos_).at("passConvVeto") .at(wp_idx_)) )) return false;// conversion veto
+
+  if(apply_iso_cut_){
+
+    const float pfIsoEA = ele_.relIsorho(evt_.rho);
+    if(!( pfIsoEA            < ElectronID::CutBased_LUT.at(tuning_).at(eleSC_pos_).at("relIsoEA")     .at(wp_idx_)  )) return false;// pfIso (PU correction: effective-area)
+  }
+
+  return true;
+}
+
+// --- Cut-Based ID: PHYS14 25ns
+bool ElectronID_PHYS14_25ns_veto        (const Electron& ele, const uhh2::Event& evt){ return Electron_CutBasedID(ele, evt, "PHYS14_25ns", "VETO"  , true) ; }
+bool ElectronID_PHYS14_25ns_veto_noIso  (const Electron& ele, const uhh2::Event& evt){ return Electron_CutBasedID(ele, evt, "PHYS14_25ns", "VETO"  , false); }
+
+bool ElectronID_PHYS14_25ns_loose       (const Electron& ele, const uhh2::Event& evt){ return Electron_CutBasedID(ele, evt, "PHYS14_25ns", "LOOSE" , true) ; }
+bool ElectronID_PHYS14_25ns_loose_noIso (const Electron& ele, const uhh2::Event& evt){ return Electron_CutBasedID(ele, evt, "PHYS14_25ns", "LOOSE" , false); }
+
+bool ElectronID_PHYS14_25ns_medium      (const Electron& ele, const uhh2::Event& evt){ return Electron_CutBasedID(ele, evt, "PHYS14_25ns", "MEDIUM", true) ; }
+bool ElectronID_PHYS14_25ns_medium_noIso(const Electron& ele, const uhh2::Event& evt){ return Electron_CutBasedID(ele, evt, "PHYS14_25ns", "MEDIUM", false); }
+
+bool ElectronID_PHYS14_25ns_tight       (const Electron& ele, const uhh2::Event& evt){ return Electron_CutBasedID(ele, evt, "PHYS14_25ns", "TIGHT" , true) ; }
+bool ElectronID_PHYS14_25ns_tight_noIso (const Electron& ele, const uhh2::Event& evt){ return Electron_CutBasedID(ele, evt, "PHYS14_25ns", "TIGHT" , false); }
+
+// --- Cut-Based ID: Spring15 50ns
+bool ElectronID_Spring15_50ns_veto        (const Electron& ele, const uhh2::Event& evt){ return Electron_CutBasedID(ele, evt, "Spring15_50ns", "VETO"  , true) ; }
+bool ElectronID_Spring15_50ns_veto_noIso  (const Electron& ele, const uhh2::Event& evt){ return Electron_CutBasedID(ele, evt, "Spring15_50ns", "VETO"  , false); }
+
+bool ElectronID_Spring15_50ns_loose       (const Electron& ele, const uhh2::Event& evt){ return Electron_CutBasedID(ele, evt, "Spring15_50ns", "LOOSE" , true) ; }
+bool ElectronID_Spring15_50ns_loose_noIso (const Electron& ele, const uhh2::Event& evt){ return Electron_CutBasedID(ele, evt, "Spring15_50ns", "LOOSE" , false); }
+
+bool ElectronID_Spring15_50ns_medium      (const Electron& ele, const uhh2::Event& evt){ return Electron_CutBasedID(ele, evt, "Spring15_50ns", "MEDIUM", true) ; }
+bool ElectronID_Spring15_50ns_medium_noIso(const Electron& ele, const uhh2::Event& evt){ return Electron_CutBasedID(ele, evt, "Spring15_50ns", "MEDIUM", false); }
+
+bool ElectronID_Spring15_50ns_tight       (const Electron& ele, const uhh2::Event& evt){ return Electron_CutBasedID(ele, evt, "Spring15_50ns", "TIGHT" , true) ; }
+bool ElectronID_Spring15_50ns_tight_noIso (const Electron& ele, const uhh2::Event& evt){ return Electron_CutBasedID(ele, evt, "Spring15_50ns", "TIGHT" , false); }
+
+// --- Cut-Based ID: Spring15 25ns
+bool ElectronID_Spring15_25ns_veto        (const Electron& ele, const uhh2::Event& evt){ return Electron_CutBasedID(ele, evt, "Spring15_25ns", "VETO"  , true) ; }
+bool ElectronID_Spring15_25ns_veto_noIso  (const Electron& ele, const uhh2::Event& evt){ return Electron_CutBasedID(ele, evt, "Spring15_25ns", "VETO"  , false); }
+
+bool ElectronID_Spring15_25ns_loose       (const Electron& ele, const uhh2::Event& evt){ return Electron_CutBasedID(ele, evt, "Spring15_25ns", "LOOSE" , true) ; }
+bool ElectronID_Spring15_25ns_loose_noIso (const Electron& ele, const uhh2::Event& evt){ return Electron_CutBasedID(ele, evt, "Spring15_25ns", "LOOSE" , false); }
+
+bool ElectronID_Spring15_25ns_medium      (const Electron& ele, const uhh2::Event& evt){ return Electron_CutBasedID(ele, evt, "Spring15_25ns", "MEDIUM", true) ; }
+bool ElectronID_Spring15_25ns_medium_noIso(const Electron& ele, const uhh2::Event& evt){ return Electron_CutBasedID(ele, evt, "Spring15_25ns", "MEDIUM", false); }
+
+bool ElectronID_Spring15_25ns_tight       (const Electron& ele, const uhh2::Event& evt){ return Electron_CutBasedID(ele, evt, "Spring15_25ns", "TIGHT" , true) ; }
+bool ElectronID_Spring15_25ns_tight_noIso (const Electron& ele, const uhh2::Event& evt){ return Electron_CutBasedID(ele, evt, "Spring15_25ns", "TIGHT" , false); }
+////
+
+//// Non-Triggering MVA ID
+
+bool Electron_NonTrigMVAID(const Electron& ele_, const uhh2::Event&, const std::string& tuning_, const std::string& wp_){
+
+  std::string category("");
+
+  const float pt(ele_.pt()), abs_etaSC(fabs(ele_.supercluster_eta()));
+  if(5. < pt && pt <= 10.){
+
+    if                         (abs_etaSC < 0.8)   category = "low-pt_barrel1";
+    else if(0.8 <= abs_etaSC && abs_etaSC < 1.479) category = "low-pt_barrel2";
+    else if                    (abs_etaSC < 2.5)   category = "low-pt_endcap";
+  }
+  else if(pt > 10.){
+
+    if                         (abs_etaSC < 0.8)   category = "high-pt_barrel1";
+    else if(0.8 <= abs_etaSC && abs_etaSC < 1.479) category = "high-pt_barrel2";
+    else if                    (abs_etaSC < 2.5)   category = "high-pt_endcap";
+  }
+  else return false;
+
+  int wp_idx(-1);
+  if     (wp_ == "80p_sigeff") wp_idx = 0;
+  else if(wp_ == "90p_sigeff") wp_idx = 1;
+  else throw std::runtime_error("Electron_NonTrigMVAID -- undefined working-point tag: "+wp_);
+
+  const float MVA(ele_.mvaNonTrigV0());
+
+  return (MVA > ElectronID::NonTrigMVA_LUT.at(tuning_).at(category).at(wp_idx));
+}
+
+bool ElectronID_MVAnotrig_PHYS14_loose(const Electron& ele, const uhh2::Event& evt){ return Electron_NonTrigMVAID(ele, evt, "PHYS14", "90p_sigeff"); }
+bool ElectronID_MVAnotrig_PHYS14_tight(const Electron& ele, const uhh2::Event& evt){ return Electron_NonTrigMVAID(ele, evt, "PHYS14", "80p_sigeff"); }
+
+bool ElectronID_MVAnotrig_Spring15_25ns_loose(const Electron& ele, const uhh2::Event& evt){ return Electron_NonTrigMVAID(ele, evt, "Spring15", "90p_sigeff"); }
+bool ElectronID_MVAnotrig_Spring15_25ns_tight(const Electron& ele, const uhh2::Event& evt){ return Electron_NonTrigMVAID(ele, evt, "Spring15", "80p_sigeff"); }
+////


### PR DESCRIPTION
* updated thresholds for electron cut-based ID
  * https://hypernews.cern.ch/HyperNews/CMS/get/egamma/1623.html
  * https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedElectronIdentificationRun2

* restructured the implementation of the ElectronID selectors in common/\*/ElectronIds.\*

  * these updates are backward-compatible (only the underlying implementation has changed)

  * the idea is to simplify the hard-coding of thresholds and make the implementation (as much as possible) not error-prone

  * the new implementation complies with the "table" structure that the Egamma twikis use for the ID working points

   * this allows to update/add ID recipes more easily, just copying the twiki table all at once in one place (instead of hard-coding thresholds 1-by-1 in different places)

   * also, the implementation is done so that the cut-based-ID thresholds are hard-coded only once (and not twice, as before, for cut-based IDs with and without isolation cut)
