### PR TITLE
Added noRes JERFile for AK8PFCHS jets, small change to LuminosityHists.h

### DIFF
--- a/common/include/JetCorrections.h
+++ b/common/include/JetCorrections.h
@@ -46,6 +46,7 @@ namespace JERFiles {
     extern const std::vector<std::string> Spring16_25ns_L123_AK4PFchs_DATA;
     extern const std::vector<std::string> Spring16_25ns_L123_noRes_AK4PFchs_DATA;
     extern const std::vector<std::string> Spring16_25ns_L123_AK8PFchs_DATA;
+    extern const std::vector<std::string> Spring16_25ns_L123_noRes_AK8PFchs_DATA;
     extern const std::vector<std::string> Spring16_25ns_L23_AK8PFchs_DATA;
     extern const std::vector<std::string> Spring16_25ns_L123_AK4PFPuppi_DATA;
     extern const std::vector<std::string> Spring16_25ns_L123_AK8PFPuppi_DATA;

--- a/common/include/LuminosityHists.h
+++ b/common/include/LuminosityHists.h
@@ -13,6 +13,8 @@ struct run_lumi {
   int run;
   int lumiblock;
 
+  friend bool operator<(const run_lumi &, const run_lumi & rl2);
+
 };
 
 class LuminosityHists: public uhh2::Hists {
@@ -24,8 +26,6 @@ public:
     virtual void fill(const uhh2::Event & ev) override;
     
 private:
-    
-    friend bool operator<(const run_lumi &, const run_lumi & rl2);
     
     // save the upper bin borders of those run/lumi numbers to
     // still include in the bin. Has size = nbins - 1, where

--- a/common/src/JetCorrections.cxx
+++ b/common/src/JetCorrections.cxx
@@ -247,6 +247,12 @@ const std::vector<std::string> JERFiles::Spring16_25ns_L123_AK8PFchs_DATA = {
   "JetMETObjects/data/Spring16_25nsV6_DATA_L2L3Residual_AK8PFchs.txt",
 };
 
+onst std::vector<std::string> JERFiles::Spring16_25ns_L123_noRes_AK8PFchs_DATA = {
+  "JetMETObjects/data/Spring16_25nsV6_DATA_L1FastJet_AK8PFchs.txt",
+  "JetMETObjects/data/Spring16_25nsV6_DATA_L2Relative_AK8PFchs.txt",
+  "JetMETObjects/data/Spring16_25nsV6_DATA_L3Absolute_AK8PFchs.txt",
+};
+
 const std::vector<std::string> JERFiles::Spring16_25ns_L23_AK8PFchs_DATA = {
   "JetMETObjects/data/Spring16_25nsV6_DATA_L2Relative_AK8PFchs.txt",
   "JetMETObjects/data/Spring16_25nsV6_DATA_L3Absolute_AK8PFchs.txt",


### PR DESCRIPTION
- noRes-JERFile for AK8PFCHS jets in order to derive L2Res corrections

- moved operator<(run_lumi, run_lumi) from LuminosityHists class to run_lumi struct