### PR TITLE
remove MET corrections

### DIFF
--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 
-useData = True
+useData = False
 use25ns = True #switch this flag to False when running on 50ns samples
 
 # minimum pt for the large-R jets (applies for all: vanilla CA8/CA15, cmstoptag, heptoptag). Also applied for the corresponding genjets.
@@ -33,11 +33,12 @@ process.MessageLogger.cerr.FwkReport.reportEvery = cms.untracked.int32(100)
 process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(False) , allowUnscheduled = cms.untracked.bool(True) )
 
 process.source = cms.Source("PoolSource",
-                            fileNames  = cms.untracked.vstring("/store/data/Run2015D/SingleMuon/MINIAOD/PromptReco-v3/000/256/729/00000/2C0BE722-5960-E511-B834-02163E014421.root"),
+                            fileNames  = cms.untracked.vstring("/store/mc/RunIISpring15MiniAODv2/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/74X_mcRun2_asymptotic_v2-v1/40000/00087FEB-236E-E511-9ACB-003048FF86CA.root"),
+                            #fileNames  = cms.untracked.vstring("/store/data/Run2015D/SingleMuon/MINIAOD/PromptReco-v3/000/256/729/00000/2C0BE722-5960-E511-B834-02163E014421.root"),
                             skipEvents = cms.untracked.uint32(0)
 )
 
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1000))
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100))
 
 # Grid-control changes:
 gc_maxevents = '__MAX_EVENTS__'
@@ -116,112 +117,6 @@ process.ApplyBaselineHBHEIsoNoiseFilter = cms.EDFilter('BooleanFlagFilter',
    inputLabel = cms.InputTag('HBHENoiseFilterResultProducer','HBHEIsoNoiseFilterResult'),
    reverseDecision = cms.bool(False)
 )
