### PR TITLE
[94X] Re-enable HOTVR & XCONE, + user FastJet

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -1,11 +1,11 @@
 LIBRARY := SUHH2core
 DICT := include/AnalysisModuleRunner.h include/NtupleObjects.h include/SUHH2core_LinkDef.h
 
-#FJINC=$(shell scram tool tag FASTJET INCLUDE)
-#FJLIB=$(shell scram tool tag FASTJET LIBDIR)
+FJINC=$(shell scram tool tag FASTJET INCLUDE)
+FJLIB=$(shell scram tool tag FASTJET LIBDIR)
 
-#USERLDFLAGS := -Wl,-rpath,${FJLIB} -lm -L${FJLIB} -lfastjettools -lfastjet -lHOTVR -lNsubjettiness -lRecursiveTools
-#USERCXXFLAGS := -I${FJINC}
+USERLDFLAGS := -Wl,-rpath,${FJLIB} -lm -L${FJLIB} -lfastjettools -lfastjet -lHOTVR -lNsubjettiness -lRecursiveTools
+USERCXXFLAGS := -I${FJINC}
 
 TEST := 1
 TESTPAR := 1

--- a/core/include/UniversalGenJetCluster.h
+++ b/core/include/UniversalGenJetCluster.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "UHH2/core/include/AnalysisModule.h"
+#include "UHH2/core/include/Event.h"
+#include "UHH2/core/include/Particle.h"
+#include "UHH2/core/include/GenParticle.h"
+#include "UHH2/core/include/GenTopJet.h"
+
+#include "fastjet/ClusterSequence.hh"
+#include "fastjet/contrib/HOTVR.hh"
+#include "fastjet/contrib/HOTVRinfo.hh"
+#include "fastjet/contrib/XConePlugin.hh"
+#include "fastjet/contrib/SoftDrop.hh"
+
+#include "vector"
+
+class UniversalGenJetCluster
+{
+ public:
+
+  UniversalGenJetCluster(std::vector<GenParticle> *genparticles);
+
+  // getter
+  std::vector<GenTopJet> GetHOTVRTopJets();
+  std::vector<GenTopJet> GetXCone23Jets();
+  std::vector<GenTopJet> GetXCone33Jets();
+  std::vector<GenTopJet> GetXCone33Jets_softdrop();
+
+ private:
+  std::vector<fastjet::PseudoJet> _psj;
+  std::vector<GenTopJet> _hotvrGenTopJets;
+  std::vector<GenTopJet> _xcone23TopJets;
+  std::vector<GenTopJet> _xcone33TopJets;
+  std::vector<GenTopJet> _xcone33TopJets_softdrop;
+  GenParticle _lepton;
+  bool _lep_found;
+
+  //  fastjet::PseudoJet ConvertGenToPsj(GenParticle * genp);
+  fastjet::PseudoJet ConvertGenToPsj(const GenParticle & genp); //TEST
+  Particle ConvertPsjToParticle(const fastjet::PseudoJet & psj);
+  GenTopJet ConvertPsjToGenTopJet(const fastjet::PseudoJet & psj, const std::vector<fastjet::PseudoJet> & subpsj);
+
+  void ClusterHOTVR();
+  void ClusterXCone23();
+  void ClusterXCone33();
+
+};

--- a/core/include/UniversalJetCluster.h
+++ b/core/include/UniversalJetCluster.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "UHH2/core/include/AnalysisModule.h"
+#include "UHH2/core/include/Event.h"
+#include "UHH2/core/include/GenParticle.h"
+#include "UHH2/core/include/Jet.h"
+#include "UHH2/core/include/TopJet.h"
+
+#include "fastjet/ClusterSequence.hh"
+#include "fastjet/ClusterSequenceArea.hh"
+#include "fastjet/contrib/HOTVR.hh"
+#include "fastjet/contrib/HOTVRinfo.hh"
+#include "fastjet/contrib/Nsubjettiness.hh"
+#include "fastjet/contrib/XConePlugin.hh"
+#include "fastjet/contrib/SoftDrop.hh"
+
+#include "vector"
+//#include <fstream>
+
+/*
+ * UniversalJetCluster implements a tool for clustering XCone and HOTVR Jets
+ */
+class UniversalJetCluster
+{
+ public:
+
+  UniversalJetCluster(std::vector<PFParticle> *pfparticles, bool, bool);
+
+  // getter
+  std::vector<TopJet> GetHOTVRTopJets();
+  std::vector<TopJet> GetXCone33Jets();
+
+ private:
+  std::vector<fastjet::PseudoJet> _psj;
+  std::vector<TopJet> _hotvrTopJets;
+  std::vector<TopJet> _xcone33TopJets;
+
+  fastjet::PseudoJet ConvertPFToPsj(const PFParticle & pfp);
+  Jet ConvertPsjToJet(const fastjet::PseudoJet & psj, double jet_area);
+  Jet ConvertPsjToJet(const fastjet::PseudoJet & psj);
+  TopJet ConvertPsjToTopJet(const fastjet::PseudoJet & psj, const std::vector<fastjet::PseudoJet> & subpsj, double tau1, double tau2, double tau3, double jet_area, std::vector<double> subjet_area);
+  TopJet ConvertPsjToTopJet(const fastjet::PseudoJet & psj, const std::vector<fastjet::PseudoJet> &subpsj, double jet_area, std::vector<double> subjet_area, float sd_mass);
+
+  void ClusterHOTVR();
+  void ClusterXCone33();
+};

--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -1283,7 +1283,6 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
    print_times(timer, "trigger");
 
    // ------------- HOTVR and XCone Jets  -------------
-   /* Disable HOTVR/XCone until FastJet mismatch can be solved
    if(doHOTVR || doXCone)
      {
        // get PFParticles
@@ -1353,7 +1352,6 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
          }
        print_times(timer, "genHOTVR");
      }
-   */
 
    // * done filling the event; call the AnalysisModule if configured:
    bool keep = true;

