### PR TITLE
Moved JetCleaner in CommonModules after application of JEC, JER & MET-smearing

### DIFF
--- a/common/include/CommonModules.h
+++ b/common/include/CommonModules.h
@@ -7,6 +7,7 @@
 #include "UHH2/common/include/NSelections.h"
 #include "UHH2/common/include/JetIds.h"
 #include "UHH2/common/include/JetCorrections.h"
+#include "UHH2/common/include/CleaningModules.h"
 
 /** \brief Run a configurable list commonly used modules
  *
@@ -106,6 +107,7 @@ private:
     std::unique_ptr<JetCorrector> jet_corrector_MC, jet_corrector_BCD, jet_corrector_EFearly, jet_corrector_FlateG, jet_corrector_H;
     std::unique_ptr<JetLeptonCleaner> JLC_MC, JLC_BCD, JLC_EFearly, JLC_FlateG, JLC_H;
     std::unique_ptr<JetResolutionSmearer> jet_resolution_smearer;
+    std::unique_ptr<JetCleaner> jet_cleaner;
     const int runnr_BCD = 276811;
     const int runnr_EFearly = 278802;
     const int runnr_FlateG = 280385;

--- a/common/src/CommonModules.cxx
+++ b/common/src/CommonModules.cxx
@@ -75,8 +75,8 @@ void CommonModules::init(Context & ctx, const std::string & SysType_PU){
 	JLC_H.reset(new JetLeptonCleaner(ctx, JERFiles::Summer16_23Sep2016_V4_H_L123_AK4PFchs_DATA));
       }
     }
-    if(jetid) modules.emplace_back(new JetCleaner(ctx, jetid));
     modules.emplace_back(new HTCalculator(ctx,HT_jetid));
+    if(jetid) jet_cleaner.reset(new JetCleaner(ctx, jetid));
 }
 
 bool CommonModules::process(uhh2::Event & event){
@@ -129,6 +129,8 @@ bool CommonModules::process(uhh2::Event & event){
       }
     }
     else if(jec || jetlepcleaner) cout <<"WARNING: You used CommonModules for either JEC or jet-lepton-cleaning but MET is not corrected. Please be aware of this." << endl;
+
+    if(jetid) jet_cleaner->process(event);
 
     if(jetptsort){
       sort_by_pt(*event.jets);


### PR DESCRIPTION
- If a JetId is given to CommonModules and it is used to clean the jet collection, the JetCleaner is now applied after applying JEC, JER and MET smearing. 

This only affects people using CommonModules for jet cleaning with kinematic cuts applied. Might change jet and/or MET connected distributions. 