-
-
-
-###############################################
-# MET without HF for run II data in CMSSW_74X
-
-#configurable options =======================================================================
-usePrivateSQlite=True #use external JECs (sqlite file)
-useHFCandidates=False #create an additionnal NoHF slimmed MET collection if the option is set to false
-applyResiduals=True #application of residual corrections. Have to be set to True once the 13 TeV residual corrections are available. False to be kept meanwhile. Can be kept to False later for private tests or for analysis checks and developments (not the official recommendation!).
-#===================================================================
-
-
-### External JECs =====================================================================================================
-
-if usePrivateSQlite:
-    from CondCore.DBCommon.CondDBSetup_cfi import *
-    import os
-    if useData:
-        if use25ns:
-            era="Summer15_25nsV5_DATA" 
-        else:
-            era="Summer15_50nsV4_DATA"
-    else:
-        if use25ns:
-            era="Summer15_25nsV2_MC" 
-        else:
-            era="Summer15_50nsV4_MC"
-
-    dBFile = os.path.expandvars(era+".db")
-    process.jec = cms.ESSource("PoolDBESSource",CondDBSetup,
-                               connect = cms.string( "sqlite_file:"+dBFile ),
-                               toGet =  cms.VPSet(
-            cms.PSet(
-                record = cms.string("JetCorrectionsRecord"),
-                tag = cms.string("JetCorrectorParametersCollection_"+era+"_AK4PF"),
-                label= cms.untracked.string("AK4PF")
-                ),
-            cms.PSet(
-                record = cms.string("JetCorrectionsRecord"),
-                tag = cms.string("JetCorrectorParametersCollection_"+era+"_AK4PFchs"),
-                label= cms.untracked.string("AK4PFchs")
-                ),
-            )
-                               )
-    process.es_prefer_jec = cms.ESPrefer("PoolDBESSource",'jec')
-
-#uncertainty file
-if use25ns: 
-    jecUncertaintyFile="UHH2/JetMETObjects/data/Summer15_25nsV5_DATA_UncertaintySources_AK4PFchs.txt" 
-else:
-    jecUncertaintyFile="PhysicsTools/PatUtils/data/Summer15_50nsV4_DATA_UncertaintySources_AK4PFchs.txt"
-
-### ------------------------------------------------------------------
-
-### ---------------------------------------------------------------------------
-### Removing the HF from the MET computation
-### ---------------------------------------------------------------------------
-if not useHFCandidates:
-    process.noHFCands = cms.EDFilter("CandPtrSelector",
-                                     src=cms.InputTag("packedPFCandidates"),
-                                     cut=cms.string("abs(pdgId)!=1 && abs(pdgId)!=2 && abs(eta)<3.0")
-                                     )
-
-#jets are rebuilt from those candidates by the tools, no need to do anything else
-### =================================================================================
-
-from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMetCorAndUncFromMiniAOD
-
-#default configuration for miniAOD reprocessing, change the isData flag to run on data
-#for a full met computation, remove the pfCandColl input
-runMetCorAndUncFromMiniAOD(process,
-                           isData=useData,
-                           jecUncFile=jecUncertaintyFile
-                           )
-
-if not useHFCandidates:
-    runMetCorAndUncFromMiniAOD(process,
-                               isData=useData,
-                               pfCandColl=cms.InputTag("noHFCands"),
-                               jecUncFile=jecUncertaintyFile,
-                               postfix="NoHF"
-                               )
-
-getattr(process,"slimmedMETs").t01Variation = cms.InputTag("slimmedMETs","","RECO")
-getattr(process,"slimmedMETsNoHF").t01Variation = cms.InputTag("slimmedMETsNoHF","","RECO")
-
-### -------------------------------------------------------------------
-### the lines below remove the L2L3 residual corrections when processing data
-### -------------------------------------------------------------------
-if not applyResiduals:
-    process.patPFMetT1T2Corr.jetCorrLabelRes = cms.InputTag("L3Absolute")
-    process.patPFMetT1T2SmearCorr.jetCorrLabelRes = cms.InputTag("L3Absolute")
-    process.patPFMetT2Corr.jetCorrLabelRes = cms.InputTag("L3Absolute")
-    process.patPFMetT2SmearCorr.jetCorrLabelRes = cms.InputTag("L3Absolute")
-    process.shiftedPatJetEnDown.jetCorrLabelUpToL3Res = cms.InputTag("ak4PFCHSL1FastL2L3Corrector")
-    process.shiftedPatJetEnUp.jetCorrLabelUpToL3Res = cms.InputTag("ak4PFCHSL1FastL2L3Corrector")
-
-    if not useHFCandidates:
-          process.patPFMetT1T2CorrNoHF.jetCorrLabelRes = cms.InputTag("L3Absolute")
-          process.patPFMetT1T2SmearCorrNoHF.jetCorrLabelRes = cms.InputTag("L3Absolute")
-          process.patPFMetT2CorrNoHF.jetCorrLabelRes = cms.InputTag("L3Absolute")
-          process.patPFMetT2SmearCorrNoHF.jetCorrLabelRes = cms.InputTag("L3Absolute")
-          process.shiftedPatJetEnDownNoHF.jetCorrLabelUpToL3Res = cms.InputTag("ak4PFCHSL1FastL2L3Corrector")
-          process.shiftedPatJetEnUpNoHF.jetCorrLabelUpToL3Res = cms.InputTag("ak4PFCHSL1FastL2L3Corrector")
-### ------------------------------------------------------------------
 
 
 


### PR DESCRIPTION
I noticed that the MET corrections in our ntuplewriter.py script were not running for MC in the latest CMSSW_7_4_X release. According to https://twiki.cern.ch/twiki/bin/view/CMS/MissingETUncertaintyPrescription#Instructions_for_7_4_X_X_12 they are not needed anymore. I removed the snippet from corMETFromMiniAOD.py completely because the corrections are supposed to be fully included in the default configuration. 

Could anyone else have a look into the twiki pages an confirm that this is correct?