--- a/core/plugins/NtupleWriter.h
+++ b/core/plugins/NtupleWriter.h
@@ -20,8 +20,8 @@
 #include <memory>
 
 // Jet Cluster for HOTVR & XCone by Alex and Dennis
-//#include "UHH2/core/include/UniversalJetCluster.h"
-//#include "UHH2/core/include/UniversalGenJetCluster.h"
+#include "UHH2/core/include/UniversalJetCluster.h"
+#include "UHH2/core/include/UniversalGenJetCluster.h"
 
 namespace uhh2 {
     class CMSSWContext;

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -1251,8 +1251,8 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
                                 pf_collection_source=cms.InputTag("packedPFCandidates"),
 
                                 # *** HOTVR & XCone stuff
-                                doHOTVR=cms.bool(False),
-                                doXCone=cms.bool(False),
+                                doHOTVR=cms.bool(True),
+                                doXCone=cms.bool(True),
                                 doGenHOTVR=cms.bool(not useData),
                                 doGenXCone=cms.bool(not useData),
 )

--- a/core/src/UniversalGenJetCluster.cxx
+++ b/core/src/UniversalGenJetCluster.cxx
@@ -1,0 +1,273 @@
+#include "UHH2/core/include/UniversalGenJetCluster.h"
+
+using namespace std;
+using namespace uhh2;
+using namespace fastjet;
+using namespace contrib;
+
+UniversalGenJetCluster::UniversalGenJetCluster(vector<GenParticle> *genparticles)
+{
+  // get stable particles and identify primary lepton for xcone23jets
+  double pt_max = 0;
+  GenParticle lepton;
+  for(unsigned int i = 0; i < genparticles->size(); ++i) 
+    {
+      //      _psj.push_back(ConvertGenToPsj(&(genparticles->at(i))));
+      _psj.push_back(ConvertGenToPsj(genparticles->at(i))); //TEST
+      if(abs(genparticles->at(i).pdgId()==11) || abs(genparticles->at(i).pdgId()==13)){
+	if(genparticles->at(i).v4().Pt() > pt_max){
+	  pt_max = genparticles->at(i).v4().Pt();
+	  lepton = genparticles->at(i);
+	}
+      }
+    }
+  _lepton = lepton;
+  if(pt_max == 0) _lep_found = false;
+  else _lep_found = true;
+
+  ClusterHOTVR();
+  ClusterXCone23();
+  ClusterXCone33();
+}
+
+
+// ---------------------------------------------------------------
+// GenTopJets
+
+//HOTVR
+void UniversalGenJetCluster::ClusterHOTVR()
+{
+  double mu(30.),                 // massjump threshold
+    theta(0.7),                   // massjump parameter
+    max_r(1.5),                   // maximum allowed distance R
+    min_r(0.1),                   // minimum allowed distance R
+    rho(600.),                    // cone shrinking parameter
+    hotvr_pt_min(30.);            // minimum pT of subjet
+  // setup jet definition with HOTVR plugin
+  HOTVR hotvr_plugin(mu, theta, min_r, max_r, rho, hotvr_pt_min, HOTVR::CALIKE); 
+  JetDefinition jet_def(&hotvr_plugin);
+  // setup cluster sequence
+  ClusterSequence cs(_psj, jet_def);
+
+  // write jets
+  vector<PseudoJet> hotvr_jets = hotvr_plugin.get_jets();
+  for (unsigned int i = 0; i < hotvr_jets.size(); ++i)
+    {
+      HOTVRinfo hi = hotvr_jets[i].user_info<HOTVRinfo>();
+      vector<PseudoJet> subjets = hi.subjets();
+      _hotvrGenTopJets.push_back(ConvertPsjToGenTopJet(hotvr_jets[i], subjets));
+    }
+
+}
+std::vector<GenTopJet> UniversalGenJetCluster::GetHOTVRTopJets()
+{
+  return _hotvrGenTopJets;
+}
+
+//XCone
+void UniversalGenJetCluster::ClusterXCone23()
+{
+  // Run first clustering step (N=2, R=1.2) 
+  std::vector<PseudoJet> fatjets;
+  XConePlugin plugin_xcone(2, 1.2, 2.0);
+  JetDefinition jet_def_xcone(&plugin_xcone);
+  ClusterSequence clust_seq_xcone(_psj, jet_def_xcone);
+  fatjets = sorted_by_pt(clust_seq_xcone.inclusive_jets(0));
+  ////
+
+  // declare leptonic and hadronic jet (default is jet1 = had)
+  bool jet1_is_had = true;
+  if(_lep_found){
+    double dR1=deltaR(fatjets[0], _lepton);
+    double dR2=deltaR(fatjets[1], _lepton);
+    if(dR1 < dR2) jet1_is_had = false;
+  }
+
+  // get and wirte list: if particle i ist clustered in jet j, the i-th entry of the list == j
+  vector<int> list_fat;
+  list_fat.clear();
+  list_fat = clust_seq_xcone.particle_jet_indices(fatjets);
+  vector<PseudoJet> particle_in_fat1, particle_in_fat2;
+
+  // get one set of particles for each jet
+  for (unsigned int ipart=0; ipart < _psj.size(); ++ipart){
+    if (list_fat[ipart]==0){
+      particle_in_fat1.push_back(_psj.at(ipart)); // get vector as PseudoJet for fatjet 1
+    }
+    if (list_fat[ipart]==1){
+      particle_in_fat2.push_back(_psj.at(ipart)); // get vector as PseudoJet for fatjet 2
+    }
+  }
+  ////
+
+  // check if both list contain at least 3 particles, 
+  // code is likely to crash if lists contain less particles than required jets
+  if(particle_in_fat1.size() < 3 || particle_in_fat2.size() <3) return;  
+  ////
+
+
+  // Run second clustering step (N=3, R=0.4) for each fat jet
+  // (this clustering depends on which jet is the leptonic and which one is the hadronic jet)
+  std::vector<fastjet::PseudoJet> subjets_1, subjets_2;
+
+  if(jet1_is_had){
+    // subjets from fat jet 1 (hadronic)
+    XConePlugin plugin_xcone_sub1(3, 0.4, 2.0);
+    JetDefinition jet_def_sub1(&plugin_xcone_sub1);
+    ClusterSequence clust_seq_sub1(particle_in_fat1, jet_def_sub1);
+    subjets_1 = sorted_by_pt(clust_seq_sub1.inclusive_jets(0));
+
+    // subjets from fat jet 2 (leptonic)
+    XConePlugin plugin_xcone_sub2(2, 0.4, 2.0);
+    JetDefinition jet_def_sub2(&plugin_xcone_sub2);
+    ClusterSequence clust_seq_sub2(particle_in_fat2, jet_def_sub2);
+    subjets_2 = sorted_by_pt(clust_seq_sub2.inclusive_jets(0));
+    ////
+  }
+  if(!jet1_is_had){
+    // subjets from fat jet 1 (leptonic)
+    XConePlugin plugin_xcone_sub1(2, 0.4, 2.0);
+    JetDefinition jet_def_sub1(&plugin_xcone_sub1);
+    ClusterSequence clust_seq_sub1(particle_in_fat1, jet_def_sub1);
+    subjets_1 = sorted_by_pt(clust_seq_sub1.inclusive_jets(0));
+
+    // subjets from fat jet 2 (hadronic)
+    XConePlugin plugin_xcone_sub2(3, 0.4, 2.0);
+    JetDefinition jet_def_sub2(&plugin_xcone_sub2);
+    ClusterSequence clust_seq_sub2(particle_in_fat2, jet_def_sub2);
+    subjets_2 = sorted_by_pt(clust_seq_sub2.inclusive_jets(0));
+    ////
+  }
+
+  // set GenTopJets with subjets
+  _xcone23TopJets.push_back(ConvertPsjToGenTopJet(fatjets[0], subjets_1));
+  _xcone23TopJets.push_back(ConvertPsjToGenTopJet(fatjets[1], subjets_2));
+  ////
+
+  // delete pseudojets and lists
+  subjets_1.clear();
+  subjets_2.clear();
+  fatjets.clear();
+  particle_in_fat1.clear();
+  particle_in_fat2.clear();
+  ////
+}
+vector<GenTopJet> UniversalGenJetCluster::GetXCone23Jets()
+{
+  return _xcone23TopJets;
+}
+
+void UniversalGenJetCluster::ClusterXCone33()
+{
+  // Run first clustering step (N=2, R=1.2) 
+  vector<PseudoJet> fatjets;
+  XConePlugin plugin_xcone(2, 1.2, 2.0);
+  JetDefinition jet_def_xcone(&plugin_xcone);
+  ClusterSequence clust_seq_xcone(_psj, jet_def_xcone);
+  fatjets = sorted_by_pt(clust_seq_xcone.inclusive_jets(0));
+  ////
+
+  // get and wirte list: if particle i ist clustered in jet j, the i-th entry of the list == j
+  vector<int> list_fat;
+  list_fat.clear();
+  list_fat = clust_seq_xcone.particle_jet_indices(fatjets);
+  vector<PseudoJet> particle_in_fat1, particle_in_fat2;
+
+  // get one set of particles for each jet
+  for (unsigned int ipart=0; ipart < _psj.size(); ++ipart){
+    if (list_fat[ipart]==0){
+      particle_in_fat1.push_back(_psj.at(ipart)); // get vector as PseudoJet for fatjet 1
+    }
+    if (list_fat[ipart]==1){
+      particle_in_fat2.push_back(_psj.at(ipart)); // get vector as PseudoJet for fatjet 2
+   }
+  }
+  ////
+
+  // check if both list contain at least 3 particles, 
+  // code is likely to crash if lists contain less particles than required jets
+  if(particle_in_fat1.size() < 3 || particle_in_fat2.size() <3) return;  
+  ////
+
+  // Run second clustering step (N=3, R=0.4) for each fat jet
+  vector<PseudoJet> subjets_1, subjets_2;
+
+  // subjets from fat jet 1 
+  XConePlugin plugin_xcone_sub1(3, 0.4, 2.0);
+  JetDefinition jet_def_sub1(&plugin_xcone_sub1);
+  ClusterSequence clust_seq_sub1(particle_in_fat1, jet_def_sub1);
+  subjets_1 = sorted_by_pt(clust_seq_sub1.inclusive_jets(0));
+
+  // subjets from fat jet 2 
+  XConePlugin plugin_xcone_sub2(3, 0.4, 2.0);
+  JetDefinition jet_def_sub2(&plugin_xcone_sub2);
+  ClusterSequence clust_seq_sub2(particle_in_fat2, jet_def_sub2);
+  subjets_2 = sorted_by_pt(clust_seq_sub2.inclusive_jets(0));
+  
+  ////
+
+  // set GenTopJets with subjets
+  _xcone33TopJets.push_back(ConvertPsjToGenTopJet(fatjets[0], subjets_1));
+  _xcone33TopJets.push_back(ConvertPsjToGenTopJet(fatjets[1], subjets_2));
+  ////
+
+  // Also write Jets with SoftDrop 
+  SoftDrop sd(0.0, 0.1, 1.2);
+  PseudoJet sdjet1 = sd(fatjets[0]);
+  PseudoJet sdjet2 = sd(fatjets[1]);
+  _xcone33TopJets_softdrop.push_back(ConvertPsjToGenTopJet(sdjet1, subjets_1));
+  _xcone33TopJets_softdrop.push_back(ConvertPsjToGenTopJet(sdjet2, subjets_2));
+  ////
+
+  // delete pseudojets and lists
+  subjets_1.clear();
+  subjets_2.clear();
+  fatjets.clear();
+  particle_in_fat1.clear();
+  particle_in_fat2.clear();
+  ////
+}
+vector<GenTopJet> UniversalGenJetCluster::GetXCone33Jets()
+{
+  return _xcone33TopJets;
+}
+vector<GenTopJet> UniversalGenJetCluster::GetXCone33Jets_softdrop()
+{
+  return _xcone33TopJets_softdrop;
+}
+
+
+// ---------------------------------------------------------------
+// Converters
+
+//PseudoJet UniversalGenJetCluster::ConvertGenToPsj(GenParticle * genp)
+ PseudoJet UniversalGenJetCluster::ConvertGenToPsj(const GenParticle & genp) //TEST
+{
+  //  PseudoJet psj(genp->v4().X(), genp->v4().Y(), genp->v4().Z(), genp->v4().T());
+  PseudoJet psj(genp.v4().X(), genp.v4().Y(), genp.v4().Z(), genp.v4().T());//TEST
+  return psj;
+}
+
+Particle UniversalGenJetCluster::ConvertPsjToParticle(const PseudoJet & psj)
+{
+  Particle part;
+  part.set_pt(psj.pt());
+  part.set_eta(psj.eta());
+  part.set_phi(psj.phi());
+  part.set_energy(psj.E());
+  return part;
+}
+
+GenTopJet UniversalGenJetCluster::ConvertPsjToGenTopJet(const PseudoJet & psj, const vector<PseudoJet> &subpsj)
+{
+  GenTopJet topjet;
+  topjet.set_pt(psj.pt());
+  topjet.set_eta(psj.eta());
+  topjet.set_phi(psj.phi());
+  topjet.set_energy(psj.E());
+  for (unsigned int i = 0; i < subpsj.size(); ++i) 
+    {
+      topjet.add_subjet(ConvertPsjToParticle(subpsj[i]));
+    }
+  return topjet;
+}

