### PR TITLE
Fix fast jet linking [RunII_80X_v3]

### DIFF
--- a/common/Makefile
+++ b/common/Makefile
@@ -1,6 +1,8 @@
 LIBRARY := SUHH2common
 DICT :=  include/ReconstructionHypothesis.h include/SUHH2common_LinkDef.h
-USERCXXFLAGS := -I/cvmfs/cms.cern.ch/slc6_amd64_gcc530/external/lhapdf/6.1.6-ikhhed/include/
+LHAPDFINC=$(shell scram tool tag lhapdf INCLUDE)
+LHAPDFLIB=$(shell scram tool tag lhapdf LIBDIR)
+USERCXXFLAGS := -I${LHAPDFINC}
 TEST := 1
-USERLDFLAGS := -lSUHH2core -lSUHH2JetMETObjects -lMinuit -lGenVector -L/cvmfs/cms.cern.ch/slc6_amd64_gcc530/external/lhapdf/6.1.6-ikhhed/lib -lLHAPDF
+USERLDFLAGS := -lSUHH2core -lSUHH2JetMETObjects -lMinuit -lGenVector -L${LHAPDFLIB} -lLHAPDF
 include ../Makefile.common

--- a/core/Makefile
+++ b/core/Makefile
@@ -1,8 +1,11 @@
 LIBRARY := SUHH2core
 DICT := include/AnalysisModuleRunner.h include/NtupleObjects.h include/SUHH2core_LinkDef.h
 
-USERLDFLAGS := -Wl,-rpath,/afs/desy.de/user/p/peiffer/www/FastJet/lib -lm -L/afs/desy.de/user/p/peiffer/www/FastJet/lib -lfastjettools -lfastjet -lHOTVR -lNsubjettiness -lRecursiveTools
-USERCXXFLAGS := -I/afs/desy.de/user/p/peiffer/www/FastJet/include
+FJINC=$(shell scram tool tag FASTJET INCLUDE)
+FJLIB=$(shell scram tool tag FASTJET LIBDIR)
+
+USERLDFLAGS := -Wl,-rpath,${FJLIB} -lm -L${FJLIB} -lfastjettools -lfastjet -lHOTVR -lNsubjettiness -lRecursiveTools
+USERCXXFLAGS := -I${FJINC}
 
 TEST := 1
 TESTPAR := 1

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -21,9 +21,11 @@ git-cms-addpkg PhysicsTools
 
 sed -i "s|use_common_bge_for_rho_and_rhom|set_common_bge_for_rho_and_rhom|g" RecoJets/JetProducers/plugins/FastjetJetProducer.cc
 sed -i "s|1.020|1.025|g" $CMSSW_BASE/config/toolbox/slc6_amd64_gcc530/tools/selected/fastjet-contrib.xml
-sed -i "s|/cvmfs/cms.cern.ch/slc6_amd64_gcc530/external/fastjet-contrib/1.025|/afs/desy.de/user/p/peiffer/www/FastJet|g" $CMSSW_BASE/config/toolbox/slc6_amd64_gcc530/tools/selected/fastjet-contrib.xml
+sed -i "s|/cvmfs/cms.cern.ch/slc6_amd64_gcc530/external/fastjet-contrib/1.025|/afs/desy.de/user/a/aggleton/public/fastjet/slc6_amd64_gcc530/fastjet-install|g" $CMSSW_BASE/config/toolbox/slc6_amd64_gcc530/tools/selected/fastjet-contrib.xml
+sed -i "s|1.020|1.025|g" $CMSSW_BASE/config/toolbox/slc6_amd64_gcc530/tools/selected/fastjet-contrib-archive.xml
+sed -i "s|/cvmfs/cms.cern.ch/slc6_amd64_gcc530/external/fastjet-contrib/1.025|/afs/desy.de/user/a/aggleton/public/fastjet/slc6_amd64_gcc530/fastjet-install|g" $CMSSW_BASE/config/toolbox/slc6_amd64_gcc530/tools/selected/fastjet-contrib-archive.xml
 sed -i "s|3.1.0|3.2.1|g" $CMSSW_BASE/config/toolbox/slc6_amd64_gcc530/tools/selected/fastjet.xml
