### PR TITLE
Use scram to get inc/lib dirs for Makefiles

### DIFF
--- a/common/Makefile
+++ b/common/Makefile
@@ -1,6 +1,8 @@
 LIBRARY := SUHH2common
 DICT :=  include/ReconstructionHypothesis.h include/SUHH2common_LinkDef.h
-USERCXXFLAGS := -I/cvmfs/cms.cern.ch/slc6_amd64_gcc530/external/lhapdf/6.1.6-ikhhed/include/
+LHAPDFINC=$(shell scram tool tag lhapdf INCLUDE)
+LHAPDFLIB=$(shell scram tool tag lhapdf LIBDIR)
+USERCXXFLAGS := -I${LHAPDFINC}
 TEST := 1
-USERLDFLAGS := -lSUHH2core -lSUHH2JetMETObjects -lMinuit -lGenVector -L/cvmfs/cms.cern.ch/slc6_amd64_gcc530/external/lhapdf/6.1.6-ikhhed/lib -lLHAPDF
+USERLDFLAGS := -lSUHH2core -lSUHH2JetMETObjects -lMinuit -lGenVector -L${LHAPDFLIB} -lLHAPDF
 include ../Makefile.common

--- a/core/Makefile
+++ b/core/Makefile
@@ -1,8 +1,11 @@
 LIBRARY := SUHH2core
 DICT := include/AnalysisModuleRunner.h include/NtupleObjects.h include/SUHH2core_LinkDef.h
 
-USERLDFLAGS := -Wl,-rpath,/afs/desy.de/user/p/peiffer/www/FastJet/lib -lm -L/afs/desy.de/user/p/peiffer/www/FastJet/lib -lfastjettools -lfastjet -lHOTVR -lNsubjettiness -lRecursiveTools
-USERCXXFLAGS := -I/afs/desy.de/user/p/peiffer/www/FastJet/include
+FJINC=$(shell scram tool tag FASTJET INCLUDE)
+FJLIB=$(shell scram tool tag FASTJET LIBDIR)
+
+USERLDFLAGS := -Wl,-rpath,${FJLIB} -lm -L${FJLIB} -lfastjettools -lfastjet -lHOTVR -lNsubjettiness -lRecursiveTools
+USERCXXFLAGS := -I${FJINC}
 
 TEST := 1
 TESTPAR := 1


### PR DESCRIPTION
This uses the `scram tool tag <TOOL> <TAGNAME>` command to retrieve the locations of LHAPDF and FastJet `include`/`lib` dirs. This way the tool location only needs updating in `$CMSSW_BASE/config/toolbox/$SCRAM_ARCH/tools/selected/<TOOL>.xml`, and the Makefiles won't need updating.

This is necessary for both the move to 94X, and for remote deployments e.g. on gitlab