### PR TITLE
LQTopMu samples and new CSV btag WPs

### DIFF
--- a/common/datasets/RunII_76X_v1/MC_LQToTopMuM1200.xml
+++ b/common/datasets/RunII_76X_v1/MC_LQToTopMuM1200.xml
@@ -1,0 +1,15 @@
+<In FileName="MC_LQToTopMu1200_121_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu1200_122_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu1200_123_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu1200_124_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu1200_125_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu1200_126_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu1200_127_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu1200_128_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu1200_129_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu1200_130_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu1200_131_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu1200_132_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu1200_133_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu1200_134_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu1200_135_Ntuple.root" Lumi="0.0"/>

--- a/common/datasets/RunII_76X_v1/MC_LQToTopMuM1400.xml
+++ b/common/datasets/RunII_76X_v1/MC_LQToTopMuM1400.xml
@@ -1,0 +1,16 @@
+<In FileName="MC_LQToTopMu1400_136_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu1400_137_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu1400_138_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu1400_139_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu1400_140_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu1400_141_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu1400_142_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu1400_143_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu1400_144_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu1400_145_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu1400_146_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu1400_147_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu1400_148_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu1400_149_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu1400_150_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu1400_151_Ntuple.root" Lumi="0.0"/>

--- a/common/datasets/RunII_76X_v1/MC_LQToTopMuM1700.xml
+++ b/common/datasets/RunII_76X_v1/MC_LQToTopMuM1700.xml
@@ -1,0 +1,16 @@
+<In FileName="MC_LQToTopMu1700_152_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu1700_153_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu1700_154_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu1700_155_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu1700_156_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu1700_157_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu1700_158_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu1700_159_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu1700_160_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu1700_161_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu1700_162_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu1700_163_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu1700_164_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu1700_165_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu1700_166_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu1700_167_Ntuple.root" Lumi="0.0"/>

--- a/common/datasets/RunII_76X_v1/MC_LQToTopMuM200.xml
+++ b/common/datasets/RunII_76X_v1/MC_LQToTopMuM200.xml
@@ -1,0 +1,16 @@
+<In FileName="MC_LQToTopMu200_0_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu200_10_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu200_11_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu200_12_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu200_13_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu200_14_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu200_15_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu200_1_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu200_2_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu200_3_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu200_4_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu200_5_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu200_6_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu200_7_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu200_8_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu200_9_Ntuple.root" Lumi="0.0"/>

--- a/common/datasets/RunII_76X_v1/MC_LQToTopMuM2000.xml
+++ b/common/datasets/RunII_76X_v1/MC_LQToTopMuM2000.xml
@@ -1,0 +1,15 @@
+<In FileName="MC_LQToTopMu2000_168_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu2000_169_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu2000_170_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu2000_171_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu2000_172_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu2000_173_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu2000_174_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu2000_175_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu2000_176_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu2000_177_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu2000_178_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu2000_179_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu2000_180_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu2000_181_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu2000_182_Ntuple.root" Lumi="0.0"/>

--- a/common/datasets/RunII_76X_v1/MC_LQToTopMuM300.xml
+++ b/common/datasets/RunII_76X_v1/MC_LQToTopMuM300.xml
@@ -1,0 +1,15 @@
+<In FileName="MC_LQToTopMu300_16_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu300_17_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu300_18_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu300_19_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu300_20_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu300_21_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu300_22_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu300_23_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu300_24_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu300_25_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu300_26_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu300_27_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu300_28_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu300_29_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu300_30_Ntuple.root" Lumi="0.0"/>

--- a/common/datasets/RunII_76X_v1/MC_LQToTopMuM400.xml
+++ b/common/datasets/RunII_76X_v1/MC_LQToTopMuM400.xml
@@ -1,0 +1,15 @@
+<In FileName="MC_LQToTopMu400_31_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu400_32_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu400_33_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu400_34_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu400_35_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu400_36_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu400_37_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu400_38_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu400_39_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu400_40_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu400_41_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu400_42_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu400_43_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu400_44_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu400_45_Ntuple.root" Lumi="0.0"/>

--- a/common/datasets/RunII_76X_v1/MC_LQToTopMuM500.xml
+++ b/common/datasets/RunII_76X_v1/MC_LQToTopMuM500.xml
@@ -1,0 +1,15 @@
+<In FileName="MC_LQToTopMu500_46_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu500_47_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu500_48_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu500_49_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu500_50_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu500_51_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu500_52_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu500_53_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu500_54_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu500_55_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu500_56_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu500_57_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu500_58_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu500_59_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu500_60_Ntuple.root" Lumi="0.0"/>

--- a/common/datasets/RunII_76X_v1/MC_LQToTopMuM600.xml
+++ b/common/datasets/RunII_76X_v1/MC_LQToTopMuM600.xml
@@ -1,0 +1,15 @@
+<In FileName="MC_LQToTopMu600_61_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu600_62_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu600_63_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu600_64_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu600_65_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu600_66_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu600_67_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu600_68_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu600_69_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu600_70_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu600_71_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu600_72_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu600_73_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu600_74_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu600_75_Ntuple.root" Lumi="0.0"/>

--- a/common/datasets/RunII_76X_v1/MC_LQToTopMuM700.xml
+++ b/common/datasets/RunII_76X_v1/MC_LQToTopMuM700.xml
@@ -1,0 +1,15 @@
+<In FileName="MC_LQToTopMu700_76_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu700_77_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu700_78_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu700_79_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu700_80_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu700_81_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu700_82_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu700_83_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu700_84_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu700_85_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu700_86_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu700_87_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu700_88_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu700_89_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu700_90_Ntuple.root" Lumi="0.0"/>

--- a/common/datasets/RunII_76X_v1/MC_LQToTopMuM800.xml
+++ b/common/datasets/RunII_76X_v1/MC_LQToTopMuM800.xml
@@ -1,0 +1,15 @@
+<In FileName="MC_LQToTopMu800_100_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu800_101_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu800_102_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu800_103_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu800_104_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu800_105_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu800_91_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu800_92_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu800_93_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu800_94_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu800_95_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu800_96_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu800_97_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu800_98_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu800_99_Ntuple.root" Lumi="0.0"/>

--- a/common/datasets/RunII_76X_v1/MC_LQToTopMuM900.xml
+++ b/common/datasets/RunII_76X_v1/MC_LQToTopMuM900.xml
@@ -1,0 +1,15 @@
+<In FileName="MC_LQToTopMu900_106_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu900_107_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu900_108_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu900_109_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu900_110_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu900_111_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu900_112_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu900_113_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu900_114_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu900_115_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu900_116_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu900_117_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu900_118_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu900_119_Ntuple.root" Lumi="0.0"/>
+<In FileName="MC_LQToTopMu900_120_Ntuple.root" Lumi="0.0"/>

--- a/common/src/JetIds.cxx
+++ b/common/src/JetIds.cxx
@@ -6,13 +6,13 @@ using namespace uhh2;
 CSVBTag::CSVBTag(wp working_point) {
     switch(working_point){
         case WP_LOOSE:
-            csv_threshold = 0.605f;
+            csv_threshold = 0.460f;
             break;
         case WP_MEDIUM:
-            csv_threshold = 0.890f;
+            csv_threshold = 0.800f;
             break;
         case WP_TIGHT:
-            csv_threshold = 0.970f;
+            csv_threshold = 0.935f;
             break;
         default:
             throw invalid_argument("invalid working point passed to CSVBTag");


### PR DESCRIPTION
- Changed CSVv2 b-tag working points to recommended ones for 76X according to https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation76X
- Added LQTopMu samples
