### PR TITLE
[94X] Fix patJetsAK8PF[CHS|PUPPI] jets in data

### DIFF
--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -638,13 +638,36 @@ addJetCollection(process, labelName='AK8PFPUPPI', jetSource=cms.InputTag('ak8Pup
                  svSource=cms.InputTag('slimmedSecondaryVertices'),
                  muSource=cms.InputTag('slimmedMuons'),
                  elSource=cms.InputTag('slimmedElectrons')
+                 getJetMCFlavour=(not useData)
                  )
+# manually override parton & genjet matching even though we set getJetMCFlavour false...
+if useData:
+    producer = getattr(process,'patJetsAK8PFPUPPI')
+    producer.addGenPartonMatch = cms.bool(False)
+    producer.embedGenJetMatch = cms.bool(False)
+    producer.embedGenPartonMatch = cms.bool(False)
+    producer.genJetMatch = cms.InputTag("")
+    producer.genPartonMatch = cms.InputTag("")
+    producer.getJetMCFlavour = cms.bool(False)
+    producer.JetFlavourInfoSource = cms.InputTag("")
+
 addJetCollection(process, labelName='AK8PFCHS', jetSource=cms.InputTag('ak8CHSJets'), algo='AK', rParam=0.8, genJetCollection=cms.InputTag('slimmedGenJetsAK8'), jetCorrections=('AK8PFchs', ['L1FastJet', 'L2Relative', 'L3Absolute'], 'None'), pfCandidates=cms.InputTag('packedPFCandidates'),
                  pvSource=cms.InputTag('offlineSlimmedPrimaryVertices'),
                  svSource=cms.InputTag('slimmedSecondaryVertices'),
                  muSource=cms.InputTag('slimmedMuons'),
                  elSource=cms.InputTag('slimmedElectrons')
+                 getJetMCFlavour=(not useData)
                  )
+if useData:
+    producer = getattr(process,'patJetsAK8PFCHS')
+    producer.addGenPartonMatch = cms.bool(False)
+    producer.embedGenJetMatch = cms.bool(False)
+    producer.embedGenPartonMatch = cms.bool(False)
+    producer.genJetMatch = cms.InputTag("")
+    producer.genPartonMatch = cms.InputTag("")
+    producer.getJetMCFlavour = cms.bool(False)
+    producer.JetFlavourInfoSource = cms.InputTag("")
+
 
 # Higgs tagging commissioning
 

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -921,9 +921,9 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
 
                                 doJets=cms.bool(True),
                                 #jet_sources = cms.vstring("patJetsAk4PFCHS", "patJetsAk8PFCHS", "patJetsCa15CHSJets", "patJetsCa8CHSJets", "patJetsCa15PuppiJets", "patJetsCa8PuppiJets"),
-                                jet_sources=cms.vstring(
-                                    "slimmedJets", "slimmedJetsPuppi"),
-                                #jet_sources = cms.vstring("slimmedJets","slimmedJetsPuppi","patJetsAK8PFPUPPI","patJetsAK8PFCHS"),
+                                #jet_sources=cms.vstring(
+                                #    "slimmedJets", "slimmedJetsPuppi"),
+                                jet_sources = cms.vstring("slimmedJets","slimmedJetsPuppi","patJetsAK8PFPUPPI","patJetsAK8PFCHS"),
                                 jet_ptmin=cms.double(10.0),
                                 jet_etamax=cms.double(999.0),
 


### PR DESCRIPTION
`addJetCollection()` is used to add in reguler, ungroomed AK8PFCHS and AK8PFPUPPI jets with lower pT thresholds. However it has no argument to turn off genParton matching, only to turn off `getJetMCFlavour`, so it breaks when running on data. This fixes that so we can store them as before (taken from ntuplewriter.py in 92X branch)
  