--- a/core/src/UniversalJetCluster.cxx
+++ b/core/src/UniversalJetCluster.cxx
@@ -1,0 +1,366 @@
+//#include "FWCore/Utilities/interface/CPUTimer.h"
+#include "UHH2/core/include/UniversalJetCluster.h"
+
+using namespace std;
+using namespace uhh2;
+using namespace fastjet;
+using namespace contrib;
+
+
+UniversalJetCluster::UniversalJetCluster(vector<PFParticle> *pfparticles, bool doHOTVR=true, bool doXCone=true)
+{
+  for(auto pf : *pfparticles) 
+    {
+      if(std::isnan(pf.v4().Px()) || std::isnan(pf.v4().Py()) || std::isnan(pf.v4().Pz()) || std::isinf(pf.v4().Px()) || std::isinf(pf.v4().Py())  || std::isinf(pf.v4().Pz()))
+	continue;
+      _psj.push_back(ConvertPFToPsj(pf));
+    }
+  if(doHOTVR)ClusterHOTVR();
+  //fastjet crashes with segmentation violation if not enough PFParticle are present!
+  
+  if(doXCone && pfparticles->size()>15)
+    ClusterXCone33();
+  // to calculate the area information for both hotvr and xcone makes the ntuplewrite 3-4 times slower!
+  // therefore we only calculate the area with reduced max eta of 4. For xcone only subjets have an area and for 
+  // hotvr the ghost area is set to 0.02 instead of 0.01
+
+}
+
+// ---------------------------------------------------------------
+// TopJets
+
+// HOTVR 
+
+void UniversalJetCluster::ClusterHOTVR()
+{
+  double mu(30.),                 // massjump threshold
+    theta(0.7),                   // massjump parameter
+    max_r(1.5),                   // maximum allowed distance R
+    min_r(0.1),                   // minimum allowed distance R
+    rho(600.),                    // cone shrinking parameter
+    hotvr_pt_min(30.);            // minimum pT of subjet
+
+  // jet definition with HOTVR plugin
+  HOTVR hotvr_plugin(mu, theta, min_r, max_r, rho, hotvr_pt_min, HOTVR::CALIKE); 
+  JetDefinition jet_def(&hotvr_plugin);
+
+   // Setup cluster sequence
+  ClusterSequence cs(_psj, jet_def);
+  vector<PseudoJet> hotvr_jets = hotvr_plugin.get_jets();
+
+  // NOTE: There is a problem when getting Nsubjettiness directly
+  // from HOTVR jets, because the link to the cluster sequence got lost
+  // somehow. Thus the approach here will be to identify the Jets from
+  // the cluster sequence with the hotvr_jets by comparing their
+  // four-vectors.
+
+  // area definition
+  double ghost_maxrap = 4.0;      // maxiumum y of ghost particles
+  AreaDefinition area_def(active_area_explicit_ghosts, GhostedAreaSpec(ghost_maxrap, 1, 0.02));
+
+  // setup cluster sequence with area
+  HOTVR hotvr_plugin_area(mu, theta, min_r, max_r, rho, hotvr_pt_min, HOTVR::CALIKE); 
+  JetDefinition jet_def_area(&hotvr_plugin_area);
+  ClusterSequenceArea cs_area(_psj, jet_def_area, area_def);
+  //ClusterSequence cs_area(_psj, jet_def_area);
+  //vector<PseudoJet> cs_jets = cs_area.inclusive_jets(hotvr_pt_min);
+  vector<PseudoJet> hotvr_jets_area = hotvr_plugin_area.get_jets();
+
+
+  //in a few cases, there are jets in the original clustering without a corresponding jet in the area clustering
+  //->add a dummy jet into the area collection and throw a warning because we cannot determine the area for these jets
+  if (hotvr_jets_area.size() != hotvr_jets.size())
+    {
+
+    for (unsigned int i = 0; i < hotvr_jets.size(); ++i)
+      {
+	bool matched=false;
+	for (unsigned int j = 0; j < hotvr_jets_area.size(); ++j)
+	  {
+	    if( fabs(hotvr_jets[i].pt() - hotvr_jets_area[j].pt())<0.0001 && fabs(hotvr_jets[i].eta() - hotvr_jets_area[j].eta())<0.0001)
+	      {
+		matched = true;
+		break;
+	      }
+	  }
+	if(!matched)
+	  {
+	    PseudoJet dummy_jet(0,0,0,0);
+	    hotvr_jets_area.insert(hotvr_jets_area.begin()+i, dummy_jet);
+	  }
+      }
+
+    //sometimes, there are more jets in the area clustering
+    //->filter out jets from the area collection which are not matched to any jet in the original clustering
+
+    for (unsigned int i = 0; i < hotvr_jets_area.size(); ++i)
+      {
+	//skip dummy jets from previous iteration
+	if(hotvr_jets_area[i].pt()==0) continue;
+	bool matched=false;
+	for (unsigned int j = 0; j < hotvr_jets.size(); ++j)
+	  {
+	    if( fabs(hotvr_jets[j].pt() - hotvr_jets_area[i].pt())<0.0001 && fabs(hotvr_jets[j].eta() - hotvr_jets_area[i].eta())<0.0001)
+	      {
+		matched = true;
+		break;
+	      }
+	  }
+	if(!matched)
+	  {
+	    hotvr_jets_area.erase(hotvr_jets_area.begin()+i);
+	    i--;
+	  }
+      }
+    }
+  
+  //this should hopefully not happen anymore
+  if(hotvr_jets_area.size() != hotvr_jets.size()){
+    throw runtime_error("ERROR in UniversalJetCluster::ClusterHOTVR: number of jets found with ClusterSequence does not match number of jets with ClusterSequenceArea.");
+  }
+  
+  for (unsigned int i = 0; i < hotvr_jets.size(); ++i)
+    {
+      double beta = 1.0;
+      HOTVRinfo hi = hotvr_jets[i].user_info<HOTVRinfo>();
+      Nsubjettiness nSub1(1,   OnePass_WTA_KT_Axes(), NormalizedMeasure(beta, hi.max_distance()));
+      Nsubjettiness nSub2(2,   OnePass_WTA_KT_Axes(), NormalizedMeasure(beta, hi.max_distance()));
+      Nsubjettiness nSub3(3,   OnePass_WTA_KT_Axes(), NormalizedMeasure(beta, hi.max_distance()));
+      double tau1 =  nSub1(hotvr_jets[i]);
+      double tau2 =  nSub2(hotvr_jets[i]);
+      double tau3 =  nSub3(hotvr_jets[i]);
+      //getting jet and subjet area
+      double jet_area = 0;
+      vector<double> subjet_area;
+      vector<PseudoJet> subjets;
+      if(hotvr_jets_area[i].pt()>0){
+	jet_area = hotvr_jets_area[i].area();
+	HOTVRinfo hi_area = hotvr_jets_area[i].user_info<HOTVRinfo>();
+	subjets = hi_area.subjets();
+	for (unsigned int j = 0; j < subjets.size(); ++j) {
+	  subjet_area.push_back(subjets[j].area());
+	  //subjet_area.push_back(0.);
+	}
+      }
+      else{
+	subjets = hi.subjets();
+	for (unsigned int j = 0; j < subjets.size(); ++j) {
+	  subjet_area.push_back(0);
+	}
+	std::cout << "WARNING in UniversalJetCluster::ClusterHOTVR: could not find area jet for a HOTVR jet; set area and subjet areas to 0." << std::endl;
+      }
+      _hotvrTopJets.push_back(ConvertPsjToTopJet(hotvr_jets[i], subjets, tau1, tau2, tau3, jet_area, subjet_area));
+    }
+  
+  
+}
+vector<TopJet> UniversalJetCluster::GetHOTVRTopJets()
+{
+  return _hotvrTopJets;
+}
+
+// XCone
+void UniversalJetCluster::ClusterXCone33()
+{
+  /*
+  cout<<"=============================="<<endl;
+  cout<<"Entering into XCone clustering"<<endl;
+  cout<<"total number "<<_psj.size()<<endl;
+  ofstream out;
+  out.open("minimal.txt");
+  out<<"Format: px py pz E"<<endl;
+  for(auto jet : _psj)
+    out<<jet.px()<<" "<<jet.py()<<" "<<jet.pz()<<" "<<jet.E()<<endl;
+    //cout<<"phi "<<jet.phi_std()<<" eta "<< jet.eta()<<" pt "<<jet.pt()<<endl;
+
+  out.close();
+  */
+
+
+  if(_psj.size()<2){
+    cerr<<"Less then 2 particles for first XCone step"<<endl;
+    return;
+  }
+  
+
+
+  // Run first clustering step (N=2, R=1.2) 
+  vector<PseudoJet> fatjets;
+  XConePlugin plugin_xcone(2, 1.2, 2.0);
+  double ghost_maxrap = 4.0;      // maxiumum y of ghost particles
+  AreaDefinition area_def(active_area, GhostedAreaSpec(ghost_maxrap));
+  JetDefinition jet_def_xcone(&plugin_xcone);
+  //ClusterSequenceArea clust_seq_xcone(_psj, jet_def_xcone, area_def);
+  ClusterSequence clust_seq_xcone(_psj, jet_def_xcone);
+  fatjets = sorted_by_pt(clust_seq_xcone.inclusive_jets(0));
+  ////
+
+  //cout<<"getting softdrop mass"<<endl;
+  // get SoftDrop Mass
+  SoftDrop sd(0.0, 0.1, 1.2);
+  PseudoJet sdjet1 = sd(fatjets[0]);
+  PseudoJet sdjet2 = sd(fatjets[1]);
+  float sd_mass1 = sdjet1.m();
+  float sd_mass2 = sdjet2.m();
+  ////
+
+  //cout<<"setting list of particles"<<endl;
+
+  // get and wirte list: if particle i is clustered in jet j, the i-th entry of the list == j
+  vector<int> list_fat;
+  list_fat.clear();
+  list_fat = clust_seq_xcone.particle_jet_indices(fatjets);
+  vector<PseudoJet> particle_in_fat1, particle_in_fat2;
+
+ 
+  // get one set of particles for each jet
+  for (unsigned int ipart=0; ipart < _psj.size(); ++ipart){
+    if (list_fat[ipart]==0){
+      particle_in_fat1.push_back(_psj.at(ipart)); // get vector as PseudoJet for fatjet 1
+    }
+    if (list_fat[ipart]==1){
+      particle_in_fat2.push_back(_psj.at(ipart)); // get vector as PseudoJet for fatjet 2
+   }
+  }
+  ////
+  /*
+  //====================
+  cout<<"Number of particles per jet"<<endl;
+  cout<<"jet 1: "<<particle_in_fat1.size()<<" jet 2: "<< particle_in_fat2.size()<<endl;
+  //====================
+  */  
+  if(particle_in_fat1.size() < 3 || particle_in_fat2.size()<3){
+    cerr<<"not enough particles to run second XCone step"<<endl;
+    cerr<<"particles 1: "<< particle_in_fat1.size()<<" particles 2: "<<particle_in_fat2.size()<<endl;
+    return;
+  }
+  // Run second clustering step (N=3, R=0.4) for each fat jet
+  vector<PseudoJet> subjets_1, subjets_2;
+
+  // subjets from fat jet 1 
+  XConePlugin plugin_xcone_sub1(3, 0.4, 2.0);
+  JetDefinition jet_def_sub1(&plugin_xcone_sub1);
+  ClusterSequenceArea clust_seq_sub1(particle_in_fat1, jet_def_sub1, area_def);
+  //ClusterSequence clust_seq_sub1(particle_in_fat1, jet_def_sub1);
+  subjets_1 = sorted_by_pt(clust_seq_sub1.inclusive_jets(0));
+  
+  //cout<<"cluster jet 1 into 04AKjets done"<<endl;
+
+
+  //subjets from fat jet 2 
+  XConePlugin plugin_xcone_sub2(3, 0.4, 2.0);
+  JetDefinition jet_def_sub2(&plugin_xcone_sub2);
+  ClusterSequenceArea clust_seq_sub2(particle_in_fat2, jet_def_sub2, area_def); 
+  subjets_2 = sorted_by_pt(clust_seq_sub2.inclusive_jets(0));
+
+  //cout<<"cluster jet 2 into 04AKjets done"<<endl;
+
+  ////
+  
+  // set TopJets with subjets and JetArea
+  
+  //double jet1_area = fatjets[0].area();
+  //double jet2_area = fatjets[1].area();
+  vector<double> subjet1_area;
+  vector<double> subjet2_area;
+  for (unsigned int j = 0; j < subjets_1.size(); ++j) subjet1_area.push_back(subjets_1[j].area());
+  for (unsigned int k = 0; k < subjets_2.size(); ++k) subjet2_area.push_back(subjets_2[k].area());
+  
+  double jet1_area = 0;
+  double jet2_area = 0;
+  /*
+  vector<double> subjet1_area;
+  vector<double> subjet2_area;
+  for (unsigned int j = 0; j < subjets_1.size(); ++j) subjet1_area.push_back(0.);
+  for (unsigned int k = 0; k < subjets_2.size(); ++k) subjet2_area.push_back(0.);
+  */
+  _xcone33TopJets.push_back(ConvertPsjToTopJet(fatjets[0], subjets_1, jet1_area, subjet1_area, sd_mass1));
+  _xcone33TopJets.push_back(ConvertPsjToTopJet(fatjets[1], subjets_2, jet2_area, subjet2_area, sd_mass2));
+  ////
+ 
+ 
+  // delete pseudojets and lists
+  subjets_1.clear();
+  subjets_2.clear();
+  fatjets.clear();
+  particle_in_fat1.clear();
+  particle_in_fat2.clear();
+  ////
+ 
+}
+vector<TopJet> UniversalJetCluster::GetXCone33Jets()
+{
+  return _xcone33TopJets;
+}
+
+
+// ---------------------------------------------------------------
+// Converters
+
+// Convert PFParticle to PseudoJet
+PseudoJet UniversalJetCluster::ConvertPFToPsj(const PFParticle & pfp)
+{
+  PseudoJet psj(pfp.v4().X(), pfp.v4().Y(), pfp.v4().Z(), pfp.v4().T());
+  return psj;
+}
+
+// Convert to Jets with Area
+Jet UniversalJetCluster::ConvertPsjToJet(const PseudoJet & psj, double jet_area)
+{
+  Jet jet;
+  jet.set_pt(psj.pt());
+  jet.set_eta(psj.eta());
+  jet.set_phi(psj.phi());
+  jet.set_energy(psj.E());
+  jet.set_jetArea(jet_area);
+  return jet;
+}
+
+// Convert to Jets
+Jet UniversalJetCluster::ConvertPsjToJet(const PseudoJet & psj)
+{
+  Jet jet;
+  jet.set_pt(psj.pt());
+  jet.set_eta(psj.eta());
+  jet.set_phi(psj.phi());
+  jet.set_energy(psj.E());
+  return jet;
+}
+
+// Convert to TopJets with groomed Nsubjettiness
+TopJet UniversalJetCluster::ConvertPsjToTopJet(const PseudoJet & psj, const vector<PseudoJet> &subpsj, double tau1, double tau2, double tau3, double jet_area, vector<double> subjet_area)
+{
+  TopJet topjet;
+  topjet.set_pt(psj.pt());
+  topjet.set_eta(psj.eta());
+  topjet.set_phi(psj.phi());
+  topjet.set_energy(psj.E());
+  topjet.set_tau1_groomed(tau1);
+  topjet.set_tau2_groomed(tau2);
+  topjet.set_tau3_groomed(tau3);
+  topjet.set_jetArea(jet_area);
+  for (unsigned int i = 0; i < subpsj.size(); ++i) 
+    {
+      topjet.add_subjet(ConvertPsjToJet(subpsj[i], subjet_area[i]));
+    }
+  return topjet;
+}
+
+// Convert to Topjets with Area and softdrop mass
+TopJet UniversalJetCluster::ConvertPsjToTopJet(const PseudoJet & psj, const vector<PseudoJet> &subpsj, double jet_area, vector<double> subjet_area, float sd_mass)
+{
+  TopJet topjet;
+  topjet.set_pt(psj.pt());
+  topjet.set_eta(psj.eta());
+  topjet.set_phi(psj.phi());
+  topjet.set_energy(psj.E());
+  topjet.set_jetArea(jet_area);
+  topjet.set_softdropmass(sd_mass);
+
+  for (unsigned int i = 0; i < subpsj.size(); ++i) 
+    {
+      topjet.add_subjet(ConvertPsjToJet(subpsj[i], subjet_area[i]));
+    }
+  return topjet;
+}
+

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,6 +6,68 @@
 #
 # before running this script
 
