### PR TITLE
[94X] Cleanup some of the warnings

### DIFF
--- a/common/include/BTagCalibrationStandalone.h
+++ b/common/include/BTagCalibrationStandalone.h
@@ -158,7 +158,7 @@ public:
   BTagCalibrationReader();
   BTagCalibrationReader(BTagEntry::OperatingPoint op,
                         std::string sysType="central");
-
+  ~BTagCalibrationReader();
   void load(const BTagCalibration & c,
             BTagEntry::JetFlavor jf,
             std::string measurementType="comb");
@@ -174,7 +174,7 @@ public:
 
 protected:
   class BTagCalibrationReaderImpl;
-  std::auto_ptr<BTagCalibrationReaderImpl> pimpl;
+  std::unique_ptr<BTagCalibrationReaderImpl> pimpl;
 };
 
 #endif  // BTagCalibrationReader_H

--- a/common/include/PDFWeights.h
+++ b/common/include/PDFWeights.h
@@ -1,7 +1,17 @@
 #ifndef PDFWeights_H
 #define PDFWeights_H
 
+// save diagnostic state
+#pragma GCC diagnostic push
+// turn off the specific warning. Can also use "-Wall"
+#pragma GCC diagnostic ignored "-Wignored-qualifiers"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+
 #include "LHAPDF/LHAPDF.h"
+
+// turn the warnings back on
+#pragma GCC diagnostic pop
+
 #include "TSystem.h"
 #include "UHH2/core/include/Event.h"
 

--- a/common/src/BTagCalibrationStandalone.cc
+++ b/common/src/BTagCalibrationStandalone.cc
@@ -533,7 +533,9 @@ std::pair<float, float> BTagCalibrationReader::BTagCalibrationReaderImpl::min_ma
 
 BTagCalibrationReader::BTagCalibrationReader(BTagEntry::OperatingPoint op,
                                              std::string sysType):
-  pimpl(new BTagCalibrationReaderImpl(op, sysType)) {}
+  pimpl(std::make_unique<BTagCalibrationReaderImpl>(op, sysType)) {}
+
+BTagCalibrationReader::~BTagCalibrationReader() = default;
 
 void BTagCalibrationReader::load(const BTagCalibration & c,
                                  BTagEntry::JetFlavor jf,

--- a/common/test/test.cxx
+++ b/common/test/test.cxx
@@ -1,2 +1,11 @@
 #define BOOST_TEST_MODULE master
+
+// save diagnostic state
+#pragma GCC diagnostic push
+// turn off the specific warning. Can also use "-Wall"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+
 #include <boost/test/included/unit_test.hpp>
+
+// turn the warnings back on
+#pragma GCC diagnostic pop

--- a/core/test/test.cxx
+++ b/core/test/test.cxx
@@ -1,2 +1,11 @@
 #define BOOST_TEST_MODULE master
+
+// save diagnostic state
+#pragma GCC diagnostic push
+// turn off the specific warning. Can also use "-Wall"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+
 #include <boost/test/included/unit_test.hpp>
+
+// turn the warnings back on
+#pragma GCC diagnostic pop


### PR DESCRIPTION
This cleans up some of the compiler warnings that muddy the output making it hard to spot proper errors. Specifically, it addresses:

- `common/include/BTagCalibrationStandalone.h:177:8: warning: 'template<class> class std::auto_ptr' is deprecated` -> converted the pimpl from `auto_ptr` to `unique_ptr`, requires specifying dtor
- The many warnings from `/cvmfs/cms.cern.ch/slc6_amd64_gcc630/external/boost/1.63.0-fmblme/include/boost/test/impl/junit_log_formatter.ipp` - just ignore these with some preprocessor voodoo, since we can't do anything about them
- Variety of warnings from LHAPDF (`warning: unused parameter 'sep'`, `warning: type qualifiers ignored on function return type`), again just ignore these ones

However, there are still some remaining:

- `src/JetCorrections.cxx:1214:155: warning: unused parameter 'allow_met_smearing'`
- `common/include/JetCorrections.h:388:117: warning: unused parameter 'met'`
- `JetMETObjects/interface/Workarounds.h:24:47: warning: throw will always call terminate()`
- Several from SFrame: `include/AnalysisModuleRunner.h`

