### PR TITLE
added soft-drop mass to TopJet

### DIFF
--- a/core/include/TopJet.h
+++ b/core/include/TopJet.h
@@ -29,7 +29,7 @@ public:
    
   
   TopJet(){
-      m_qjets_volatility = m_tau1 = m_tau2 = m_tau3 = m_mvahiggsdiscr = m_prunedmass = -1.0f;
+      m_qjets_volatility = m_tau1 = m_tau2 = m_tau3 = m_mvahiggsdiscr = m_prunedmass = m_softdropmass = -1.0f;
   }
 
   // getters
@@ -41,6 +41,8 @@ public:
   float mvahiggsdiscr() const {return m_mvahiggsdiscr;}
 
   float prunedmass() const {return m_prunedmass;}
+
+  float softdropmass() const {return m_softdropmass;}
 
   const std::vector<Jet> & subjets() const{return m_subjets;}
   
@@ -57,6 +59,8 @@ public:
   void set_mvahiggsdiscr(float x){m_mvahiggsdiscr = x;}
 
   void set_prunedmass(float x){m_prunedmass = x;}
+
+  void set_softdropmass(float x){m_softdropmass = x;}
 
   void add_subjet(const Jet & subjet){m_subjets.push_back(subjet);}
 
@@ -76,6 +80,8 @@ private:
   float m_mvahiggsdiscr;
 
   float m_prunedmass;
+
+  float m_softdropmass;
 
   Tags tags;
 };

--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -250,7 +250,8 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
     auto subjet_taginfos = iConfig.getParameter<std::vector<std::string> >("subjet_taginfos");
     auto higgstag_sources = iConfig.getParameter<std::vector<std::string> >("higgstag_sources");
     auto higgstag_names = iConfig.getParameter<std::vector<std::string> >("higgstag_names");
-    auto topjet_prunedmass_sources = iConfig.getParameter<std::vector<std::string> >("topjet_prunedmass_sources");
+    auto topjet_prunedmass_sources   = iConfig.getParameter<std::vector<std::string> >("topjet_prunedmass_sources");
+    auto topjet_softdropmass_sources = iConfig.getParameter<std::vector<std::string> >("topjet_softdropmass_sources");
     double topjet_ptmin = iConfig.getParameter<double> ("topjet_ptmin");
     double topjet_etamax = iConfig.getParameter<double> ("topjet_etamax");
     bool substructure_variables = false;
