### PR TITLE
change of default value in BTagScaleFactor

### DIFF
--- a/common/include/MCWeight.h
+++ b/common/include/MCWeight.h
@@ -153,7 +153,7 @@ class MCBTagScaleFactor: public uhh2::AnalysisModule {
                              const std::string & jets_handle_name="jets",
                              const std::string & sysType="central",
                              const std::string & measType_bc="mujets",
-                             const std::string & measType_udsg="comb",
+                             const std::string & measType_udsg="incl",
                              const std::string & xml_param_name="MCBtagEfficiencies",
                              const std::string & weights_name_postfix="");
 


### PR DESCRIPTION
to reduce misunderstandings regarding the issue  "new CSVv2.csv for 76X doesn't work on the 76X branch #403" 
@emanueleusai 