### PR TITLE
Implement TopJetLepton cleaning and change JetCleaner and TopJetCleaner

### DIFF
--- a/common/include/CleaningModules.h
+++ b/common/include/CleaningModules.h
@@ -13,12 +13,13 @@
 class JetCleaner: public uhh2::AnalysisModule {
 public:
     
-    explicit JetCleaner(const JetId & jet_id);
-    JetCleaner(float minpt, float maxeta);
+    explicit JetCleaner(uhh2::Context & ctx, const JetId & jet_id_, std::string const & label_ = "jets");
+    JetCleaner(uhh2::Context & ctx, float minpt, float maxeta, std::string const & label_ = "jets");
     virtual bool process(uhh2::Event & event) override;
     
 private:
     JetId jet_id;
+    uhh2::Event::Handle<std::vector<Jet>> hndl;
 };
 
 
@@ -93,10 +94,11 @@ private:
 class TopJetCleaner : public uhh2::AnalysisModule {
 public:
 
-    explicit TopJetCleaner(const TopJetId & topjet_id);
+    explicit TopJetCleaner(uhh2::Context & ctx, const TopJetId & jet_id_, std::string const & label_ = "topjets");
     virtual bool process(uhh2::Event & event) override;
 
 private:
     TopJetId topjet_id;
+    uhh2::Event::Handle<std::vector<TopJet>> hndl;
 };
 

--- a/common/include/JetCorrections.h
+++ b/common/include/JetCorrections.h
@@ -192,7 +192,11 @@ private:
  * Can now run on TopJet Collection as well; the class will first check whether a Jet collection with
  * the given label name exists, if not, it will look for a TopJet collection with this name.
  *
