### PR TITLE
Enabled PU-systematics via CommonModules

### DIFF
--- a/common/include/CommonModules.h
+++ b/common/include/CommonModules.h
@@ -88,7 +88,7 @@ public:
       working_point=working_point_;
     }
     virtual bool process(uhh2::Event & event) override;
-    void init(uhh2::Context & ctx);
+    void init(uhh2::Context & ctx, const std::string & SysType_PU = "central");
 
 private:
     void fail_if_init() const;

--- a/common/src/CommonModules.cxx
+++ b/common/src/CommonModules.cxx
@@ -23,7 +23,7 @@ CommonModules::CommonModules(){
 }
 
 
-void CommonModules::init(Context & ctx){
+void CommonModules::init(Context & ctx, const std::string & SysType_PU){
     if(init_done){
         throw invalid_argument("CommonModules::init called twice!");
     }
@@ -34,7 +34,7 @@ void CommonModules::init(Context & ctx){
     if(pvfilter) modules.emplace_back(new PrimaryVertexCleaner(pvid));
     if(is_mc){
         if(mclumiweight)  modules.emplace_back(new MCLumiWeight(ctx));
-        if(mcpileupreweight) modules.emplace_back(new MCPileupReweight(ctx));
+        if(mcpileupreweight) modules.emplace_back(new MCPileupReweight(ctx,SysType_PU));
         if(jec) modules.emplace_back(new JetCorrector(ctx,JERFiles::Summer15_25ns_L123_AK4PFchs_MC));
         if(jersmear) modules.emplace_back(new JetResolutionSmearer(ctx));
     }


### PR DESCRIPTION
- created a second argument for CommonModules::init to allow applying PU-systematics inside CommonModules