+
+# Create default make args for parallel jobs
+if [ -z "$MAKEFLAGS" ]
+then
+	np=$(grep -c ^processor /proc/cpuinfo)
+	let np+=2
+	export MAKEFLAGS="-j$np"
+fi
+
+getToolVersion() {
+    # Get CMSSW tool version using scram
+    # args: <toolname>
+    local toolname="$1"
+    scram tool info "$toolname" | grep -i "Version : " | sed "s/Version : //"
+}
+
+setupFastjet() {
+	FJVER="$1"
+	FJCONTRIBVER="$2"
+	echo "Setting up fastjet $FJVER and fastjet-contrib $FJCONTRIBVER"
+
+	# Create default make args for parallel jobs
+	if [ -z "$MAKEFLAGS" ]
+	then
+		np=$(grep -c ^processor /proc/cpuinfo)
+		let np+=2
+		export MAKEFLAGS="-j$np"
+	fi
+
+	# Setup fastjet & fastjet-contrib
+	# NB use curl not wget as curl available by cvmfs, wget isnt
+	FJINSTALLDIR="$(pwd)/fastjet-install"
+	curl -O http://fastjet.fr/repo/fastjet-${FJVER}.tar.gz
+	tar xzf fastjet-${FJVER}.tar.gz
+	mkdir "${FJINSTALLDIR}"
+	cd fastjet-${FJVER}    
+	./configure --prefix="${FJINSTALLDIR}" --enable-allplugins --enable-allcxxplugins CXXFLAGS=-fPIC
+	make $MAKEFLAGS
+	make check
+	make install
+	cd ..
+
+	# Add fastjet-config to PATH
+	export PATH="${FJINSTALLDIR}/bin":$PATH
+
+	curl -O http://fastjet.hepforge.org/contrib/downloads/fjcontrib-${FJCONTRIBVER}.tar.gz
+	tar xzf fjcontrib-${FJCONTRIBVER}.tar.gz
+	cd fjcontrib-${FJCONTRIBVER}
+	# add HOTVR from SVN - do it this way until it becomes a proper contrib
+	svn co http://fastjet.hepforge.org/svn/contrib/contribs/HOTVR/trunk HOTVR/
+	# although we add fastjet-config to path, due to a bug we need to 
+	# explicitly state its path to ensure the necessary fragile library gets built 
+	./configure --fastjet-config="${FJINSTALLDIR}/bin/fastjet-config" CXXFLAGS=-fPIC
+	make $MAKEFLAGS
+	make check
+	make install
+	# the fragile libs are necessary for CMSSW
+	make fragile-shared
+	make fragile-shared-install
+	cd ..
+}
+
 source /cvmfs/cms.cern.ch/cmsset_default.sh
 
 # Get SFrame, do not compile it until we have the right ROOT etc
