### PR TITLE
fix JEC propagation to MET correction

### DIFF
--- a/core/include/Jet.h
+++ b/core/include/Jet.h
@@ -34,6 +34,7 @@ class Jet : public FlavorParticle {
     m_btag_BoostedDoubleSecondaryVertexAK8 = 0;
     m_btag_BoostedDoubleSecondaryVertexCA15 = 0;
     m_JEC_factor_raw = 0;
+    m_JEC_L1factor_raw = 0;
     m_genjet_index = 0;
     m_hadronFlavor = 0;
 
@@ -61,6 +62,7 @@ class Jet : public FlavorParticle {
   float btag_BoostedDoubleSecondaryVertexAK8() const{return m_btag_BoostedDoubleSecondaryVertexAK8;}
   float btag_BoostedDoubleSecondaryVertexCA15() const{return m_btag_BoostedDoubleSecondaryVertexCA15;}
   float JEC_factor_raw() const{return m_JEC_factor_raw;}
+  float JEC_L1factor_raw() const{return m_JEC_L1factor_raw;}
   float get_tag(tag t) const { return tags.get_tag(static_cast<int>(t)); }
   JetBTagInfo btaginfo() const{return m_btaginfo;}
   int hadronFlavor() const { return m_hadronFlavor; }
@@ -88,6 +90,7 @@ class Jet : public FlavorParticle {
   void set_btag_BoostedDoubleSecondaryVertexAK8(float x){m_btag_BoostedDoubleSecondaryVertexAK8=x;}
   void set_btag_BoostedDoubleSecondaryVertexCA15(float x){m_btag_BoostedDoubleSecondaryVertexCA15=x;}
   void set_JEC_factor_raw(float x){m_JEC_factor_raw=x;}
+  void set_JEC_L1factor_raw(float x){m_JEC_L1factor_raw=x;}
   void set_genjet_index(int x){m_genjet_index=x;}
   void set_tag(tag t, float value) { return tags.set_tag(static_cast<int>(t), value); }
   void set_btaginfo(JetBTagInfo x){m_btaginfo=x;}
@@ -118,6 +121,7 @@ class Jet : public FlavorParticle {
   float m_btag_BoostedDoubleSecondaryVertexAK8;
   float m_btag_BoostedDoubleSecondaryVertexCA15;
   float m_JEC_factor_raw;
+  float m_JEC_L1factor_raw;
   int m_genjet_index;
   int m_hadronFlavor;
 

--- a/core/include/MET.h
+++ b/core/include/MET.h
@@ -7,6 +7,8 @@ public:
       m_pt = 0;
       m_phi = 0;
       m_mEtSig = 0;
+      m_uncorr_pt = 0;
+      m_uncorr_phi = 0;
       m_shiftedPx_JetEnUp = 0;
       m_shiftedPx_JetEnDown = 0;
       m_shiftedPx_JetResUp = 0;
@@ -31,6 +33,9 @@ public:
       m_shiftedPy_TauEnDown = 0;
       m_shiftedPy_MuonEnDown = 0;
       m_shiftedPy_MuonEnUp = 0;
+      /* m_corr_x = 0; */
+      /* m_corr_y = 0; */
+      /* //  m_corr_SumEt = 0; */
   }
 
   /// transverse momentum
@@ -39,6 +44,17 @@ public:
    float phi() const{return m_phi;}
    /// transverse momentum significance
    float mEtSig() const{return m_mEtSig;}
+
+   /// uncorrected transverse momentum
+   float uncorr_pt() const{return m_uncorr_pt;}
+   /// uncorrected phi
+   float uncorr_phi() const{return m_uncorr_phi;}
+   /* /// corr in Px */
+   /* float corr_x() const{return m_corr_x;} */
+   /* /// corr in Py */
+   /* float corr_y() const{return m_corr_y;} */
+   /// corr in SumEt
+   //   float corr_SumEt() const{return m_corr_SumEt;}
    
    float shiftedPx_JetEnUp() const{return m_shiftedPx_JetEnUp;}
    
@@ -93,7 +109,17 @@ public:
    void set_phi(float phi){m_phi=phi;}
    /// set transverse momentum significance
    void set_mEtSig(float mEtSig){m_mEtSig=mEtSig;}
-   
+
+   /// set uncorrected transverse momentum
+   void set_uncorr_pt(float pt){m_uncorr_pt=pt;}  
+   /// set uncorrected phi
+   void set_uncorr_phi(float phi){m_uncorr_phi=phi;}
+
+   /* /// set corr in Px, Py, SumEt */
+   /* void set_corr_x(float x){m_corr_x=x;} */
+   /* void set_corr_y(float x){m_corr_y=x;} */
+   /* //   void set_corr_SumEt(float x)(m_corr_SumEt=x;} */
+
    void set_shiftedPx_JetEnUp(float shiftedPx_JetEnUp) {m_shiftedPx_JetEnUp = shiftedPx_JetEnUp;}
    
    void set_shiftedPx_JetEnDown(float shiftedPx_JetEnDown) {m_shiftedPx_JetEnDown = shiftedPx_JetEnDown;}
@@ -149,6 +175,14 @@ public:
       met.SetPhi(m_phi);
       return met;
    }
+
+   /// convert missing transverse energy into 4-vector
+   LorentzVector uncorr_v4(){
+      LorentzVector met(0,0,0,0);
+      met.SetPt(m_uncorr_pt);
+      met.SetPhi(m_uncorr_phi);
+      return met;
+   }
    
 private:
    float m_pt;
@@ -178,4 +212,9 @@ private:
    float m_shiftedPy_TauEnDown;
    float m_shiftedPy_MuonEnDown;
    float m_shiftedPy_MuonEnUp;
+   float m_uncorr_pt;
+   float m_uncorr_phi;
+   /* float m_corr_x; */
+   /* float m_corr_y; */
+   //   float m_corr_SumEt;
 };

--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -460,7 +460,8 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
     for(size_t j=0; j< met_sources.size(); ++j){  
       met_tokens.push_back(consumes<vector<pat::MET>>(met_sources[j]));
       branch(tr, met_sources[j].c_str(), "MET", &met[j]);
-      if (met_sources[j]=="slimmedMETsPuppi") puppi.push_back(true);
+      //      if (met_sources[j]=="slimmedMETsPuppi") puppi.push_back(true);
+      if (met_sources[j]=="slimmedMETsPuppi" || met_sources[j]=="slMETsCHST1") puppi.push_back(true); //Puppi and CHS don't have METUncertainty
       else puppi.push_back(false);
     }
     if(!met_sources.empty()){
@@ -903,10 +904,13 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
          std::cout<< "WARNING: number of METs = " << pat_mets.size() <<", should be 1" << std::endl;
        }
        else{
-         pat::MET pat_met = pat_mets[0];
+	 pat::MET pat_met = pat_mets[0];
          met[j].set_pt(pat_met.pt());
          met[j].set_phi(pat_met.phi());
          met[j].set_mEtSig(pat_met.mEtSig());
+	 met[j].set_uncorr_pt(pat_met.uncorPt());
+	 met[j].set_uncorr_phi(pat_met.uncorPhi());
+	 //	 std::cout<<"MET uncorrPt = "<<pat_met.uncorPt()<<" uncorrPhi = "<<pat_met.uncorPhi()<<" corrPt = "<<pat_met.pt()<<" corrPhi = "<<pat_met.phi()<<std::endl;
          if(!puppi.at(j))
             {
                met[j].set_shiftedPx_JetEnUp(pat_met.shiftedPx(pat::MET::METUncertainty::JetEnUp, pat::MET::METCorrectionLevel::Type1));


### PR DESCRIPTION
add slimmedMETsCHS collection
add uncorrected MET variables
store L1 factor for JEC (needed for MET correction)

Result for JEC application and corresponding MET correction consistent with cms-jet/JMEReferenceTable results.
