### PR TITLE
make autocompletion work in CMSSW_8X

### DIFF
--- a/scripts/crab/DasQuery.py
+++ b/scripts/crab/DasQuery.py
@@ -7,6 +7,7 @@ from das_client import get_data
 
 def autocomplete_Datasets(data):
     result_array =[]
+    os.environ['SSL_CERT_DIR'] = '/etc/grid-security/certificates/'
     for element in data:
         if '*' in element:
             jsondict = get_data('https://cmsweb.cern.ch',"dataset="+element,0,0,0)


### PR DESCRIPTION
The version of OpenSSL changed. Now it does a server verification. The needed certificate is located in the folder in SSL_CERT_DIR