@@ -265,6 +266,10 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
     }
     if(topjet_prunedmass_sources.size()!=topjet_sources.size()){
       cerr << "Exception: wrong size of topjet_prunedmass_sources" << endl;
+      throw;
+    }
+    if(topjet_softdropmass_sources.size()!=topjet_sources.size()){
+      cerr << "Exception: wrong size of topjet_softdropmass_sources" << endl;
       throw;
     }
     if(subjet_sources.size()!=subjet_taginfos.size()){
@@ -298,6 +303,7 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
 	cfg.higgs_src = higgstag_sources[j];
 	cfg.higgs_name = higgstag_names[j];
 	cfg.pruned_src = topjet_prunedmass_sources[j];
+        cfg.softdrop_src = topjet_softdropmass_sources[j];
 	if(higgstag_sources[j]!=""&&higgstag_names[j]==""){
 	  cerr << "Exception: higgstag source specified, but no higgstag discriminator name" << endl;
 	  throw;

--- a/core/plugins/NtupleWriterJets.cxx
+++ b/core/plugins/NtupleWriterJets.cxx
@@ -214,10 +214,17 @@ NtupleWriterTopJets::NtupleWriterTopJets(Config & cfg, bool set_jets_member): pt
     qjets_src = cfg.qjets_src;
     subjet_src = cfg.subjet_src;
     higgs_src= cfg.higgs_src;
+
     pruned_src = cfg.pruned_src;
     if(pruned_src.find("Mass")==string::npos){
       src_pruned_token = cfg.cc.consumes<std::vector<pat::Jet>>(cfg.pruned_src);
     }
+
+    softdrop_src = cfg.softdrop_src;
+    if(softdrop_src.find("Mass")==string::npos){
+      src_softdrop_token = cfg.cc.consumes<std::vector<pat::Jet>>(cfg.softdrop_src);
+    }
+
     src_higgs_token = cfg.cc.consumes<std::vector<pat::Jet>>(cfg.higgs_src);
     higgs_name=cfg.higgs_name;
     do_taginfo_subjets = cfg.do_taginfo_subjets;
@@ -309,37 +316,56 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
               topjet.set_tag(TopJet::tagname2tag("ptForRoptCalc"), jet_info.properties().ptForRoptCalc);
            }
 
-    //njettiness
-    if(njettiness_src.empty()){
-       topjet.set_tau1(pat_topjet.userFloat("NjettinessAK8:tau1"));
-       topjet.set_tau2(pat_topjet.userFloat("NjettinessAK8:tau2"));
-       topjet.set_tau3(pat_topjet.userFloat("NjettinessAK8:tau3"));
-    }
-    if(pruned_src.find("Mass")!=string::npos){
-       topjet.set_prunedmass(pat_topjet.userFloat(pruned_src));
-    }
-    else{
-       edm::Handle<pat::JetCollection> pruned_pat_topjets;
-       event.getByToken(src_pruned_token, pruned_pat_topjets);
-       const vector<pat::Jet> & pat_prunedjets = *pruned_pat_topjets;
-       
-	  //match a jet from pruned collection
-	  int i_pat_prunedjet = -1;
-	  double drmin = numeric_limits<double>::infinity();
-	  for (unsigned int ih = 0; ih < pat_prunedjets.size(); ih++) {
-	    const pat::Jet & pruned_jet = pat_prunedjets[ih];
-	    auto dr = reco::deltaR(pruned_jet, pat_topjet);
-	    if(dr < drmin){
-	      i_pat_prunedjet = ih;
-	      drmin = dr;
-	    }
-	  }
-	  
-	  if (i_pat_prunedjet >= 0 && drmin < 1.0){
-	    const pat::Jet & pruned_jet = pat_prunedjets[i_pat_prunedjet];
-	    topjet.set_prunedmass(pruned_jet.mass());
-	  }
-	}//pruned mass set through matching with pruned collection
+        /* --- Njettiness -----*/
+        if(njettiness_src.empty()){
+
+          topjet.set_tau1(pat_topjet.userFloat("NjettinessAK8:tau1"));
+          topjet.set_tau2(pat_topjet.userFloat("NjettinessAK8:tau2"));
+          topjet.set_tau3(pat_topjet.userFloat("NjettinessAK8:tau3"));
+        }
+        /*---------------------*/
+
+        /*--- pruned mass -----*/
+        if(pruned_src.find("Mass")!=string::npos){
+
+          topjet.set_prunedmass(pat_topjet.userFloat(pruned_src));
+        }
+        else{//pruned mass set through matching with pruned-jet collection
+
+          edm::Handle<pat::JetCollection> pruned_pat_topjets;
+          event.getByToken(src_pruned_token, pruned_pat_topjets);
+          const vector<pat::Jet> & pat_prunedjets = *pruned_pat_topjets;
+
+          //match a jet from pruned collection
+          int i_pat_prunedjet = -1;
+          double drmin = numeric_limits<double>::infinity();
+          for (unsigned int ih = 0; ih < pat_prunedjets.size(); ih++) {
+
+            const pat::Jet & pruned_jet = pat_prunedjets[ih];
+            auto dr = reco::deltaR(pruned_jet, pat_topjet);
+            if(dr < drmin){
+              i_pat_prunedjet = ih;
+              drmin = dr;
+            }
+          }
+
+          if(i_pat_prunedjet >= 0 && drmin < 1.0){
+
+            const pat::Jet & pruned_jet = pat_prunedjets[i_pat_prunedjet];
+            topjet.set_prunedmass(pruned_jet.mass());
+          }
+        }
+        /*---------------------*/
+
+        /*--- softdrop mass ---*/
+        if(softdrop_src.find("Mass")!=string::npos){
+
+          topjet.set_softdropmass(pat_topjet.userFloat(softdrop_src));
+        }
+        else {//softdrop mass set through matching with softdrop-jet collection
+          /* not implemented */
+        }
+        /*---------------------*/
 
 	if(higgs_src!=""){
 	  

--- a/core/plugins/NtupleWriterJets.h
+++ b/core/plugins/NtupleWriterJets.h
@@ -23,6 +23,7 @@ private:
     edm::EDGetToken src_token;
     edm::EDGetToken src_higgs_token;
     edm::EDGetToken src_pruned_token;
+    edm::EDGetToken src_softdrop_token;
     float ptmin, etamax;
     Event::Handle<std::vector<Jet>> handle; // main handle to write output to
     boost::optional<Event::Handle<std::vector<Jet>>> jets_handle; // handle of name "jets" in case set_jets_member is true
@@ -45,6 +46,7 @@ public:
 	std::string higgs_src;
 	std::string higgs_name;
 	std::string pruned_src;
+        std::string softdrop_src;
     };
 
     explicit NtupleWriterTopJets(Config & cfg, bool set_jets_member);
@@ -57,8 +59,8 @@ private:
     edm::InputTag src;
     float ptmin, etamax;
     bool do_btagging, do_btagging_subjets, do_taginfo_subjets;
-    edm::EDGetToken src_token, src_higgs_token,  src_pruned_token, substructure_variables_src_token;
-   std::string njettiness_src, qjets_src, subjet_src, higgs_src, higgs_name, pruned_src, topjet_collection;
+    edm::EDGetToken src_token, src_higgs_token, src_pruned_token, src_softdrop_token, substructure_variables_src_token;
+    std::string njettiness_src, qjets_src, subjet_src, higgs_src, higgs_name, pruned_src, softdrop_src, topjet_collection;
     Event::Handle<std::vector<TopJet>> handle;
     boost::optional<Event::Handle<std::vector<TopJet>>> topjets_handle;
     std::vector<TopJet::tag> id_tags;

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -732,6 +732,7 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
         #Alternatively it is possible to specify another pruned jet collection (to be produced here), from which to get it by jet-matching.
         #Finally, it is also possible to leave the pruned mass empty with ""
         topjet_prunedmass_sources = cms.vstring("ak8PFJetsCHSPrunedMass","patJetsAk8CHSJetsPrunedPacked","patJetsCa15CHSJetsPrunedPacked","patJetsCa15CHSJetsPrunedPacked","patJetsCa15CHSJetsPrunedPacked"),
+        topjet_softdropmass_sources = cms.vstring("ak8PFJetsCHSSoftDropMass", "", "", "", ""),
         #topjet_sources = cms.vstring("patJetsHepTopTagCHSPacked", "patJetsCmsTopTagCHSPacked", "patJetsCa8CHSJetsPrunedPacked", "patJetsCa15CHSJetsFilteredPacked",
         #        "patJetsHepTopTagPuppiPacked", "patJetsCmsTopTagPuppiPacked", "patJetsCa8PuppiJetsPrunedPacked", "patJetsCa15PuppiJetsFilteredPacked",
         #        'patJetsCa8CHSJetsSoftDropPacked', 'patJetsCa8PuppiJetsSoftDropPacked'


### PR DESCRIPTION
* added a 'soft-drop mass' member to the TopJet class (similarly to what is done for the pruned mass)
* currently storing the uncorrected softdrop mass from the miniAOD collection (only for the slimmedJetsAK8 collection)
