### PR TITLE
fixed electronID-HEEP in common/ElectronIds

### DIFF
--- a/common/include/ElectronIds.h
+++ b/common/include/ElectronIds.h
@@ -254,55 +254,53 @@ namespace ElectronID {
 
 }
 
-
 // --- Electron HEEP ID
 // REF https://twiki.cern.ch/twiki/bin/view/CMS/HEEPElectronIdentificationRun2
 bool Electron_HEEP(const Electron&, const std::string&, const std::string&);
 bool Electron_HEEP(const Electron&, const std::string&, const std::string&, const int);
 
-
-bool ElectronID_HEEP_RunII_25ns(const Electron&, const uhh2::Event& evt);
-
-
+bool ElectronID_HEEP_RunII_25ns(const Electron&, const uhh2::Event&);
 
 namespace ElectronID {
-  const std::unordered_map<std::string, std::unordered_map<std::string, std::unordered_map<std::string, std::vector<float> > > > HEEP_LUT = {
- {"RunII_25ns", {
 
+  const std::unordered_map<std::string, std::unordered_map<std::string, std::unordered_map<std::string, std::vector<float> > > > HEEP_LUT = {
+
+  /** Spring 15 **/
+    {"RunII_25ns", {
       {"barrel", {
-                          /* CMS_WorkPoint_NoIso   */
-        {"Et" , { 35 }},
-        {"|dEtaInSeed|"        , { 0.004  }},
-        {"|dPhiIn|"      , { 0.06 }},
-        {"HoverE coef"     , { 1  }},
-        {"HoverE const"          , { 0.05 }},
-	{"sigmaIEtaIEta"          , { 1e6 }},
-	{"E2x5 over E5x5"          , { 0.94 }},
-	{"E1x5 over E5x5"          , { 0.83 }},
-	{"missingHits"   , { 1 }},
-	{"|dxy|", { 0.02 }},
-       },
+
+        {"Et"            , { 35.   }},
+        {"|dEtaInSeed|"  , { 0.004 }},
+        {"|dPhiIn|"      , { 0.06  }},
+        {"HoverE coef"   , { 1.    }},
+        {"HoverE const"  , { 0.05  }},
+        {"sigmaIEtaIEta" , { 1e6   }},
+        {"E2x5 over E5x5", { 0.94  }},
+        {"E1x5 over E5x5", { 0.83  }},
+        {"missingHits"   , { 1     }},
+        {"|dxy|"         , { 0.02  }},
+	},
       },
 
       {"endcap", {
-	                      /* CMS_WorkPoint_NoIso   */
 
-	  {"Et" , { 35 }},
-	  {"|dEtaInSeed|"        , { 0.006  }},
-	  {"|dPhiIn|"      , { 0.06 }},
-	  {"HoverE coef"     , { 5  }},
-	  {"HoverE const"          , { 0.05 }},
-	  {"sigmaIEtaIEta"          , { 0.03 }},
-	  {"E2x5 over E5x5"          , { -1e6 }},
-	  {"E1x5 over E5x5"          , { -1e6 }},
-	  {"missingHits"   , { 1 }},
-	  {"|dxy|", { 0.05 }},
+        {"Et"            , { 35.   }},
+        {"|dEtaInSeed|"  , { 0.006 }},
+        {"|dPhiIn|"      , { 0.06  }},
+        {"HoverE coef"   , { 5.    }},
+        {"HoverE const"  , { 0.05  }},
+        {"sigmaIEtaIEta" , { 0.03  }},
+        {"E2x5 over E5x5", { -1.   }},
+        {"E1x5 over E5x5", { -1.   }},
+        {"missingHits"   , { 1     }},
+        {"|dxy|"         , { 0.05  }},
        },
-
       },
+
      },
     },
-  /*******************/
+  /***************/
 
   };
+
 }


### PR DESCRIPTION
* bugfix for ElectronID_HEEP in common/ElectronIds
  * absolute value requirement was missing in the "dEtaInSeed" and "dPhiIn" cuts

* code editing (just alignment), no further change intended

* changes transparent to users

* please, if this is ok, cherry-pick to master (does not apply to RunII_25ns_v2)
