### PR TITLE
[94X] Install SFrame in main install.sh script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,8 +6,11 @@
 #
 # before running this script
 
-
 source /cvmfs/cms.cern.ch/cmsset_default.sh
+
+# Get SFrame, do not compile it until we have the right ROOT etc
+git clone https://github.com/UHH2/SFrame.git
+
 export SCRAM_ARCH=slc6_amd64_gcc630
 eval `cmsrel CMSSW_9_4_1`
 cd CMSSW_9_4_1/src

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,6 +11,7 @@ source /cvmfs/cms.cern.ch/cmsset_default.sh
 # Get SFrame, do not compile it until we have the right ROOT etc
 git clone https://github.com/UHH2/SFrame.git
 
+# Get CMSSW
 export SCRAM_ARCH=slc6_amd64_gcc630
 eval `cmsrel CMSSW_9_4_1`
 cd CMSSW_9_4_1/src
@@ -33,6 +34,8 @@ git cms-merge-topic lsoffi:CMSSW_9_4_0_pre3_TnP
 
 #scram b clean
 scram b -j 20
+
+# Get the UHH2 repo & JEC files
 cd $CMSSW_BASE/src
 git clone -b RunII_94X_v1 https://github.com/UHH2/UHH2.git
 cd UHH2


### PR DESCRIPTION
This adds checking out of SFrame to the `install.sh` script. This simplifies things for users, and enforces 1 SFrame per 1 UHH2 deployment as good practice. 

It is set up such that wherever the user runs `install.sh` it will put SFrame and CMSSW there (i.e. not nested)

I've also switched to the GitHub source of SFrame (https://github.com/UHH2/SFrame), to allow further developments if necessary, and incase the SVN link one day breaks. Note that the HEAD of the SFrame master branch is the exact same as the `SFrame-04-00-01` tag used before, so there should be 0 difference.

I'll add another PR to backport this to master as well for future.