### PR TITLE
Comment out FastJet libs to fix compilation

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -1,11 +1,11 @@
 LIBRARY := SUHH2core
 DICT := include/AnalysisModuleRunner.h include/NtupleObjects.h include/SUHH2core_LinkDef.h
 
-FJINC=$(shell scram tool tag FASTJET INCLUDE)
-FJLIB=$(shell scram tool tag FASTJET LIBDIR)
+#FJINC=$(shell scram tool tag FASTJET INCLUDE)
+#FJLIB=$(shell scram tool tag FASTJET LIBDIR)
 
-USERLDFLAGS := -Wl,-rpath,${FJLIB} -lm -L${FJLIB} -lfastjettools -lfastjet -lHOTVR -lNsubjettiness -lRecursiveTools
-USERCXXFLAGS := -I${FJINC}
+#USERLDFLAGS := -Wl,-rpath,${FJLIB} -lm -L${FJLIB} -lfastjettools -lfastjet -lHOTVR -lNsubjettiness -lRecursiveTools
+#USERCXXFLAGS := -I${FJINC}
 
 TEST := 1
 TESTPAR := 1


### PR DESCRIPTION
This should fix the compilation failing:

```
creating /nfs/dust/cms/user/karavdia/SFrame_94X_v1/lib/libSUHH2core.so
/cvmfs/cms.cern.ch/slc6_amd64_gcc630/external/gcc/6.3.0/bin/../lib/gcc/x86_64-unknown-linux-gnu/6.3.0/../../../../x86_64-unknown-linux-gnu/bin/ld: cannot find -lHOTVR
/cvmfs/cms.cern.ch/slc6_amd64_gcc630/external/gcc/6.3.0/bin/../lib/gcc/x86_64-unknown-linux-gnu/6.3.0/../../../../x86_64-unknown-linux-gnu/bin/ld: cannot find -lNsubjettiness
/cvmfs/cms.cern.ch/slc6_amd64_gcc630/external/gcc/6.3.0/bin/../lib/gcc/x86_64-unknown-linux-gnu/6.3.0/../../../../x86_64-unknown-linux-gnu/bin/ld: cannot find -lRecursiveTools
collect2: error: ld returned 1 exit status
../Makefile.common:72: recipe for target '/nfs/dust/cms/user/karavdia/SFrame_94X_v1/lib/libSUHH2core.so' failed
make[1]: *** [/nfs/dust/cms/user/karavdia/SFrame_94X_v1/lib/libSUHH2core.so] Error 1
make[1]: Leaving directory '/nfs/dust/cms/user/karavdia/CMSSW_9_4_1/src/UHH2/core'
Makefile:14: recipe for target 'sframe' failed
make: *** [sframe] Error 1
```

These are only needed for HOTVR/XCONE, so we can re-enable them when all that is fixed.