-sed -i "s|/cvmfs/cms.cern.ch/slc6_amd64_gcc530/external/fastjet/3.2.1|/afs/desy.de/user/p/peiffer/www/FastJet|g" $CMSSW_BASE/config/toolbox/slc6_amd64_gcc530/tools/selected/fastjet.xml
+sed -i "s|/cvmfs/cms.cern.ch/slc6_amd64_gcc530/external/fastjet/3.2.1|/afs/desy.de/user/a/aggleton/public/fastjet/slc6_amd64_gcc530/fastjet-install|g" $CMSSW_BASE/config/toolbox/slc6_amd64_gcc530/tools/selected/fastjet.xml
 scram b clean
 scram b -j 20
 cd $CMSSW_BASE/external

--- a/scripts/install_CMSSW8026_withEGReg_UHH.sh
+++ b/scripts/install_CMSSW8026_withEGReg_UHH.sh
@@ -32,9 +32,11 @@ git-cms-addpkg PhysicsTools
 
 sed -i "s|use_common_bge_for_rho_and_rhom|set_common_bge_for_rho_and_rhom|g" $CMSSW_BASE/src/RecoJets/JetProducers/plugins/FastjetJetProducer.cc
 sed -i "s|1.020|1.025|g" $CMSSW_BASE/config/toolbox/slc6_amd64_gcc530/tools/selected/fastjet-contrib.xml
-sed -i "s|/cvmfs/cms.cern.ch/slc6_amd64_gcc530/external/fastjet-contrib/1.025|/afs/desy.de/user/p/peiffer/www/FastJet|g" $CMSSW_BASE/config/toolbox/slc6_amd64_gcc530/tools/selected/fastjet-contrib.xml
+sed -i "s|/cvmfs/cms.cern.ch/slc6_amd64_gcc530/external/fastjet-contrib/1.025|/afs/desy.de/user/a/aggleton/public/fastjet/slc6_amd64_gcc530/fastjet-install|g" $CMSSW_BASE/config/toolbox/slc6_amd64_gcc530/tools/selected/fastjet-contrib.xml
+sed -i "s|1.020|1.025|g" $CMSSW_BASE/config/toolbox/slc6_amd64_gcc530/tools/selected/fastjet-contrib-archive.xml
+sed -i "s|/cvmfs/cms.cern.ch/slc6_amd64_gcc530/external/fastjet-contrib/1.025|/afs/desy.de/user/a/aggleton/public/fastjet/slc6_amd64_gcc530/fastjet-install|g" $CMSSW_BASE/config/toolbox/slc6_amd64_gcc530/tools/selected/fastjet-contrib-archive.xml
 sed -i "s|3.1.0|3.2.1|g" $CMSSW_BASE/config/toolbox/slc6_amd64_gcc530/tools/selected/fastjet.xml
-sed -i "s|/cvmfs/cms.cern.ch/slc6_amd64_gcc530/external/fastjet/3.2.1|/afs/desy.de/user/p/peiffer/www/FastJet|g" $CMSSW_BASE/config/toolbox/slc6_amd64_gcc530/tools/selected/fastjet.xml
+sed -i "s|/cvmfs/cms.cern.ch/slc6_amd64_gcc530/external/fastjet/3.2.1|/afs/desy.de/user/a/aggleton/public/fastjet/slc6_amd64_gcc530/fastjet-install|g" $CMSSW_BASE/config/toolbox/slc6_amd64_gcc530/tools/selected/fastjet.xml
 scram b clean
 scram b -j 20
 cd $CMSSW_BASE/external


### PR DESCRIPTION
Since they have deleted Thomas' AFS area, we now need to have another FastJet to link against.
We will use one in my AFS for now.

This PR updates the install script (which updates to tool files), and backports #784 to ensure no hard-coded paths in Makefiles