### PR TITLE
cleaning the tau object

### DIFF
--- a/common/include/TauIds.h
+++ b/common/include/TauIds.h
@@ -10,6 +10,11 @@ public:
     bool operator()(const Tau & tau, const uhh2::Event & event) const;
 };
 
+class TauIDMediumInverted {
+public:
+    bool operator()(const Tau & tau, const uhh2::Event & event) const;
+};
+
 class TauIDDecayModeFinding {
 public:
     bool operator()(const Tau & tau, const uhh2::Event & event) const;
@@ -17,3 +22,7 @@ public:
 
 
 
+class TauIDTight {
+public:
+    bool operator()(const Tau & tau, const uhh2::Event & event) const;
+};

--- a/common/src/TauIds.cxx
+++ b/common/src/TauIds.cxx
@@ -3,8 +3,8 @@
 using namespace uhh2;
 
 bool TauIDMedium::operator()(const Tau & tau, const Event & event) const {
-    if(!tau.get_bool(Tau::decayModeFinding)) return false;
-    if(!tau.get_bool(Tau::againstElectronTightMVA5)) return false;
+    if(!tau.get_bool(Tau::decayModeFindingNewDMs)) return false;
+    if(!tau.get_bool(Tau::againstElectronMediumMVA5)) return false;
     if(!tau.get_bool(Tau::againstMuonTight3)) return false;
     if(!tau.get_bool(Tau::byMediumCombinedIsolationDeltaBetaCorr3Hits)) return false;
     if(event.muons){
@@ -15,7 +15,34 @@ bool TauIDMedium::operator()(const Tau & tau, const Event & event) const {
     return true;
 }
 
+bool TauIDMediumInverted::operator()(const Tau & tau, const Event & event) const {
+    if(!tau.get_bool(Tau::decayModeFindingNewDMs)) return false;
+    if(!tau.get_bool(Tau::againstElectronMediumMVA5)) return false;
+    if(!tau.get_bool(Tau::againstMuonTight3)) return false;
+    if(tau.get_bool(Tau::byMediumCombinedIsolationDeltaBetaCorr3Hits)) return false;
+    if(event.muons){
+        for(auto & muon : *event.muons) {
+            if (deltaR(muon,tau) < 0.4) return false;
+        }
+    }
+    return true;
+}
+
+
 bool TauIDDecayModeFinding::operator()(const Tau & tau, const Event &) const {
-    if(!tau.get_bool(Tau::decayModeFinding)) return false;
+    if(!tau.get_bool(Tau::decayModeFindingNewDMs)) return false;
+    return true;
+}
+
+bool TauIDTight::operator()(const Tau & tau, const Event & event) const {
+    if(!tau.get_bool(Tau::decayModeFindingNewDMs)) return false;
+    if(!tau.get_bool(Tau::againstElectronMediumMVA5)) return false;
+    if(!tau.get_bool(Tau::againstMuonTight3)) return false;
+    if(!tau.get_bool(Tau::byTightCombinedIsolationDeltaBetaCorr3Hits)) return false;
+    if(event.muons){
+        for(auto & muon : *event.muons) {
+            if (deltaR(muon,tau) < 0.4) return false;
+        }
+    }
     return true;
 }

--- a/core/include/Tau.h
+++ b/core/include/Tau.h
@@ -18,14 +18,12 @@ public:
   // the names used in the twiki page above (e.g. 'by...Rejection' has the name 'against...' here). See at the end of this file for a list
   // of variable names in miniAOD.
   enum bool_id {
-      againstElectronLoose = 0, againstElectronMedium, againstElectronTight,
       againstElectronVLooseMVA5, againstElectronLooseMVA5, againstElectronMediumMVA5, againstElectronTightMVA5, againstElectronVTightMVA5, 
-      againstMuonLoose, againstMuonMedium, againstMuonTight, againstMuonLoose3, againstMuonTight3,
-      againstMuonLooseMVA, againstMuonMediumMVA, againstMuonTightMVA, 
-      decayModeFinding, 
-      byLooseCombinedIsolationDeltaBetaCorr3Hits, byMediumCombinedIsolationDeltaBetaCorr3Hits, byTightCombinedIsolationDeltaBetaCorr3Hits /* = 19 */,
+      againstMuonLoose3, againstMuonTight3,
+      decayModeFindingOldDMs, decayModeFindingNewDMs,
+      byLooseCombinedIsolationDeltaBetaCorr3Hits, byMediumCombinedIsolationDeltaBetaCorr3Hits, byTightCombinedIsolationDeltaBetaCorr3Hits,
       byVLooseIsolationMVA3newDMwoLT, byLooseIsolationMVA3newDMwoLT, byMediumIsolationMVA3newDMwoLT, byTightIsolationMVA3newDMwoLT, byVTightIsolationMVA3newDMwoLT, byVVTightIsolationMVA3newDMwoLT,
-      byVLooseIsolationMVA3newDMwLT, byLooseIsolationMVA3newDMwLT, byMediumIsolationMVA3newDMwLT, byTightIsolationMVA3newDMwLT, byVTightIsolationMVA3newDMwLT, byVVTightIsolationMVA3newDMwLT, decayModeFindingNewDMs /* = 32 */
+      byVLooseIsolationMVA3newDMwLT, byLooseIsolationMVA3newDMwLT, byMediumIsolationMVA3newDMwLT, byTightIsolationMVA3newDMwLT, byVTightIsolationMVA3newDMwLT, byVVTightIsolationMVA3newDMwLT
   };
   
   bool get_bool(bool_id i) const {
@@ -42,8 +40,6 @@ public:
   }
   
   // some non-bool values ('raw'):
-  float againstElectronMVA5raw() const { return m_againstElectronMVA5raw; }
-  float againstMuonMVAraw() const { return m_againstMuonMVAraw;}
   float byCombinedIsolationDeltaBetaCorrRaw3Hits() const { return m_byCombinedIsolationDeltaBetaCorrRaw3Hits; }
   float byIsolationMVA3newDMwLTraw() const { return m_byIsolationMVA3newDMwLTraw; }
   float byIsolationMVA3newDMwoLTraw() const { return m_byIsolationMVA3newDMwoLTraw; }
@@ -51,12 +47,21 @@ public:
   float chargedIsoPtSum() const { return m_chargedIsoPtSum; }
   float neutralIsoPtSum() const { return m_neutralIsoPtSum; }
   float puCorrPtSum() const { return m_puCorrPtSum; }
+  
+
+  float byLoosePileupWeightedIsolation3Hits() const { return m_byLoosePileupWeightedIsolation3Hits; }
+  float byMediumPileupWeightedIsolation3Hits() const { return m_byMediumPileupWeightedIsolation3Hits; }
+  float byTightPileupWeightedIsolation3Hits() const { return m_byTightPileupWeightedIsolation3Hits; }
+  float byPileupWeightedIsolationRaw3Hits() const { return m_byPileupWeightedIsolationRaw3Hits; }
+  float neutralIsoPtSumWeight() const { return m_neutralIsoPtSumWeight; }
+  float footprintCorrection() const { return m_footprintCorrection; }
+  float photonPtSumOutsideSignalCone() const { return m_photonPtSumOutsideSignalCone; }
+  
+
+ 
 
   int decayMode() const { return m_decayMode; }
   
-  
-  void set_againstElectronMVA5raw(float value) { m_againstElectronMVA5raw = value;}
-  void set_againstMuonMVAraw(float value) { m_againstMuonMVAraw = value; }
   void set_byCombinedIsolationDeltaBetaCorrRaw3Hits(float value){ m_byCombinedIsolationDeltaBetaCorrRaw3Hits = value; }
   void set_byIsolationMVA3newDMwoLTraw(float value) { m_byIsolationMVA3newDMwoLTraw = value; }
   void set_byIsolationMVA3newDMwLTraw(float value) { m_byIsolationMVA3newDMwLTraw = value; }
@@ -67,14 +72,24 @@ public:
   
   void set_decayMode(int value){ m_decayMode = value; }
 
+  
+  void set_byLoosePileupWeightedIsolation3Hits(float value) { m_byLoosePileupWeightedIsolation3Hits = value;}
+  void set_byMediumPileupWeightedIsolation3Hits(float value) { m_byMediumPileupWeightedIsolation3Hits = value; }
+  void set_byTightPileupWeightedIsolation3Hits(float value){ m_byTightPileupWeightedIsolation3Hits = value; }
+
+  void set_byPileupWeightedIsolationRaw3Hits(float value) { m_byPileupWeightedIsolationRaw3Hits = value;}
+  void set_neutralIsoPtSumWeight(float value) { m_neutralIsoPtSumWeight = value;}
+  void set_footprintCorrection(float value) { m_footprintCorrection = value;}
+  void set_photonPtSumOutsideSignalCone(float value) { m_photonPtSumOutsideSignalCone = value;}
+  
+
+
   float get_tag(tag t) const { return tags.get_tag(static_cast<int>(t)); }
   void set_tag(tag t, float value) { return tags.set_tag(static_cast<int>(t), value); }
   
   
   Tau(){
       id_bits = 0;
-      m_againstElectronMVA5raw = 0;
-      m_againstMuonMVAraw = 0;
       m_byCombinedIsolationDeltaBetaCorrRaw3Hits = 0;
       m_byIsolationMVA3newDMwoLTraw = 0;
       m_byIsolationMVA3newDMwLTraw = 0;
@@ -86,14 +101,21 @@ private:
     // the bit positions correspond to the int-converted values of the enum bool_id.
     uint64_t id_bits;
     
-    float m_againstElectronMVA5raw;
-    float m_againstMuonMVAraw;
     float m_byCombinedIsolationDeltaBetaCorrRaw3Hits;
     float m_byIsolationMVA3newDMwoLTraw;
     float m_byIsolationMVA3newDMwLTraw;
     float m_chargedIsoPtSum;
     float m_neutralIsoPtSum;
     float m_puCorrPtSum;
+    
+    float m_byLoosePileupWeightedIsolation3Hits;
+    float m_byMediumPileupWeightedIsolation3Hits;
+    float m_byTightPileupWeightedIsolation3Hits;
+    float m_byPileupWeightedIsolationRaw3Hits;
+    float m_neutralIsoPtSumWeight;
+    float m_footprintCorrection;
+    float m_photonPtSumOutsideSignalCone;
+    
     
     int m_decayMode;
   

--- a/core/plugins/NtupleWriterLeptons.cxx
+++ b/core/plugins/NtupleWriterLeptons.cxx
@@ -197,27 +197,18 @@ void NtupleWriterTaus::process(const edm::Event & event, uhh2::Event & uevent){
          // used in the same as the string used for the pat tauID.
          #define FILL_TAU_BIT(tauidname) tau.set_bool(Tau:: tauidname, pat_tau.tauID(#tauidname) > 0.5)
         
-	 //         FILL_TAU_BIT(againstElectronLoose);         //  0
-	 //         FILL_TAU_BIT(againstElectronMedium);
-	 //         FILL_TAU_BIT(againstElectronTight);
          FILL_TAU_BIT(againstElectronVLooseMVA5);
          FILL_TAU_BIT(againstElectronLooseMVA5);
          FILL_TAU_BIT(againstElectronMediumMVA5);
          FILL_TAU_BIT(againstElectronTightMVA5);
          FILL_TAU_BIT(againstElectronVTightMVA5);
-         //FILL_TAU_BIT(againstMuonLoose);
-         //FILL_TAU_BIT(againstMuonMedium);
-         //FILL_TAU_BIT(againstMuonTight);            // 10
          FILL_TAU_BIT(againstMuonLoose3);
          FILL_TAU_BIT(againstMuonTight3);
-         //FILL_TAU_BIT(againstMuonLooseMVA);
-         //FILL_TAU_BIT(againstMuonMediumMVA);
-         //FILL_TAU_BIT(againstMuonTightMVA);
-         FILL_TAU_BIT(decayModeFinding);
          FILL_TAU_BIT(byLooseCombinedIsolationDeltaBetaCorr3Hits);
          FILL_TAU_BIT(byMediumCombinedIsolationDeltaBetaCorr3Hits);
          FILL_TAU_BIT(byTightCombinedIsolationDeltaBetaCorr3Hits);
-         //FILL_TAU_BIT(byVLooseIsolationMVA3newDMwoLT);  // 20
+	 // MVA based isolation discriminators not yet recommended for RunII (need to be retrained)
+         //FILL_TAU_BIT(byVLooseIsolationMVA3newDMwoLT);
          //FILL_TAU_BIT(byLooseIsolationMVA3newDMwoLT);
          //FILL_TAU_BIT(byMediumIsolationMVA3newDMwoLT);
          //FILL_TAU_BIT(byTightIsolationMVA3newDMwoLT);
@@ -227,22 +218,31 @@ void NtupleWriterTaus::process(const edm::Event & event, uhh2::Event & uevent){
          FILL_TAU_BIT(byLooseIsolationMVA3newDMwLT);
          FILL_TAU_BIT(byMediumIsolationMVA3newDMwLT);
          FILL_TAU_BIT(byTightIsolationMVA3newDMwLT);
-         FILL_TAU_BIT(byVTightIsolationMVA3newDMwLT);  // 30
-         FILL_TAU_BIT(byVVTightIsolationMVA3newDMwLT); // 31
+         FILL_TAU_BIT(byVTightIsolationMVA3newDMwLT);
+         FILL_TAU_BIT(byVVTightIsolationMVA3newDMwLT);
+	 FILL_TAU_BIT(decayModeFindingOldDMs);
          FILL_TAU_BIT(decayModeFindingNewDMs);
+
 
          #undef FILL_TAU_BIT
          #define FILL_TAU_FLOAT(name) tau.set_##name (pat_tau.tauID(#name))
          
-         FILL_TAU_FLOAT(againstElectronMVA5raw);
-	 //         FILL_TAU_FLOAT(againstMuonMVAraw);
          FILL_TAU_FLOAT(byCombinedIsolationDeltaBetaCorrRaw3Hits);
-         //FILL_TAU_FLOAT(byIsolationMVA3newDMwoLTraw);
          FILL_TAU_FLOAT(byIsolationMVA3newDMwLTraw);
          FILL_TAU_FLOAT(chargedIsoPtSum);
          FILL_TAU_FLOAT(neutralIsoPtSum);
          FILL_TAU_FLOAT(puCorrPtSum);
+
+	 // note: only available with dynamic strip reconstruction (included by default from CMSSW_7_4_14)
+	 FILL_TAU_BIT(byLoosePileupWeightedIsolation3Hits);
+	 FILL_TAU_BIT(byMediumPileupWeightedIsolation3Hits);
+	 FILL_TAU_BIT(byTightPileupWeightedIsolation3Hits);
+	 FILL_TAU_BIT(byPileupWeightedIsolationRaw3Hits);
+	 FILL_TAU_BIT(neutralIsoPtSumWeight);
+	 FILL_TAU_BIT(footprintCorrection);
+	 FILL_TAU_BIT(photonPtSumOutsideSignalCone);
          
+
          #undef FILL_TAU_FLOAT
 
          tau.set_decayMode(pat_tau.decayMode());


### PR DESCRIPTION
The tau object was cleaned up in the ntuplewriter. Old discriminaters have been killed, also I filled new discriminators which are recommended for Run II.
Moreover, some tauids have been added. Also, the againstElectronTightMVA5 discriminator was changed to medium as it is recommended from the tau POG.