### PR TITLE
fix for source_candidate class dictionary in core/

### DIFF
--- a/core/include/Electron.h
+++ b/core/include/Electron.h
@@ -3,6 +3,7 @@
 #include "Particle.h"
 #include "Tags.h"
 #include "FlavorParticle.h"
+#include "source_candidate.h"
 
 #include <vector>
 
@@ -20,15 +21,6 @@ class Electron : public Particle {
 
     throw std::runtime_error("unknown Electron::tag '" + tagname + "'");
   }
-
-  struct source_candidate {
-
-    long int key;
-    float px;
-    float py;
-    float pz;
-    float E;
-  };
 
   Electron(){
 
@@ -111,7 +103,7 @@ class Electron : public Particle {
   float pfMINIIso_NH_pfwgt() const { return m_pfMINIIso_NH_pfwgt; }
   float pfMINIIso_Ph_pfwgt() const { return m_pfMINIIso_Ph_pfwgt; }
 
-  std::vector<source_candidate> source_candidates() const { return m_source_candidates; }
+  const std::vector<source_candidate>& source_candidates() const { return m_source_candidates; }
 
   void set_supercluster_eta(float x){m_supercluster_eta=x;} 
   void set_supercluster_phi(float x){m_supercluster_phi=x;} 
@@ -151,7 +143,8 @@ class Electron : public Particle {
   void set_pfMINIIso_NH_pfwgt(float x){ m_pfMINIIso_NH_pfwgt = x; }
   void set_pfMINIIso_Ph_pfwgt(float x){ m_pfMINIIso_Ph_pfwgt = x; }
 
-  void add_source_candidate(const source_candidate& sc){ m_source_candidates.push_back(sc); }
+  void set_source_candidates(const std::vector<source_candidate>& vsc){ m_source_candidates = vsc; }
+  void add_source_candidate (const source_candidate& sc){ m_source_candidates.push_back(sc); }
 
   bool  has_tag(tag t) const { return tags.has_tag(static_cast<int>(t)); }
   float get_tag(tag t) const { return tags.get_tag(static_cast<int>(t)); }

--- a/core/include/Jet.h
+++ b/core/include/Jet.h
@@ -67,7 +67,7 @@ class Jet : public FlavorParticle {
   JetBTagInfo btaginfo() const{return m_btaginfo;}
   int hadronFlavor() const { return m_hadronFlavor; }
 
-  std::vector<long int> lepton_keys() const { return m_lepton_keys; }
+  const std::vector<long int>& lepton_keys() const { return m_lepton_keys; }
 
   void set_jetArea(float x){m_jetArea=x;}
   void set_numberOfDaughters(int x){m_numberOfDaughters=x;} 
@@ -96,7 +96,8 @@ class Jet : public FlavorParticle {
   void set_btaginfo(JetBTagInfo x){m_btaginfo=x;}
   void set_hadronFlavor(int x){ m_hadronFlavor = x; }
 
-  void add_lepton_key(const long int k){ m_lepton_keys.push_back(k); }
+  void set_lepton_keys(const std::vector<long int>& vlk){ m_lepton_keys = vlk; }
+  void add_lepton_key (const long int k){ m_lepton_keys.push_back(k); }
 
  private:
   float m_jetArea;

--- a/core/include/Muon.h
+++ b/core/include/Muon.h
@@ -2,6 +2,7 @@
 
 #include "Particle.h"
 #include "FlavorParticle.h"
+#include "source_candidate.h"
 
 #include <stdint.h>
 #include <vector>
@@ -27,15 +28,6 @@ class Muon : public Particle {
     if(value) id_bits |=   uint64_t(1) << static_cast<uint64_t>(i);
     else      id_bits &= ~(uint64_t(1) << static_cast<uint64_t>(i));
   }
-
-  struct source_candidate {
-
-    long int key;
-    float px;
-    float py;
-    float pz;
-    float E;
-  };
 
   Muon(){
 
@@ -98,7 +90,7 @@ class Muon : public Particle {
   float pfMINIIso_NH_pfwgt() const { return m_pfMINIIso_NH_pfwgt; }
   float pfMINIIso_Ph_pfwgt() const { return m_pfMINIIso_Ph_pfwgt; }
 
-  std::vector<source_candidate> source_candidates() const { return m_source_candidates; }
+  const std::vector<source_candidate>& source_candidates() const { return m_source_candidates; }
 
   void set_dxy(float x){m_dxy=x;}
   void set_dxy_error(float x){m_dxy_error=x;}
@@ -127,7 +119,8 @@ class Muon : public Particle {
   void set_pfMINIIso_NH_pfwgt(float x){ m_pfMINIIso_NH_pfwgt = x; }
   void set_pfMINIIso_Ph_pfwgt(float x){ m_pfMINIIso_Ph_pfwgt = x; }
 
-  void add_source_candidate(const source_candidate& sc){ m_source_candidates.push_back(sc); }
+  void set_source_candidates(const std::vector<source_candidate>& vsc){ m_source_candidates = vsc; }
+  void add_source_candidate (const source_candidate& sc){ m_source_candidates.push_back(sc); }
 
   bool  has_tag(tag t) const { return tags.has_tag(static_cast<int>(t)); }
   float get_tag(tag t) const { return tags.get_tag(static_cast<int>(t)); }

--- a/core/include/NtupleObjects.h
+++ b/core/include/NtupleObjects.h
@@ -10,4 +10,4 @@
 #include "UHH2/core/include/GenJetWithParts.h"
 #include "UHH2/core/include/GenParticle.h"
 #include "UHH2/core/include/GenTopJet.h"
-
+#include "UHH2/core/include/source_candidate.h"

--- a/core/include/SUHH2core_LinkDef.h
+++ b/core/include/SUHH2core_LinkDef.h
@@ -37,5 +37,7 @@
 #pragma link C++ class GenInfo+;
 #pragma link C++ class GenParticle+;
 #pragma link C++ class std::vector<GenParticle>+;
+#pragma link C++ class source_candidate+;
+#pragma link C++ class std::vector<source_candidate>+;
 
 #endif // __CINT__

--- a/core/include/source_candidate.h
+++ b/core/include/source_candidate.h
@@ -1,0 +1,11 @@
+#pragma once
+
+class source_candidate {
+
+ public:
+  long int key;
+  float px;
+  float py;
+  float pz;
+  float E;
+};

--- a/core/plugins/NtupleWriterLeptons.cxx
+++ b/core/plugins/NtupleWriterLeptons.cxx
@@ -88,7 +88,7 @@ void NtupleWriterElectrons::process(const edm::Event & event, uhh2::Event & ueve
 
             if(!pat_ele.sourceCandidatePtr(s).isAvailable()) continue;
 
-            Electron::source_candidate sc;
+            source_candidate sc;
             sc.key = pat_ele.sourceCandidatePtr(s).key();
             sc.px  = pat_ele.sourceCandidatePtr(s)->px();
             sc.py  = pat_ele.sourceCandidatePtr(s)->py();
@@ -187,7 +187,7 @@ void NtupleWriterMuons::process(const edm::Event & event, uhh2::Event & uevent){
 
          if(!pat_mu.sourceCandidatePtr(s).isAvailable()) continue;
 
-         Muon::source_candidate sc;
+         source_candidate sc;
          sc.key = pat_mu.sourceCandidatePtr(s).key();
          sc.px  = pat_mu.sourceCandidatePtr(s)->px();
          sc.py  = pat_mu.sourceCandidatePtr(s)->py();

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 
-useData = True
+useData = False
 use25ns = True #switch this flag to False when running on 50ns samples
 
 # minimum pt for the large-R jets (applies for all: vanilla CA8/CA15, cmstoptag, heptoptag). Also applied for the corresponding genjets.
@@ -35,8 +35,8 @@ process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(False) , 
 process.source = cms.Source("PoolSource",
   fileNames  = cms.untracked.vstring([
 #    '/store/mc/RunIISpring15MiniAODv2/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/74X_mcRun2_asymptotic_v2-v1/40000/00087FEB-236E-E511-9ACB-003048FF86CA.root',
-    '/store/data/Run2015D/SingleMuon/MINIAOD/PromptReco-v3/000/256/729/00000/2C0BE722-5960-E511-B834-02163E014421.root',
-#    '/store/mc/RunIISpring15MiniAODv2/ZprimeToTT_M-3000_W-30_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/74X_mcRun2_asymptotic_v2-v1/40000/A679787E-496D-E511-AEDF-9CB654AEAE86.root',
+#    '/store/data/Run2015D/SingleMuon/MINIAOD/PromptReco-v3/000/256/729/00000/2C0BE722-5960-E511-B834-02163E014421.root',
+    '/store/mc/RunIISpring15MiniAODv2/ZprimeToTT_M-3000_W-30_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/74X_mcRun2_asymptotic_v2-v1/40000/A679787E-496D-E511-AEDF-9CB654AEAE86.root',
   ]),
   skipEvents = cms.untracked.uint32(0)
 )

--- a/core/src/classes.h
+++ b/core/src/classes.h
@@ -14,6 +14,7 @@
 #include "UHH2/core/include/GenTopJet.h"
 #include "UHH2/core/include/GenInfo.h"
 #include "UHH2/core/include/GenParticle.h"
+#include "UHH2/core/include/source_candidate.h"
 
 #include <vector>
 #include <map>
@@ -50,5 +51,7 @@ namespace {
     GenInfo genInfo;
     GenParticle genp;
     std::vector<GenParticle> genps;
+    source_candidate sc;
+    std::vector<source_candidate> scs;
   }
 }

--- a/core/src/classes_def.xml
+++ b/core/src/classes_def.xml
@@ -29,4 +29,6 @@
 <class name="GenInfo"/>
 <class name="GenParticle"/>
 <class name="std::vector<GenParticle>"/>
+<class name="source_candidate"/>
+<class name="std::vector<source_candidate>"/>
 </lcgdict>


### PR DESCRIPTION
* fix to correctly handle the ROOT dictionary of the 'source_candidate' class
 * removed struct used in Muon and Electron, added it as standalone class with all standard calls for handling dictionaries (e.g. see core/src/classes*)
 * previous dictionary handling (currently in UHH2:RunII_25ns_v2) leads to problems when analyzing ntuples, in some cases: not possible to read ntuples produced with crab (2 and 3), things seem ok using grid-control (not sure why).

* some fixes in Muon, Electron and Jet (pass vector objects by const-ref)