@@ -16,24 +78,45 @@ export SCRAM_ARCH=slc6_amd64_gcc630
 eval `cmsrel CMSSW_9_4_1`
 cd CMSSW_9_4_1/src
 eval `scramv1 runtime -sh`
-git cms-init
+
+# Install FastJet & contribs for HOTVR & XCONE
+cd ../..
+FJVER="3.1.0"
+FJCONTRIBVER="1.026"
+time setupFastjet $FJVER $FJCONTRIBVER
+
+cd $CMSSW_BASE/src
+
+time git cms-init -y  # not needed if not addpkg ing
 
 # Add in preliminary EGamma VID
 git cms-merge-topic lsoffi:CMSSW_9_4_0_pre3_TnP
 
-#git cms-addpkg RecoJets/JetProducers
+# Necessary for using our FastJet
+git cms-addpkg RecoJets/JetProducers
 
 # Update FastJet and contribs for HOTVR and UniversalJetCluster
-#sed -i "s|3.1.0|3.2.1|g" $CMSSW_BASE/config/toolbox/$SCRAM_ARCH/tools/selected/fastjet.xml
-#sed -i "s|/cvmfs/cms.cern.ch/slc6_amd64_gcc630/external/fastjet/3.2.1|/afs/desy.de/user/a/aggleton/public/fastjet/slc6_amd64_gcc630/fastjet-install|g" $CMSSW_BASE/config/toolbox/$SCRAM_ARCH/tools/selected/fastjet.xml
-#sed -i "s|/cvmfs/cms.cern.ch/slc6_amd64_gcc630/external/fastjet-contrib/1.026|/afs/desy.de/user/a/aggleton/public/fastjet/slc6_amd64_gcc630/fastjet-install|g" $CMSSW_BASE/config/toolbox/$SCRAM_ARCH/tools/selected/fastjet-contrib.xml
-#sed -i "s|/cvmfs/cms.cern.ch/slc6_amd64_gcc630/external/fastjet-contrib/1.026|/afs/desy.de/user/a/aggleton/public/fastjet/slc6_amd64_gcc630/fastjet-install|g" $CMSSW_BASE/config/toolbox/$SCRAM_ARCH/tools/selected/fastjet-contrib-archive.xml
-#scram setup fastjet
-#scram setup fastjet-contrib
-#scram setup fastjet-contrib-archive
+FJINSTALL=$(fastjet-config --prefix)
+OLD_FJ_VER=$(getToolVersion fastjet)
+FJ_TOOL_FILE=$CMSSW_BASE/config/toolbox/$SCRAM_ARCH/tools/selected/fastjet.xml
+sed -i "s|/cvmfs/cms.cern.ch/$SCRAM_ARCH/external/fastjet/$OLD_FJ_VER|$FJINSTALL|g" "$FJ_TOOL_FILE"
+sed -i "s|$OLD_FJ_VER|$FJVER|g" "$FJ_TOOL_FILE"
 
