### PR TITLE
jet-lepton keys in ntuple format

### DIFF
--- a/core/include/Electron.h
+++ b/core/include/Electron.h
@@ -4,7 +4,9 @@
 #include "Tags.h"
 #include "FlavorParticle.h"
 
-class Electron: public Particle {
+#include <vector>
+
+class Electron : public Particle {
 
  public:
   enum tag {
@@ -14,45 +16,57 @@ class Electron: public Particle {
   };
 
   static tag tagname2tag(const std::string & tagname){
-    if(tagname == "heepElectronID_HEEPV60")                                  return heepElectronID_HEEPV60;
+    if(tagname == "heepElectronID_HEEPV60") return heepElectronID_HEEPV60;
 
     throw std::runtime_error("unknown Electron::tag '" + tagname + "'");
   }
 
-  Electron(){
-   m_supercluster_eta = 0; 
-   m_supercluster_phi = 0; 
-   m_dB = 0; 
-   m_neutralHadronIso = 0; 
-   m_chargedHadronIso = 0; 
-   m_photonIso = 0;
-   m_trackIso = 0; 
-   m_puChargedHadronIso = 0;
-   m_gsfTrack_trackerExpectedHitsInner_numberOfLostHits = 0;
-   m_gsfTrack_px = 0;
-   m_gsfTrack_py = 0;
-   m_gsfTrack_pz = 0;
-   m_gsfTrack_vx = 0;
-   m_gsfTrack_vy = 0;
-   m_gsfTrack_vz = 0;
-   m_passconversionveto = false;
-   m_dEtaIn = 0;
-   m_dPhiIn = 0; 
-   m_sigmaIEtaIEta = 0; 
-   m_HoverE = 0;
-   m_fbrem = 0;
-   m_EoverPIn = 0;
-   m_EcalEnergy = 0;
-   m_mvaNonTrigV0 = 0;
-   m_mvaTrigV0 = 0;
-   m_AEff = 0;
+  struct source_candidate {
 
-   m_pfMINIIso_CH       = 0;
-   m_pfMINIIso_NH       = 0;
-   m_pfMINIIso_Ph       = 0;
-   m_pfMINIIso_PU       = 0;
-   m_pfMINIIso_NH_pfwgt = 0;
-   m_pfMINIIso_Ph_pfwgt = 0;
+    long int key;
+    float px;
+    float py;
+    float pz;
+    float E;
+  };
+
+  Electron(){
+
+    m_supercluster_eta = 0; 
+    m_supercluster_phi = 0; 
+    m_dB = 0; 
+    m_neutralHadronIso = 0; 
+    m_chargedHadronIso = 0; 
+    m_photonIso = 0;
+    m_trackIso = 0; 
+    m_puChargedHadronIso = 0;
+    m_gsfTrack_trackerExpectedHitsInner_numberOfLostHits = 0;
+    m_gsfTrack_px = 0;
+    m_gsfTrack_py = 0;
+    m_gsfTrack_pz = 0;
+    m_gsfTrack_vx = 0;
+    m_gsfTrack_vy = 0;
+    m_gsfTrack_vz = 0;
+    m_passconversionveto = false;
+    m_dEtaIn = 0;
+    m_dPhiIn = 0; 
+    m_sigmaIEtaIEta = 0; 
+    m_HoverE = 0;
+    m_fbrem = 0;
+    m_EoverPIn = 0;
+    m_EcalEnergy = 0;
+    m_mvaNonTrigV0 = 0;
+    m_mvaTrigV0 = 0;
+    m_AEff = 0;
+
+    m_pfMINIIso_CH       = 0;
+    m_pfMINIIso_NH       = 0;
+    m_pfMINIIso_Ph       = 0;
+    m_pfMINIIso_PU       = 0;
+    m_pfMINIIso_NH_pfwgt = 0;
+    m_pfMINIIso_Ph_pfwgt = 0;
+
+    m_source_candidates.clear();
   }
 
   float supercluster_eta() const{return m_supercluster_eta;} 
@@ -89,8 +103,7 @@ class Electron: public Particle {
   float pfMINIIso_NH_pfwgt() const { return m_pfMINIIso_NH_pfwgt; }
   float pfMINIIso_Ph_pfwgt() const { return m_pfMINIIso_Ph_pfwgt; }
 
-  float get_tag(tag t)const {return tags.get_tag(static_cast<int>(t));}
-  bool has_tag(tag t) const {return tags.has_tag(static_cast<int>(t));}
+  std::vector<source_candidate> source_candidates() const { return m_source_candidates; }
 
   void set_supercluster_eta(float x){m_supercluster_eta=x;} 
   void set_supercluster_phi(float x){m_supercluster_phi=x;} 
@@ -126,25 +139,34 @@ class Electron: public Particle {
   void set_pfMINIIso_NH_pfwgt(float x){ m_pfMINIIso_NH_pfwgt = x; }
   void set_pfMINIIso_Ph_pfwgt(float x){ m_pfMINIIso_Ph_pfwgt = x; }
 
-  void set_tag(tag t, float value) { tags.set_tag(static_cast<int>(t), value);}
+  void add_source_candidate(const source_candidate& sc){ m_source_candidates.push_back(sc); }
+
+  bool  has_tag(tag t) const { return tags.has_tag(static_cast<int>(t)); }
+  float get_tag(tag t) const { return tags.get_tag(static_cast<int>(t)); }
+  void  set_tag(tag t, float value) { tags.set_tag(static_cast<int>(t), value);}
 
   float gsfTrack_dxy_vertex(const float point_x, const float point_y) const{ 
     return ( - (m_gsfTrack_vx-point_x) * m_gsfTrack_py + (m_gsfTrack_vy-point_y) * m_gsfTrack_px ) / sqrt(m_gsfTrack_px*m_gsfTrack_px+m_gsfTrack_py*m_gsfTrack_py);  
   };
+
   float gsfTrack_dz_vertex(const float point_x, const float point_y, const float point_z) const{ 
     return (m_gsfTrack_vz-point_z) - ((m_gsfTrack_vx-point_x)*m_gsfTrack_px+(m_gsfTrack_vy-point_y)*m_gsfTrack_py)/(m_gsfTrack_px*m_gsfTrack_px+m_gsfTrack_py*m_gsfTrack_py) * m_gsfTrack_pz; 
   }
+
   float relIso() const{
     return ( m_chargedHadronIso +  m_neutralHadronIso + m_photonIso  ) / pt();
   }
+
   float relIsodb() const{
     return ( m_chargedHadronIso + std::max( 0.0, m_neutralHadronIso + m_photonIso - 0.5*m_puChargedHadronIso ) ) / pt();
   }
+
   float relIsorho(const double rho) const{
     return ( m_chargedHadronIso + std::max( 0.0, m_neutralHadronIso + m_photonIso - rho*m_AEff ) ) / pt();
   }
 
-  operator FlavorParticle() const{
+  operator FlavorParticle() const {
+
     FlavorParticle fp;
     fp.set_charge(this->charge());
     fp.set_pt(this->pt());
@@ -152,6 +174,7 @@ class Electron: public Particle {
     fp.set_phi(this->phi());
     fp.set_energy(this->energy());
     fp.set_pdgId(-13*this->charge());
+
     return fp;
   }
 
@@ -189,6 +212,8 @@ class Electron: public Particle {
   float m_pfMINIIso_PU;
   float m_pfMINIIso_NH_pfwgt;
   float m_pfMINIIso_Ph_pfwgt;
+
+  std::vector<source_candidate> m_source_candidates;
 
   Tags tags;
 };

--- a/core/include/Jet.h
+++ b/core/include/Jet.h
@@ -4,6 +4,8 @@
 #include "Tags.h"
 #include "JetBTagInfo.h"
 
+#include <vector>
+
 class Jet : public FlavorParticle {
 
  public:
@@ -35,6 +37,8 @@ class Jet : public FlavorParticle {
     m_JEC_factor_raw = 0;
     m_genjet_index = 0;
     m_hadronFlavor = 0;
+
+    m_lepton_keys.clear();
   }
 
   float jetArea() const{return m_jetArea;}
@@ -63,6 +67,8 @@ class Jet : public FlavorParticle {
   JetBTagInfo btaginfo() const{return m_btaginfo;}
   int hadronFlavor() const { return m_hadronFlavor; }
 
+  std::vector<long int> lepton_keys() const { return m_lepton_keys; }
+
   void set_jetArea(float x){m_jetArea=x;}
   void set_numberOfDaughters(int x){m_numberOfDaughters=x;} 
   void set_neutralEmEnergyFraction(float x){m_neutralEmEnergyFraction=x;}
@@ -89,6 +95,8 @@ class Jet : public FlavorParticle {
   void set_tag(tag t, float value) { return tags.set_tag(static_cast<int>(t), value); }
   void set_btaginfo(JetBTagInfo x){m_btaginfo=x;}
   void set_hadronFlavor(int x){ m_hadronFlavor = x; }
+
+  void add_lepton_key(const long int k){ m_lepton_keys.push_back(k); }
 
  private:
   float m_jetArea;
@@ -117,6 +125,8 @@ class Jet : public FlavorParticle {
   int m_hadronFlavor;
 
   JetBTagInfo m_btaginfo;
+
+  std::vector<long int> m_lepton_keys;
 
   Tags tags;
 };

--- a/core/include/Muon.h
+++ b/core/include/Muon.h
@@ -4,8 +4,10 @@
 #include "FlavorParticle.h"
 
 #include <stdint.h>
+#include <vector>
 
-class Muon: public Particle{
+class Muon : public Particle {
+
  public:
   enum bool_id {
     soft = 0, loose, medium, tight, highpt,
@@ -25,6 +27,15 @@ class Muon: public Particle{
     if(value) id_bits |=   uint64_t(1) << static_cast<uint64_t>(i);
     else      id_bits &= ~(uint64_t(1) << static_cast<uint64_t>(i));
   }
+
+  struct source_candidate {
+
+    long int key;
+    float px;
+    float py;
+    float pz;
+    float E;
+  };
 
   Muon(){
 
@@ -56,8 +67,10 @@ class Muon: public Particle{
     m_pfMINIIso_PU       = 0;
     m_pfMINIIso_NH_pfwgt = 0;
     m_pfMINIIso_Ph_pfwgt = 0;
+
+    m_source_candidates.clear();
   }
-  
+
   float dxy() const{return m_dxy;}
   float dxy_error() const{return m_dxy_error;}
   float dz() const{return m_dz;}
@@ -84,6 +97,8 @@ class Muon: public Particle{
   float pfMINIIso_PU()       const { return m_pfMINIIso_PU; }
   float pfMINIIso_NH_pfwgt() const { return m_pfMINIIso_NH_pfwgt; }
   float pfMINIIso_Ph_pfwgt() const { return m_pfMINIIso_Ph_pfwgt; }
+
+  std::vector<source_candidate> source_candidates() const { return m_source_candidates; }
 
   void set_dxy(float x){m_dxy=x;}
   void set_dxy_error(float x){m_dxy_error=x;}
@@ -112,6 +127,8 @@ class Muon: public Particle{
   void set_pfMINIIso_NH_pfwgt(float x){ m_pfMINIIso_NH_pfwgt = x; }
   void set_pfMINIIso_Ph_pfwgt(float x){ m_pfMINIIso_Ph_pfwgt = x; }
 
+  void add_source_candidate(const source_candidate& sc){ m_source_candidates.push_back(sc); }
+
   bool  has_tag(tag t) const { return tags.has_tag(static_cast<int>(t)); }
   float get_tag(tag t) const { return tags.get_tag(static_cast<int>(t)); }
   void  set_tag(tag t, float value) { tags.set_tag(static_cast<int>(t), value); }
@@ -120,7 +137,7 @@ class Muon: public Particle{
     return ( m_sumChargedHadronPt + std::max( 0.0, m_sumNeutralHadronEt + m_sumPhotonEt - 0.5*m_sumPUPt) ) / pt();
   }
 
-  operator FlavorParticle() const{
+  operator FlavorParticle() const {
 
     FlavorParticle fp;
     fp.set_charge(this->charge());
@@ -162,6 +179,8 @@ class Muon: public Particle{
   float m_pfMINIIso_PU;
   float m_pfMINIIso_NH_pfwgt;
   float m_pfMINIIso_Ph_pfwgt;
+
+  std::vector<source_candidate> m_source_candidates;
 
   Tags tags;
 };

--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -367,6 +367,10 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
 	cfg.dest_branchname = topbranch;
 	cfg.dest = topbranch;
         writer_modules.emplace_back(new NtupleWriterTopJets(cfg, j==0));
+/*
+        // switch on lepton-keys storage for TopJet collections
+        writer_modules.emplace_back(new NtupleWriterTopJets(cfg, i==0, muon_sources, elec_sources));
+*/
     }
   }
 

--- a/core/plugins/NtupleWriterJets.cxx
+++ b/core/plugins/NtupleWriterJets.cxx
@@ -105,6 +105,8 @@ void NtupleWriterJets::process(const edm::Event & event, uhh2::Event & uevent){
           const auto& jet_daughter_ptrs = pat_jet.daughterPtrVector();
           for(const auto & daughter_p : jet_daughter_ptrs){
 
+            if(!daughter_p.isAvailable()) continue;
+
             const auto& key = daughter_p.key();
 
             if(std::find(lepton_keys.begin(), lepton_keys.end(), key) == lepton_keys.end()) continue;

--- a/core/plugins/NtupleWriterJets.cxx
+++ b/core/plugins/NtupleWriterJets.cxx
@@ -17,7 +17,7 @@ using namespace std;
 
 bool btag_warning;
 
-NtupleWriterJets::NtupleWriterJets(Config & cfg, bool set_jets_member) {
+NtupleWriterJets::NtupleWriterJets(Config & cfg, bool set_jets_member){
     handle = cfg.ctx.declare_event_output<vector<Jet>>(cfg.dest_branchname, cfg.dest);
     ptmin = cfg.ptmin;
     etamax = cfg.etamax;
@@ -27,6 +27,20 @@ NtupleWriterJets::NtupleWriterJets(Config & cfg, bool set_jets_member) {
     src = cfg.src;
     src_token = cfg.cc.consumes<std::vector<pat::Jet>>(cfg.src);
     btag_warning=true;
+
+    save_lepton_keys_ = false;
+
+    h_muons.clear();
+    h_elecs.clear();
+}
+
+NtupleWriterJets::NtupleWriterJets(Config & cfg, bool set_jets_member, const std::vector<std::string>& muon_sources, const std::vector<std::string>& elec_sources):
+  NtupleWriterJets::NtupleWriterJets(cfg, set_jets_member) {
+
+    save_lepton_keys_ = true;
+
+    for(const auto& muo_src : muon_sources){ auto h_muon = cfg.ctx.get_handle<std::vector<Muon>    >(muo_src); h_muons.push_back(h_muon); }
+    for(const auto& ele_src : elec_sources){ auto h_elec = cfg.ctx.get_handle<std::vector<Electron>>(ele_src); h_elecs.push_back(h_elec); }
 }
 
 NtupleWriterJets::~NtupleWriterJets(){}
@@ -34,20 +48,71 @@ NtupleWriterJets::~NtupleWriterJets(){}
 void NtupleWriterJets::process(const edm::Event & event, uhh2::Event & uevent){
     edm::Handle< std::vector<pat::Jet> > jet_handle;
     event.getByToken(src_token, jet_handle);
-    std::vector<Jet> jets;
     const std::vector<pat::Jet> & pat_jets = *jet_handle;
+
+    /*--- lepton keys ---*/
+    std::vector<long int> lepton_keys;
+    if(save_lepton_keys_){
+
+      for(const auto& h_muo : h_muons){
+
+        const auto& muons = uevent.get(h_muo);
+
+        for(const auto& muo : muons){
+          for(const auto& sc : muo.source_candidates()){
+
+            lepton_keys.push_back(sc.key);
+          }
+        }
+      }
+
+      for(const auto& h_ele : h_elecs){
+
+        const auto& elecs = uevent.get(h_ele);
+
+        for(const auto& ele : elecs){
+          for(const auto& sc : ele.source_candidates()){
+
+            lepton_keys.push_back(sc.key);
+          }
+        }
+      }
+    }
+    /*-------------------*/
+
+    std::vector<Jet> jets;
     for (unsigned int i = 0; i < pat_jets.size(); ++i) {
         const pat::Jet & pat_jet = pat_jets[i];
         if(pat_jet.pt() < ptmin) continue;
         if(fabs(pat_jet.eta()) > etamax) continue;
         jets.emplace_back();
+
+        Jet& jet = jets.back();
+
         try {
-	  fill_jet_info(pat_jet, jets.back(), true, false);
+
+          fill_jet_info(pat_jet, jet, true, false);
         }
         catch(runtime_error & ex){
-            cerr << "Exception in fill_jet_info in NtupleWriterJets::process for jets with src=" << src << endl;
-            throw;
+
+          cerr << "Exception in fill_jet_info in NtupleWriterJets::process for jets with src=" << src << endl;
+          throw;
         }
+
+        /*--- lepton keys ---*/
+        if(save_lepton_keys_){
+
+          const auto& jet_daughter_ptrs = pat_jet.daughterPtrVector();
+          for(const auto & daughter_p : jet_daughter_ptrs){
+
+            const auto& key = daughter_p.key();
+
+            if(std::find(lepton_keys.begin(), lepton_keys.end(), key) == lepton_keys.end()) continue;
+
+            jet.add_lepton_key(key);
+          }
+        }
+        /*-------------------*/
     }
     uevent.set(handle, move(jets));
     if(jets_handle){
@@ -204,7 +269,7 @@ void NtupleWriterJets::fill_jet_info(const pat::Jet & pat_jet, Jet & jet, bool d
 }
 
 
-NtupleWriterTopJets::NtupleWriterTopJets(Config & cfg, bool set_jets_member): ptmin(cfg.ptmin), etamax(cfg.etamax){
+NtupleWriterTopJets::NtupleWriterTopJets(Config & cfg, bool set_jets_member): ptmin(cfg.ptmin), etamax(cfg.etamax) {
     handle = cfg.ctx.declare_event_output<vector<TopJet>>(cfg.dest_branchname, cfg.dest);
     if(set_jets_member){
         topjets_handle = cfg.ctx.get_handle<vector<TopJet>>("topjets");
@@ -236,6 +301,20 @@ NtupleWriterTopJets::NtupleWriterTopJets(Config & cfg, bool set_jets_member): pt
     }
     btag_warning=true;
     topjet_collection = cfg.dest_branchname;
+
+    save_lepton_keys_ = false;
+
+    h_muons.clear();
+    h_elecs.clear();
+}
+
+NtupleWriterTopJets::NtupleWriterTopJets(Config & cfg, bool set_jets_member, const std::vector<std::string>& muon_sources, const std::vector<std::string>& elec_sources):
+  NtupleWriterTopJets::NtupleWriterTopJets(cfg, set_jets_member) {
+
+    save_lepton_keys_ = true;
+
+    for(const auto& muo_src : muon_sources){ auto h_muon = cfg.ctx.get_handle<std::vector<Muon>    >(muo_src); h_muons.push_back(h_muon); }
+    for(const auto& ele_src : elec_sources){ auto h_elec = cfg.ctx.get_handle<std::vector<Electron>>(ele_src); h_elecs.push_back(h_elec); }
 }
 
 NtupleWriterTopJets::~NtupleWriterTopJets(){}
@@ -245,7 +324,7 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
     edm::Handle<pat::JetCollection> h_pat_topjets;
     event.getByToken(src_token, h_pat_topjets);
     const vector<pat::Jet> & pat_topjets = *h_pat_topjets;
-    
+
     edm::Handle<edm::ValueMap<float>> h_njettiness1, h_njettiness2, h_njettiness3;
     edm::Handle<edm::ValueMap<float>> h_qjets;
     
@@ -267,7 +346,37 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
     if (topjet_collection.find("CHS")!=string::npos) event.getByLabel("hepTopTagCHS", top_jet_infos);
     if (topjet_collection.find("Puppi")!=string::npos) event.getByLabel("hepTopTagPuppi", top_jet_infos); // Make sure both collections have the same size
     if (topjet_collection.find("Hep")!=string::npos) assert(pat_topjets.size()==top_jet_infos->size());
-       
+
+    /*--- lepton keys ---*/
+    std::vector<long int> lepton_keys;
+    if(save_lepton_keys_){
+
+      for(const auto& h_muo : h_muons){
+
+        const auto& muons = uevent.get(h_muo);
+
+        for(const auto& muo : muons){
+          for(const auto& sc : muo.source_candidates()){
+
+            lepton_keys.push_back(sc.key);
+          }
+        }
+      }
+
+      for(const auto& h_ele : h_elecs){
+
+        const auto& elecs = uevent.get(h_ele);
+
+        for(const auto& ele : elecs){
+          for(const auto& sc : ele.source_candidates()){
+
+            lepton_keys.push_back(sc.key);
+          }
+        }
+      }
+    }
+    /*-------------------*/
+
     for (unsigned int i = 0; i < pat_topjets.size(); i++) {
         const pat::Jet & pat_topjet =  pat_topjets[i];
         if(pat_topjet.pt() < ptmin) continue;
@@ -281,6 +390,24 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
            cerr << "Error in fill_jet_info for topjets in NtupleWriterTopJets with src = " << src << "." << endl;
            throw;
         }
+
+        /*--- lepton keys ---*/
+        if(save_lepton_keys_){
+
+          const auto& jet_daughter_ptrs = pat_topjet.daughterPtrVector();
+          for(const auto & daughter_p : jet_daughter_ptrs){
+
+            if(!daughter_p.isAvailable()) continue;
+
+            const auto& key = daughter_p.key();
+
+            if(std::find(lepton_keys.begin(), lepton_keys.end(), key) == lepton_keys.end()) continue;
+
+            topjet.add_lepton_key(key);
+          }
+        }
+        /*-------------------*/
+
         // match a unpruned jet according to topjets_with_cands:
         int i_pat_topjet_wc = -1;
         if(!njettiness_src.empty() || !qjets_src.empty()){
@@ -316,7 +443,7 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
               topjet.set_tag(TopJet::tagname2tag("ptForRoptCalc"), jet_info.properties().ptForRoptCalc);
            }
 
-        /* --- Njettiness -----*/
+        /*--- Njettiness ------*/
         if(njettiness_src.empty()){
 
           topjet.set_tau1(pat_topjet.userFloat("NjettinessAK8:tau1"));
@@ -434,7 +561,24 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
 		cerr << "Error in fill_jet_info for subjets in NtupleWriterTopJets with src = " << src << "." << endl;
 		throw;
 	      }
-	    }
+
+              /*--- lepton keys ---*/
+              if(save_lepton_keys_){
+
+                const auto& jet_daughter_ptrs = tpatsubjet->daughterPtrVector();
+                for(const auto & daughter_p : jet_daughter_ptrs){
+
+                  if(!daughter_p.isAvailable()) continue;
+
+                  const auto& key = daughter_p.key();
+
+                  if(std::find(lepton_keys.begin(), lepton_keys.end(), key) == lepton_keys.end()) continue;
+
+                  subjet.add_lepton_key(key);
+                }
+              }
+              /*-------------------*/
+            }
 	    else{
 	      cerr << "Error in fill_jet_info for subjets in NtupleWriterTopJets with src = " << src << "." << endl;
 	      throw;

--- a/core/plugins/NtupleWriterJets.h
+++ b/core/plugins/NtupleWriterJets.h
@@ -10,10 +10,10 @@ namespace uhh2 {
 
 class NtupleWriterJets: public NtupleWriterModule {
 public:
-
     static void fill_jet_info(const pat::Jet & pat_jet, Jet & jet, bool do_btagging, bool do_taginfo);
 
     explicit NtupleWriterJets(Config & cfg, bool set_jets_member);
+    explicit NtupleWriterJets(Config & cfg, bool set_jets_member, const std::vector<std::string>&, const std::vector<std::string>&);
 
     virtual void process(const edm::Event &, uhh2::Event &);
 
@@ -27,6 +27,10 @@ private:
     float ptmin, etamax;
     Event::Handle<std::vector<Jet>> handle; // main handle to write output to
     boost::optional<Event::Handle<std::vector<Jet>>> jets_handle; // handle of name "jets" in case set_jets_member is true
+
+    bool save_lepton_keys_;
+    std::vector<Event::Handle<std::vector<Muon>    >> h_muons;
+    std::vector<Event::Handle<std::vector<Electron>>> h_elecs;
 };
 
 
@@ -50,6 +54,7 @@ public:
     };
 
     explicit NtupleWriterTopJets(Config & cfg, bool set_jets_member);
+    explicit NtupleWriterTopJets(Config & cfg, bool set_jets_member, const std::vector<std::string>&, const std::vector<std::string>&);
 
     virtual void process(const edm::Event &, uhh2::Event &);
 
@@ -65,6 +70,9 @@ private:
     boost::optional<Event::Handle<std::vector<TopJet>>> topjets_handle;
     std::vector<TopJet::tag> id_tags;
 
+    bool save_lepton_keys_;
+    std::vector<Event::Handle<std::vector<Muon>    >> h_muons;
+    std::vector<Event::Handle<std::vector<Electron>>> h_elecs;
 };
 
 }

--- a/core/plugins/NtupleWriterLeptons.h
+++ b/core/plugins/NtupleWriterLeptons.h
@@ -9,14 +9,15 @@ class NtupleWriterElectrons: public NtupleWriterModule {
 public:
     
     struct Config: public NtupleWriterModule::Config {        
-        std::vector<std::string> id_keys;
+      std::vector<std::string> id_keys;
 
-        // inherit constructor does not work yet :-(
-        Config(uhh2::Context & ctx_, edm::ConsumesCollector && cc_, const edm::InputTag & src_, const std::string & dest_,
-                const std::string & dest_branchname_ = ""): NtupleWriterModule::Config(ctx_, std::move(cc_), src_, dest_, dest_branchname_){}
+      // inherit constructor does not work yet :-(
+      Config(uhh2::Context & ctx_, edm::ConsumesCollector && cc_, const edm::InputTag & src_,
+             const std::string & dest_, const std::string & dest_branchname_ = ""):
+        NtupleWriterModule::Config(ctx_, std::move(cc_), src_, dest_, dest_branchname_) {}
     };
 
-    explicit NtupleWriterElectrons(Config & cfg, bool set_electrons_member);
+    explicit NtupleWriterElectrons(Config & cfg, bool set_electrons_member, const bool save_source_cands=0);
 
     virtual void process(const edm::Event &, uhh2::Event &);
 
@@ -26,20 +27,23 @@ private:
     std::vector<std::string> IDtag_keys;
     Event::Handle<std::vector<Electron>> handle; // main handle to write output to
     boost::optional<Event::Handle<std::vector<Electron>>> electrons_handle; // handle of name "electrons" in case set_electrons_member is true
+
+    bool save_source_candidates_;
 };
 
 class NtupleWriterMuons: public NtupleWriterModule {
 public:
     
-    struct Config: public NtupleWriterModule::Config {        
-        edm::InputTag pv_src;
+    struct Config: public NtupleWriterModule::Config {
+      edm::InputTag pv_src;
 
-        // inherit constructor does not work yet :-(
-        Config(uhh2::Context & ctx_, edm::ConsumesCollector && cc_, const edm::InputTag & src_, const std::string & dest_,
-                const std::string & dest_branchname_ = ""): NtupleWriterModule::Config(ctx_, std::move(cc_), src_, dest_, dest_branchname_){}
+      // inherit constructor does not work yet :-(
+      Config(uhh2::Context & ctx_, edm::ConsumesCollector && cc_, const edm::InputTag & src_,
+             const std::string & dest_, const std::string & dest_branchname_ = ""):
+        NtupleWriterModule::Config(ctx_, std::move(cc_), src_, dest_, dest_branchname_) {}
     };
 
-    explicit NtupleWriterMuons(Config & cfg, bool set_muons_member);
+    explicit NtupleWriterMuons(Config & cfg, bool set_muons_member, const bool save_source_cands=0);
 
     virtual void process(const edm::Event &, uhh2::Event &);
 
@@ -49,6 +53,8 @@ private:
     edm::EDGetToken pv_token;
     Event::Handle<std::vector<Muon>> handle;
     boost::optional<Event::Handle<std::vector<Muon>>> muons_handle;
+
+    bool save_source_candidates_;
 };
 
 class NtupleWriterTaus: public NtupleWriterModule {

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -33,9 +33,12 @@ process.MessageLogger.cerr.FwkReport.reportEvery = cms.untracked.int32(100)
 process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(False) , allowUnscheduled = cms.untracked.bool(True) )
 
 process.source = cms.Source("PoolSource",
-                            fileNames  = cms.untracked.vstring("/store/mc/RunIISpring15MiniAODv2/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/74X_mcRun2_asymptotic_v2-v1/40000/00087FEB-236E-E511-9ACB-003048FF86CA.root"),
-                            #fileNames  = cms.untracked.vstring("/store/data/Run2015D/SingleMuon/MINIAOD/PromptReco-v3/000/256/729/00000/2C0BE722-5960-E511-B834-02163E014421.root"),
-                            skipEvents = cms.untracked.uint32(0)
+  fileNames  = cms.untracked.vstring([
+#    '/store/mc/RunIISpring15MiniAODv2/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/74X_mcRun2_asymptotic_v2-v1/40000/00087FEB-236E-E511-9ACB-003048FF86CA.root',
+#    '/store/data/Run2015D/SingleMuon/MINIAOD/PromptReco-v3/000/256/729/00000/2C0BE722-5960-E511-B834-02163E014421.root',
+    '/store/mc/RunIISpring15MiniAODv2/ZprimeToTT_M-3000_W-30_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/74X_mcRun2_asymptotic_v2-v1/40000/A679787E-496D-E511-AEDF-9CB654AEAE86.root',
+  ]),
+  skipEvents = cms.untracked.uint32(0)
 )
 
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100))
@@ -567,6 +570,9 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
         pv_sources = cms.vstring("offlineSlimmedPrimaryVertices"),
         doRho = cms.untracked.bool(True),
         rho_source = cms.InputTag("fixedGridRhoFastjetAll"),
+
+        save_lepton_keys = cms.bool(True),
+
         doElectrons = cms.bool(True),
         electron_source = cms.InputTag("slimmedElectronsUSER"),
         electron_IDtags = cms.vstring(


### PR DESCRIPTION
* implemented the storage of 'candidate-keys' in leptons and (AK4) jets, in order to be able to apply jet-lepton cleaning by ref-matching at the analysis level
   * added list of source candidates in 'Muon' and 'Electron' collections
   * added list of daughter keys in AK4 Jet collections (only those linked to muons or electrons are kept, to save disk space); also to save disk space, the keys are not kept in TopJet collections and their subjets (the implementation is actually there for 'NtupleWriterTopJets' as well, but it is switched off at the moment)

* this new feature can be switched on/off with the NtupleWriter option "save_lepton_keys" (see ntuplewriter.py)

* based on some small local tests, the output size should increase only by a few percent (between 1% and 3%, depending on the sample); (example) tested on 500 events from Zprime 3TeV MC

| | exec-time/event (s) | output size [MB] |
|:--|--:|--:|
|after update “save_lepton_keys=False” | 0.568 | 10.22 |
|after update “save_lepton_keys=True” | 0.572 | 10.33 |
