### PR TITLE
Fix fast jet linking [master]

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -27,7 +27,7 @@ git cms-addpkg RecoEgamma
 #sed -i "s|1.020|1.025|g" $CMSSW_BASE/config/toolbox/slc6_amd64_gcc530/tools/selected/fastjet-contrib.xml ## FASTJET-CONTRIB IS PART OF CMSSW 91X
 #sed -i "s|/cvmfs/cms.cern.ch/slc6_amd64_gcc530/external/fastjet-contrib/1.025|/afs/desy.de/user/p/peiffer/www/FastJet|g" ## FASTJET-CONTRIB IS PART OF CMSSW 91X $CMSSW_BASE/config/toolbox/slc6_amd64_gcc530/tools/selected/fastjet-contrib.xml
 sed -i "s|3.1.0|3.2.1|g" $CMSSW_BASE/config/toolbox/slc6_amd64_gcc530/tools/selected/fastjet.xml
-sed -i "s|/cvmfs/cms.cern.ch/slc6_amd64_gcc530/external/fastjet/3.2.1|/afs/desy.de/user/p/peiffer/www/FastJet|g" $CMSSW_BASE/config/toolbox/slc6_amd64_gcc530/tools/selected/fastjet.xml
+sed -i "s|/cvmfs/cms.cern.ch/slc6_amd64_gcc530/external/fastjet/3.2.1|/afs/desy.de/user/a/aggleton/public/fastjet/slc6_amd64_gcc530/fastjet-install|g" $CMSSW_BASE/config/toolbox/slc6_amd64_gcc530/tools/selected/fastjet.xml
 scram b clean
 scram b -j 20
 #cd $CMSSW_BASE/external

--- a/scripts/install_CMSSW8026_withEGReg_UHH.sh
+++ b/scripts/install_CMSSW8026_withEGReg_UHH.sh
@@ -32,9 +32,9 @@ git-cms-addpkg PhysicsTools
 
 sed -i "s|use_common_bge_for_rho_and_rhom|set_common_bge_for_rho_and_rhom|g" $CMSSW_BASE/src/RecoJets/JetProducers/plugins/FastjetJetProducer.cc
 sed -i "s|1.020|1.025|g" $CMSSW_BASE/config/toolbox/slc6_amd64_gcc530/tools/selected/fastjet-contrib.xml
-sed -i "s|/cvmfs/cms.cern.ch/slc6_amd64_gcc530/external/fastjet-contrib/1.025|/afs/desy.de/user/p/peiffer/www/FastJet|g" $CMSSW_BASE/config/toolbox/slc6_amd64_gcc530/tools/selected/fastjet-contrib.xml
+sed -i "s|/cvmfs/cms.cern.ch/slc6_amd64_gcc530/external/fastjet-contrib/1.025|/afs/desy.de/user/a/aggleton/public/fastjet/slc6_amd64_gcc530/fastjet-install|g" $CMSSW_BASE/config/toolbox/slc6_amd64_gcc530/tools/selected/fastjet-contrib.xml
 sed -i "s|3.1.0|3.2.1|g" $CMSSW_BASE/config/toolbox/slc6_amd64_gcc530/tools/selected/fastjet.xml
-sed -i "s|/cvmfs/cms.cern.ch/slc6_amd64_gcc530/external/fastjet/3.2.1|/afs/desy.de/user/p/peiffer/www/FastJet|g" $CMSSW_BASE/config/toolbox/slc6_amd64_gcc530/tools/selected/fastjet.xml
+sed -i "s|/cvmfs/cms.cern.ch/slc6_amd64_gcc530/external/fastjet/3.2.1|/afs/desy.de/user/a/aggleton/public/fastjet/slc6_amd64_gcc530/fastjet-install|g" $CMSSW_BASE/config/toolbox/slc6_amd64_gcc530/tools/selected/fastjet.xml
 scram b clean
 scram b -j 20
 cd $CMSSW_BASE/external


### PR DESCRIPTION
Since they have deleted Thomas' AFS area, we now need to have another FastJet to link against.
We will use one in my AFS for now.

This PR updates the install script (which updates to tool files).

There will be separate PRs for the 80X and 92X branches.

For future, we will get user's to compile their own copy of FastJet to avoid this problem again.