-#scram b clean
-scram b -j 20
+OLD_FJCONTRIB_VER=$(getToolVersion fastjet-contrib)
+FJCONFIG_TOOL_FILE=$CMSSW_BASE/config/toolbox/$SCRAM_ARCH/tools/selected/fastjet-contrib.xml
+sed -i "s|/cvmfs/cms.cern.ch/$SCRAM_ARCH/external/fastjet-contrib/$OLD_FJCONTRIB_VER|$FJINSTALL|g" "$FJCONFIG_TOOL_FILE"
+sed -i "s|$OLD_FJCONTRIB_VER|$FJCONTRIB_VER|g" "$FJCONFIG_TOOL_FILE"
+
+FJCONFIG_ARCHIVE_TOOL_FILE=$CMSSW_BASE/config/toolbox/$SCRAM_ARCH/tools/selected/fastjet-contrib-archive.xml
+sed -i "s|/cvmfs/cms.cern.ch/$SCRAM_ARCH/external/fastjet-contrib/$OLD_FJCONTRIB_VER|$FJINSTALL|g" "$FJCONFIG_ARCHIVE_TOOL_FILE"
+sed -i "s|$OLD_FJCONTRIB_VER|$FJCONTRIB_VER|g" "$FJCONFIG_ARCHIVE_TOOL_FILE"
+
+scram setup fastjet
+scram setup fastjet-contrib
+scram setup fastjet-contrib-archive
+
+scram b clean
+time scram b $MAKEFLAGS
 
 # Get the UHH2 repo & JEC files
 cd $CMSSW_BASE/src

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -12,6 +12,12 @@ if [ -z "$MAKEFLAGS" ]
 then
 	np=$(grep -c ^processor /proc/cpuinfo)
 	let np+=2