- * Default is 'jets' so it will run over the standard Ak4 jet collection
+ * Default is 'jets' so it will run over the standard Ak4 jet collection.
+ *
+ * DISCLAIMER: In case of Ak8 jets, this JetLeptonCleaner only runs over the fat jet itself, not
+ * the subjets of the Ak8 jets! Whether this is necessary and has any effects on subjet-related
+ * quantities might need to be tested in the future.
  */
 class JetLeptonCleaner_by_KEYmatching: public uhh2::AnalysisModule {
 
@@ -210,7 +214,6 @@ class JetLeptonCleaner_by_KEYmatching: public uhh2::AnalysisModule {
  private:
   uhh2::Event::Handle<std::vector<Jet> > h_jets_;
   uhh2::Event::Handle<std::vector<TopJet> > h_topjets_;
-  std::string label_;
   std::unique_ptr<FactorizedJetCorrector> corrector;
   MuonId     muo_id;
   ElectronId ele_id;

--- a/common/include/JetCorrections.h
+++ b/common/include/JetCorrections.h
@@ -189,6 +189,10 @@ private:
 
 /** \brief JetLeptonCleaner using the matching of candidates' keys
  *
+ * Can now run on TopJet Collection as well; the class will first check whether a Jet collection with
+ * the given label name exists, if not, it will look for a TopJet collection with this name.
+ *
+ * Default is 'jets' so it will run over the standard Ak4 jet collection
  */
 class JetLeptonCleaner_by_KEYmatching: public uhh2::AnalysisModule {
 
@@ -197,6 +201,7 @@ class JetLeptonCleaner_by_KEYmatching: public uhh2::AnalysisModule {
   virtual ~JetLeptonCleaner_by_KEYmatching();
 
   virtual bool process(uhh2::Event & event) override;
+  bool do_cleaning(Jet & jet, uhh2::Event & event);
 
   void set_muon_id(const MuonId& muo_id_){ muo_id = muo_id_; }
 
@@ -204,6 +209,8 @@ class JetLeptonCleaner_by_KEYmatching: public uhh2::AnalysisModule {
 
  private:
   uhh2::Event::Handle<std::vector<Jet> > h_jets_;
+  uhh2::Event::Handle<std::vector<TopJet> > h_topjets_;
+  std::string label_;
   std::unique_ptr<FactorizedJetCorrector> corrector;
   MuonId     muo_id;
   ElectronId ele_id;

--- a/common/src/CleaningModules.cxx
+++ b/common/src/CleaningModules.cxx
@@ -7,12 +7,19 @@ using namespace uhh2;
 using namespace std;
 
 
-JetCleaner::JetCleaner(const JetId & jet_id_): jet_id(jet_id_){}
+JetCleaner::JetCleaner(Context & ctx, const JetId & jet_id_, string const & label_):
+    jet_id(jet_id_), hndl(ctx.get_handle<vector<Jet>>(label_)) {}
 
-JetCleaner::JetCleaner(float minpt, float maxeta): jet_id(PtEtaCut(minpt, maxeta)){}
+JetCleaner::JetCleaner(Context & ctx, float minpt, float maxeta, string const & label_):
+    jet_id(PtEtaCut(minpt, maxeta)), hndl(ctx.get_handle<vector<Jet>>(label_)) {}
 
 bool JetCleaner::process(Event & event){
-    clean_collection(*event.jets, event, jet_id);
+    if (!event.is_valid(hndl)) {
+        cerr << "In JetCleaner: Handle not valid!\n";
+        assert(false);
+    }
+    vector<Jet> & jet_collection = event.get(hndl);
+    clean_collection(jet_collection, event, jet_id);
     return true;
 }
 
@@ -50,12 +57,15 @@ bool TauCleaner::process(uhh2::Event & event){
     return true;
 }
 
-
-
-TopJetCleaner::TopJetCleaner(const TopJetId & topjet_id_): topjet_id(topjet_id_){}
+TopJetCleaner::TopJetCleaner(Context & ctx, const TopJetId & topjet_id_, string const & label_):
+    topjet_id(topjet_id_), hndl(ctx.get_handle<vector<TopJet>>(label_)) {}
 
 bool TopJetCleaner::process(uhh2::Event & event){
-    assert(event.topjets);
-    clean_collection(*event.topjets, event, topjet_id);
+    if (!event.is_valid(hndl)) {
+        cerr << "In TopJetCleaner: Handle not valid!\n";
+        assert(false);
+    }
+    vector<TopJet> & topjet_collection = event.get(hndl);
+    clean_collection(topjet_collection, event, topjet_id);
     return true;
 }

--- a/common/src/CommonModules.cxx
+++ b/common/src/CommonModules.cxx
@@ -57,13 +57,13 @@ void CommonModules::init(Context & ctx){
     if(muid)  modules.emplace_back(new MuonCleaner(muid));
     if(tauid) modules.emplace_back(new TauCleaner(tauid));
     if(jetpfidcleaner){
-      modules.emplace_back(new JetCleaner(JetPFID(working_point)));
+      modules.emplace_back(new JetCleaner(ctx, JetPFID(working_point)));
     }
     if(jetlepcleaner) {
       if(is_mc) modules.emplace_back(new JetLeptonCleaner(ctx, JERFiles::Summer15_25ns_L123_AK4PFchs_MC));
       else modules.emplace_back(new JetLeptonCleaner(ctx, JERFiles::Summer15_25ns_L123_AK4PFchs_DATA));
     }
-    if(jetid) modules.emplace_back(new JetCleaner(jetid));
+    if(jetid) modules.emplace_back(new JetCleaner(ctx, jetid));
     modules.emplace_back(new HTCalculator(ctx));
 }
 

--- a/common/src/JetCorrections.cxx
+++ b/common/src/JetCorrections.cxx
@@ -429,7 +429,6 @@ JetLeptonCleaner_by_KEYmatching::JetLeptonCleaner_by_KEYmatching(uhh2::Context& 
 
     h_jets_ = ctx.get_handle<std::vector<Jet>>(jet_label);
     h_topjets_ = ctx.get_handle<std::vector<TopJet>>(jet_label);
-    label_ = jet_label;
     corrector = build_corrector(filenames);
     direction = 0;
     jec_uncertainty = corrector_uncertainty(ctx, filenames, direction) ;
@@ -461,6 +460,8 @@ bool JetLeptonCleaner_by_KEYmatching::do_cleaning(Jet & jet, uhh2::Event& event)
           muo_cand_p4.SetPy(muo_cand.py);
           muo_cand_p4.SetPz(muo_cand.pz);
           muo_cand_p4.SetE (muo_cand.E);
+
+          jet_p4_raw -= muo_cand_p4;
         }
       }
     }
@@ -484,6 +485,8 @@ bool JetLeptonCleaner_by_KEYmatching::do_cleaning(Jet & jet, uhh2::Event& event)
           ele_cand_p4.SetPy(ele_cand.py);
           ele_cand_p4.SetPz(ele_cand.pz);
           ele_cand_p4.SetE (ele_cand.E);
+
+          jet_p4_raw -= ele_cand_p4;
         }
       }
     }