+	# Be nice on shared machines, don't take up all the cores
+	limit="12"
+	if [[ "$np" -gt "$limit" ]]
+	then
+		np=$limit
+	fi
 	export MAKEFLAGS="-j$np"
 fi
 
@@ -26,14 +32,6 @@ setupFastjet() {
 	FJVER="$1"
 	FJCONTRIBVER="$2"
 	echo "Setting up fastjet $FJVER and fastjet-contrib $FJCONTRIBVER"
-
-	# Create default make args for parallel jobs
-	if [ -z "$MAKEFLAGS" ]
-	then
-		np=$(grep -c ^processor /proc/cpuinfo)
-		let np+=2
-		export MAKEFLAGS="-j$np"
-	fi
 
 	# Setup fastjet & fastjet-contrib
 	# NB use curl not wget as curl available by cvmfs, wget isnt

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# might be usefull to call 
+# might be usefull to call
 #
 #   export CMSSW_GIT_REFERENCE=<DIRECTORYWITHENOUGHSPACE>/cmssw.git
 #
@@ -41,7 +41,7 @@ setupFastjet() {
 	curl -O http://fastjet.fr/repo/fastjet-${FJVER}.tar.gz
 	tar xzf fastjet-${FJVER}.tar.gz
 	mkdir "${FJINSTALLDIR}"
-	cd fastjet-${FJVER}    
+	cd fastjet-${FJVER}
 	./configure --prefix="${FJINSTALLDIR}" --enable-allplugins --enable-allcxxplugins CXXFLAGS=-fPIC
 	make $MAKEFLAGS
 	make check
@@ -56,8 +56,8 @@ setupFastjet() {
 	cd fjcontrib-${FJCONTRIBVER}
 	# add HOTVR from SVN - do it this way until it becomes a proper contrib
 	svn co http://fastjet.hepforge.org/svn/contrib/contribs/HOTVR/trunk HOTVR/
-	# although we add fastjet-config to path, due to a bug we need to 
-	# explicitly state its path to ensure the necessary fragile library gets built 
+	# although we add fastjet-config to path, due to a bug we need to
+	# explicitly state its path to ensure the necessary fragile library gets built
 	./configure --fastjet-config="${FJINSTALLDIR}/bin/fastjet-config" CXXFLAGS=-fPIC
 	make $MAKEFLAGS
 	make check


### PR DESCRIPTION
This re-enables HOTVR & XCONE in the ntuplewriter & config. I have re-added back in the Universal(gen)Clusterer files.

To enable all of this, **I have modified the install script to install FastJet for each user**. Note that in the past we all used Thomas' centralised installation on his AFS.
The rational for this change is:

- It stops the same problem in the future of having one centralised fastjet installation that everyone attempts to use, which may get deleted, breaking it for everyone
- User's can now freely play around with fastjet & contribs independently
- It doesn't take long to compile, < 5 minutes.

However I can understand that it may seem like an additional complication. If you don't want a per-user installation I can go back to one centralised installation on AFS that everyone links to.

Using our own fastjet also means that `RecoJets/JetProducers` requires checking out & recompiling.

**NB** the version of FastJet used here is 3.1.0, the same as in CMSSW_9_4_1. Previously we used 3.2.1 as that was required for HOTVR, but it seems to work fine with 3.1.0... 3.2.1 won't work with this version of CMSSW due to an API incompatibility in `fastjet::JetDefintion` constructor that certain modules in `RecoJets/JetProducers` calls.

**NB2** running with HOTVR & XCONE massively increases processing time: in data it goes from <1s/event to ~2-3s/event, with a similar increase for MC. The Ntuplewriter module by itself takes ~ 100x longer to run/event.