--- a/common/src/JetCorrections.cxx
+++ b/common/src/JetCorrections.cxx
@@ -428,6 +428,8 @@ JetLeptonCleaner::~JetLeptonCleaner(){}
 JetLeptonCleaner_by_KEYmatching::JetLeptonCleaner_by_KEYmatching(uhh2::Context& ctx, const std::vector<std::string> & filenames, const std::string& jet_label){
 
     h_jets_ = ctx.get_handle<std::vector<Jet>>(jet_label);
+    h_topjets_ = ctx.get_handle<std::vector<TopJet>>(jet_label);
+    label_ = jet_label;
     corrector = build_corrector(filenames);
     direction = 0;
     jec_uncertainty = corrector_uncertainty(ctx, filenames, direction) ;
@@ -435,78 +437,98 @@ JetLeptonCleaner_by_KEYmatching::JetLeptonCleaner_by_KEYmatching(uhh2::Context& 
 
 JetLeptonCleaner_by_KEYmatching::~JetLeptonCleaner_by_KEYmatching(){}
 
-bool JetLeptonCleaner_by_KEYmatching::process(uhh2::Event& event){
+bool JetLeptonCleaner_by_KEYmatching::do_cleaning(Jet & jet, uhh2::Event& event) {
+  bool correct_p4(false);
+  auto jet_p4_raw = jet.v4() * jet.JEC_factor_raw();
 
-  auto& jets = event.get(h_jets_);
-
-  for(auto& jet : jets){
-
-    bool correct_p4(false);
-    auto jet_p4_raw = jet.v4() * jet.JEC_factor_raw();
-
-    const auto& jet_lepton_keys = jet.lepton_keys();
+  const auto& jet_lepton_keys = jet.lepton_keys();
 
     // muon-cleaning
-    if(event.muons){
+  if(event.muons){
 
-      for(const auto& muo : *event.muons){
+    for(const auto& muo : *event.muons){
 
-        if(muo_id && !(muo_id(muo, event))) continue;
+      if(muo_id && !(muo_id(muo, event))) continue;
 
-        for(const auto& muo_cand : muo.source_candidates()){
+      for(const auto& muo_cand : muo.source_candidates()){
 
-          if(std::find(jet_lepton_keys.begin(), jet_lepton_keys.end(), muo_cand.key) != jet_lepton_keys.end()){
+        if(std::find(jet_lepton_keys.begin(), jet_lepton_keys.end(), muo_cand.key) != jet_lepton_keys.end()){
 
-            correct_p4 = true;
+          correct_p4 = true;
 
-            LorentzVectorXYZE muo_cand_p4;
-            muo_cand_p4.SetPx(muo_cand.px);
-            muo_cand_p4.SetPy(muo_cand.py);
-            muo_cand_p4.SetPz(muo_cand.pz);
-            muo_cand_p4.SetE (muo_cand.E);
-
-            jet_p4_raw -= muo_cand_p4;
-          }
+          LorentzVectorXYZE muo_cand_p4;
+          muo_cand_p4.SetPx(muo_cand.px);
+          muo_cand_p4.SetPy(muo_cand.py);
+          muo_cand_p4.SetPz(muo_cand.pz);
+          muo_cand_p4.SetE (muo_cand.E);
         }
       }
-    }
-
-    // electron-cleaning
-    if(event.electrons){
-
-      for(const auto& ele : *event.electrons){
-
-        if(ele_id && !(ele_id(ele, event))) continue;
-
-        for(const auto& ele_cand : ele.source_candidates()){
-
-          if(std::find(jet_lepton_keys.begin(), jet_lepton_keys.end(), ele_cand.key) != jet_lepton_keys.end()){
-
-            correct_p4 = true;
-
-            LorentzVectorXYZE ele_cand_p4;
-            ele_cand_p4.SetPx(ele_cand.px);
-            ele_cand_p4.SetPy(ele_cand.py);
-            ele_cand_p4.SetPz(ele_cand.pz);
-            ele_cand_p4.SetE (ele_cand.E);
-
-            jet_p4_raw -= ele_cand_p4;
-          }
-        }
-      }
-    }
-
-    // jet-p4 correction
-    if(correct_p4){
-
-      jet.set_JEC_factor_raw(1.);
-      jet.set_v4(jet_p4_raw);
-
-      correct_jet(*corrector, jet, event, jec_uncertainty, direction);
     }
   }
 
+    // electron-cleaning
+  if(event.electrons){
+
+    for(const auto& ele : *event.electrons){
+
+      if(ele_id && !(ele_id(ele, event))) continue;
+
+      for(const auto& ele_cand : ele.source_candidates()){
+
+        if(std::find(jet_lepton_keys.begin(), jet_lepton_keys.end(), ele_cand.key) != jet_lepton_keys.end()){
+
+          correct_p4 = true;
+
+          LorentzVectorXYZE ele_cand_p4;
+          ele_cand_p4.SetPx(ele_cand.px);
+          ele_cand_p4.SetPy(ele_cand.py);
+          ele_cand_p4.SetPz(ele_cand.pz);
+          ele_cand_p4.SetE (ele_cand.E);
+        }
+      }
+    }
+  }
+
+    // jet-p4 correction
+  if(correct_p4){
+
+    jet.set_JEC_factor_raw(1.);
+    jet.set_v4(jet_p4_raw);
+
+    correct_jet(*corrector, jet, event, jec_uncertainty, direction);
+    return true;
+  }
+  return false;
+}
+
+bool JetLeptonCleaner_by_KEYmatching::process(uhh2::Event& event){
+
+  std::vector<Jet> * jets = NULL;
+  std::vector<TopJet> * topjets = NULL;
+  if (event.is_valid(h_jets_)) {
+    jets = &event.get(h_jets_);
+  } else {
+    assert(event.is_valid(h_topjets_));
+    topjets = &event.get(h_topjets_);
+  }
+
+  if (jets) {
+    for(auto& jet : *jets ){
+      do_cleaning(jet, event);
+    }
+  }
+  else if (topjets) {
+    for(auto& jet : *topjets ){
+      do_cleaning(jet, event);
+    }
+  }
+  else {
+    std::cerr << "Neither jet nor topjet collection found for this name!\n";
+    assert(false);
+  }
+
   return true;
+    
 }
 
 ////

--- a/common/test/TestJetLeptonCleaner.cpp
+++ b/common/test/TestJetLeptonCleaner.cpp
@@ -78,9 +78,9 @@ JetLeptonSubtractionResult DoJetLeptonSubtraction(const Muon & mu, vector<Jet> &
 
 class TestJetLeptonCleaner: public uhh2::AnalysisModule {
 public:
-    explicit TestJetLeptonCleaner(Context &) {
+    explicit TestJetLeptonCleaner(Context & ctx) {
         jet_printer.reset(new JetPrinter("jets", 30.0));
-        jet_cleaner.reset(new JetCleaner(30.0, 2.4));
+        jet_cleaner.reset(new JetCleaner(ctx, 30.0, 2.4));
         muon_printer.reset(new MuonPrinter());
         muon_cleaner.reset(new MuonCleaner(AndId<Muon>(PtEtaCut(30., 2.4), MuonIDTight(), MuonIso(0.12))));
     }

--- a/common/test/TopJetId.cpp
+++ b/common/test/TopJetId.cpp
@@ -13,7 +13,7 @@ using namespace std;
 class TestTopJetId: public uhh2::AnalysisModule {
 public:
     explicit TestTopJetId(Context & ctx) {
-        cleaner = make_unique<TopJetCleaner>(CMSTopTag());
+        cleaner.reset(new TopJetCleaner(ctx, CMSTopTag()));
         all_tops = new TH1D("all_tops", "all_tops", 100, 0, 1000.);
         tagged_tops = new TH1D("tagged_tops", "tagged_tops", 100, 0, 1000.);
         ctx.put("", all_tops);

--- a/common/test/test_JLCkey.cpp
+++ b/common/test/test_JLCkey.cpp
@@ -65,7 +65,7 @@ test_JLCkey::test_JLCkey(uhh2::Context& ctx){
     JEC_AK8 = JERFiles::Summer15_25ns_L123_AK8PFchs_DATA;
   }
 
-  jet_IDcleaner.reset(new JetCleaner(jetID));
+  jet_IDcleaner.reset(new JetCleaner(ctx, jetID));
   jet_corrector.reset(new JetCorrector(ctx,JEC_AK4));
   jetlepton_cleaner1.reset(new JetLeptonCleaner(ctx,JEC_AK4));
   jetlepton_cleaner1->set_drmax(.4);

--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -368,7 +368,7 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
 	std::string topbranch=topjet_sources[j]+"_"+subjet_sources[j];
 	cfg.dest_branchname = topbranch;
 	cfg.dest = topbranch;
-        writer_modules.emplace_back(new NtupleWriterTopJets(cfg, j==0));
+        writer_modules.emplace_back(new NtupleWriterTopJets(cfg, j==0, muon_sources, elec_sources));
 /*
         // switch on lepton-keys storage for TopJet collections
         writer_modules.emplace_back(new NtupleWriterTopJets(cfg, i==0, muon_sources, elec_sources));

--- a/examples/src/ExampleModule.cxx
+++ b/examples/src/ExampleModule.cxx
@@ -65,7 +65,7 @@ ExampleModule::ExampleModule(Context & ctx){
     // TODO: configure common here, e.g. by 
     // calling common->set_*_id or common->disable_*
     common->init(ctx);
-    jetcleaner.reset(new JetCleaner(30.0, 2.4)); 
+    jetcleaner.reset(new JetCleaner(ctx, 30.0, 2.4)); 
     
     // note that the JetCleaner is only kept for the sake of example;
     // instead of constructing a jetcleaner explicitly,

--- a/examples/src/ExampleModule2.cxx
+++ b/examples/src/ExampleModule2.cxx
@@ -53,7 +53,7 @@ ExampleModule2::ExampleModule2(Context & ctx): ele_selection(ctx, "ele"), mu_sel
     eleid = AndId<Electron>(ElectronID_PHYS14_25ns_medium, PtEtaCut(20.0, 2.5));
     
     // clean the objects:
-    modules.emplace_back(new JetCleaner(jet_kinematic));
+    modules.emplace_back(new JetCleaner(ctx, jet_kinematic));
     modules.emplace_back(new MuonCleaner(muid));
     modules.emplace_back(new ElectronCleaner(eleid));
     

--- a/examples/src/ExampleTTbarRec.cxx
+++ b/examples/src/ExampleTTbarRec.cxx
@@ -46,7 +46,7 @@ ExampleTTbarRec::ExampleTTbarRec(Context & ctx): selection(ctx, "selection") {
     muid = AndId<Muon>(MuonIDTight(), PtEtaCut(20.0, 2.4));
     
     // clean the objects:
-    cleanermodules.emplace_back(new JetCleaner(jet_kinematic));
+    cleanermodules.emplace_back(new JetCleaner(ctx, jet_kinematic));
     cleanermodules.emplace_back(new MuonCleaner(muid));
     
     // make the selection, step-by-step. Note that in most cases, no explicit


### PR DESCRIPTION
# Commit 1
* Changed ntuplewriter so that lepton keys will be stored also for TopJets
* Changed  JetLeptonCleaner_by_KEYmatching so that it can also run over TopJets (tested it so that it doesn't break anybody's code)

# Commit 2
* Changed JetCleaner and TopJetCleaner classes so that they can run over arbitrary collections
* Classes in UHH2/common are changed accordingly so that the code compiles, however, users might have to change their private analysis code to account for this change. This simply requires adding ctx in the construcutor of the JetCleaner and TopJetCleaner classes