### PR TITLE
[94X] Update HEEP & MVA Electron IDs

### DIFF
--- a/common/include/ElectronIds.h
+++ b/common/include/ElectronIds.h
@@ -255,59 +255,44 @@ namespace ElectronID {
 // Electron MVA IDs
 // REF https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2
 
-// --- General Purpose MVA ID
-bool Electron_GeneralPurposeMVAID(const Electron&, const uhh2::Event&, const std::string&, const std::string&);
+// --- MVA ID
+bool Electron_MVAID(const Electron&, const uhh2::Event&, const std::string&, const std::string&, const bool);
 
-// --- General Purpose MVA ID: Spring16
-bool ElectronID_MVAGeneralPurpose_Spring16_loose(const Electron&, const uhh2::Event&);
-bool ElectronID_MVAGeneralPurpose_Spring16_tight(const Electron&, const uhh2::Event&);
-
-// --- HZZ MVA ID
-bool Electron_HZZMVAID(const Electron&, const uhh2::Event&, const std::string&, const std::string&);
-
-// --- HZZ MVA ID: Spring16
-bool ElectronID_MVAHZZ_Spring16(const Electron&, const uhh2::Event&);
+// --- Specific MVA IDs: Fall17
+bool ElectronID_MVA_Fall17_loose_iso(const Electron&, const uhh2::Event&);
+bool ElectronID_MVA_Fall17_loose_noIso(const Electron&, const uhh2::Event&);
 
 
 namespace ElectronID {
 
-  const std::unordered_map<std::string, std::unordered_map<std::string, std::vector<float> > > GeneralPurposeMVA_LUT = {
-
-  /************/
-
-  /** Spring16 **/
-    {"Spring16", 
+  const std::unordered_map<std::string, std::unordered_map<std::string, std::vector<float> > > MVA_LUT_Iso = {
+    {"Fall17",
      {
-                         /* 80% SE    , 90% SE    */
-      //no GeneralPurpose ID below 10 GeV
-      {"high-pt_barrel1", {  0.941 ,  0.837 }},
-      {"high-pt_barrel2", {  0.899 ,  0.715 }},
-      {"high-pt_endcap" , {  0.758 ,  0.357 }},
-
-     },
-    },
-  /**************/
-
+      // currently only for wp loose
+      {"low-pt_barrel1",  {  -0.13  }},
+      {"low-pt_barrel2",  {  -0.32  }},
+      {"low-pt_endcap" ,  {  -0.08  }},
+      {"high-pt_barrel1", {  -0.86  }},
+      {"high-pt_barrel2", {  -0.81  }},
+      {"high-pt_endcap" , {  -0.72  }},
+     }
+    }
   };
 
-  const std::unordered_map<std::string, std::unordered_map<std::string, std::vector<float> > > HZZMVA_LUT = {
-
-
-    /** Spring16 **/
-    {"Spring16", 
-     {   
-	/* 98% SE      */
-	{"low-pt_barrel1" , {  -0.211  }}, 
-	{"low-pt_barrel2" , {  -0.396  }}, 
-	{"low-pt_endcap"  , {  -0.215  }},
-	{"high-pt_barrel1", {  -0.870 }},
-	{"high-pt_barrel2", {  -0.838 }},
-	{"high-pt_endcap" , {  -0.763 }}, 
-      },
-    },
-    /**************/ 
-
+  const std::unordered_map<std::string, std::unordered_map<std::string, std::vector<float> > > MVA_LUT_NoIso = {
+    {"Fall17",
+     {
+      // currently only for wp loose
+      {"low-pt_barrel1",  {  -0.10  }},
+      {"low-pt_barrel2",  {  -0.28  }},
+      {"low-pt_endcap" ,  {  -0.05  }},
+      {"high-pt_barrel1", {  -0.83  }},
+      {"high-pt_barrel2", {  -0.77  }},
+      {"high-pt_endcap" , {  -0.69  }},
+     }
+    }
   };
+
 }
 
 

--- a/common/src/ElectronIds.cxx
+++ b/common/src/ElectronIds.cxx
@@ -126,64 +126,40 @@ bool ElectronID_Spring16_tight_noIso (const Electron& ele, const uhh2::Event& ev
 
 //// General Purpose MVA ID
 
-bool Electron_GeneralPurposeMVAID(const Electron& ele_, const uhh2::Event&, const std::string& tuning_, const std::string& wp_){
+bool Electron_MVAID(const Electron& ele_, const uhh2::Event&, const std::string& tuning_, const std::string& wp_, const bool iso_){
 
   std::string category("");
 
   const float pt(ele_.pt()), abs_etaSC(fabs(ele_.supercluster_eta()));
   if(pt > 10.){
-
     if                         (abs_etaSC < 0.8)   category = "high-pt_barrel1";
     else if(0.8 <= abs_etaSC && abs_etaSC < 1.479) category = "high-pt_barrel2";
     else if                    (abs_etaSC < 2.5)   category = "high-pt_endcap";
-  }
-  else return false;
-
-  int wp_idx(-1);
-  if     (wp_ == "80p_sigeff") wp_idx = 0;
-  else if(wp_ == "90p_sigeff") wp_idx = 1;
-  else throw std::runtime_error("Electron_GeneralPurposeMVAID -- undefined working-point tag: "+wp_);
-
-  const float MVA(10);
-
-  return (MVA > ElectronID::GeneralPurposeMVA_LUT.at(tuning_).at(category).at(wp_idx));
-}
-
-bool ElectronID_MVAGeneralPurpose_Spring16_loose(const Electron& ele, const uhh2::Event& evt){ return Electron_GeneralPurposeMVAID(ele, evt, "Spring16", "90p_sigeff"); }
-bool ElectronID_MVAGeneralPurpose_Spring16_tight(const Electron& ele, const uhh2::Event& evt){ return Electron_GeneralPurposeMVAID(ele, evt, "Spring16", "80p_sigeff"); }
-
-
-//// HZZ MVA ID
-
-bool Electron_HZZMVAID(const Electron& ele_, const uhh2::Event&, const std::string& tuning_, const std::string& wp_){ 
-
-  std::string category("");
-  const float pt(ele_.pt()), abs_etaSC(fabs(ele_.supercluster_eta()));
-  if(5. < pt && pt <= 10.){ 
+  } else if (pt > 5.) {
     if                         (abs_etaSC < 0.8)   category = "low-pt_barrel1";
     else if(0.8 <= abs_etaSC && abs_etaSC < 1.479) category = "low-pt_barrel2";
     else if                    (abs_etaSC < 2.5)   category = "low-pt_endcap";
   }
-  if(pt > 10.){
-    if                         (abs_etaSC < 0.8)   category = "high-pt_barrel1";
-    else if(0.8 <= abs_etaSC && abs_etaSC < 1.479) category = "high-pt_barrel2";
-    else if                    (abs_etaSC < 2.5)   category = "high-pt_endcap";
-  }
-  else return false; 
+  else return false;
 
   int wp_idx(-1);
-  if     (wp_ == "98p_sigeff") wp_idx = 0;
-  else throw std::runtime_error("Electron_HZZPurposeMVAID -- undefined working-point tag: "+wp_);
+  if (wp_ == "loose") wp_idx = 0;
+  else throw std::runtime_error("Electron_MVAID -- undefined working-point tag: "+wp_);
 
-  const float MVA(10);
-
-  return (MVA > ElectronID::HZZMVA_LUT.at(tuning_).at(category).at(wp_idx));
-
+  // FIXME: better way to handle this...?
+  if (iso_) {
+    const float MVA = ele_.mvaIso();
+    return (MVA > ElectronID::MVA_LUT_Iso.at(tuning_).at(category).at(wp_idx));
+  } else {
+    const float MVA = ele_.mvaNoIso();
+    return (MVA > ElectronID::MVA_LUT_NoIso.at(tuning_).at(category).at(wp_idx));
+  }
 }
 
-bool ElectronID_MVAHZZ_Spring16_loose(const Electron& ele, const uhh2::Event& evt){ return Electron_HZZMVAID(ele, evt, "Spring16", "98p_sigeff"); }
+bool ElectronID_MVA_Fall17_loose_iso(const Electron& ele, const uhh2::Event& evt){ return Electron_MVAID(ele, evt, "Fall17", "loose", true); }
+bool ElectronID_MVA_Fall17_loose_noIso(const Electron& ele, const uhh2::Event& evt){ return Electron_MVAID(ele, evt, "Fall17", "loose", false); }
 
-////
+//// HEEP ID
 
 bool ElectronID_HEEP_RunII_25ns(const Electron& ele, const uhh2::Event&){ return Electron_HEEP(ele, "RunII_25ns", "CMS_WorkPoint_NoIso"); }
 

--- a/common/src/ElectronIds.cxx
+++ b/common/src/ElectronIds.cxx
@@ -131,14 +131,15 @@ bool Electron_MVAID(const Electron& ele_, const uhh2::Event&, const std::string&
   std::string category("");
 
   const float pt(ele_.pt()), abs_etaSC(fabs(ele_.supercluster_eta()));
-  if(pt > 10.){
+  if (abs_etaSC > 2.5) return false;
+  if (pt > 10.){
     if                         (abs_etaSC < 0.8)   category = "high-pt_barrel1";
     else if(0.8 <= abs_etaSC && abs_etaSC < 1.479) category = "high-pt_barrel2";
-    else if                    (abs_etaSC < 2.5)   category = "high-pt_endcap";
+    else                                           category = "high-pt_endcap";
   } else if (pt > 5.) {
     if                         (abs_etaSC < 0.8)   category = "low-pt_barrel1";
     else if(0.8 <= abs_etaSC && abs_etaSC < 1.479) category = "low-pt_barrel2";
-    else if                    (abs_etaSC < 2.5)   category = "low-pt_endcap";
+    else                                           category = "low-pt_endcap";
   }
   else return false;
 

--- a/common/src/ElectronIds.cxx
+++ b/common/src/ElectronIds.cxx
@@ -144,7 +144,7 @@ bool Electron_GeneralPurposeMVAID(const Electron& ele_, const uhh2::Event&, cons
   else if(wp_ == "90p_sigeff") wp_idx = 1;
   else throw std::runtime_error("Electron_GeneralPurposeMVAID -- undefined working-point tag: "+wp_);
 
-  const float MVA(ele_.mvaGeneralPurpose());
+  const float MVA(10);
 
   return (MVA > ElectronID::GeneralPurposeMVA_LUT.at(tuning_).at(category).at(wp_idx));
 }
@@ -175,7 +175,7 @@ bool Electron_HZZMVAID(const Electron& ele_, const uhh2::Event&, const std::stri
   if     (wp_ == "98p_sigeff") wp_idx = 0;
   else throw std::runtime_error("Electron_HZZPurposeMVAID -- undefined working-point tag: "+wp_);
 
-  const float MVA(ele_.mvaHZZ());
+  const float MVA(10);
 
   return (MVA > ElectronID::HZZMVA_LUT.at(tuning_).at(category).at(wp_idx));
 

--- a/common/src/ElectronIds.cxx
+++ b/common/src/ElectronIds.cxx
@@ -131,15 +131,18 @@ bool Electron_MVAID(const Electron& ele_, const uhh2::Event&, const std::string&
   std::string category("");
 
   const float pt(ele_.pt()), abs_etaSC(fabs(ele_.supercluster_eta()));
+  const float ebSplit = 0.8;
+  const float ebeeSplit = 1.479;
+
   if (abs_etaSC > 2.5) return false;
   if (pt > 10.){
-    if                         (abs_etaSC < 0.8)   category = "high-pt_barrel1";
-    else if(0.8 <= abs_etaSC && abs_etaSC < 1.479) category = "high-pt_barrel2";
-    else                                           category = "high-pt_endcap";
+    if       (abs_etaSC < ebSplit)  category = "high-pt_barrel1";
+    else if (abs_etaSC < ebeeSplit) category = "high-pt_barrel2";
+    else                            category = "high-pt_endcap";
   } else if (pt > 5.) {
-    if                         (abs_etaSC < 0.8)   category = "low-pt_barrel1";
-    else if(0.8 <= abs_etaSC && abs_etaSC < 1.479) category = "low-pt_barrel2";
-    else                                           category = "low-pt_endcap";
+    if       (abs_etaSC < ebSplit)  category = "low-pt_barrel1";
+    else if (abs_etaSC < ebeeSplit) category = "low-pt_barrel2";
+    else                            category = "low-pt_endcap";
   }
   else return false;
 

--- a/core/include/Electron.h
+++ b/core/include/Electron.h
@@ -18,9 +18,7 @@ class Electron : public RecParticle {
     cutBasedElectronID_Fall17_94X_V1_Preliminary_veto,
     cutBasedElectronID_Fall17_94X_V1_Preliminary_loose,
     cutBasedElectronID_Fall17_94X_V1_Preliminary_medium,
-    cutBasedElectronID_Fall17_94X_V1_Preliminary_tight,
-    cutBasedElectronHLTPreselection_Summer16_V1
-
+    cutBasedElectronID_Fall17_94X_V1_Preliminary_tight
   };
 
   static tag tagname2tag(const std::string & tagname){
@@ -29,7 +27,6 @@ class Electron : public RecParticle {
     if(tagname == "cutBasedElectronID_Fall17_94X_V1_Preliminary_loose") return cutBasedElectronID_Fall17_94X_V1_Preliminary_loose;
     if(tagname == "cutBasedElectronID_Fall17_94X_V1_Preliminary_medium") return cutBasedElectronID_Fall17_94X_V1_Preliminary_medium;
     if(tagname == "cutBasedElectronID_Fall17_94X_V1_Preliminary_tight") return cutBasedElectronID_Fall17_94X_V1_Preliminary_tight;
-    if(tagname == "cutBasedElectronHLTPreselection_Summer16_V1") return cutBasedElectronHLTPreselection_Summer16_V1;
     throw std::runtime_error("unknown Electron::tag '" + tagname + "'");
   }
 

--- a/core/include/Electron.h
+++ b/core/include/Electron.h
@@ -59,8 +59,8 @@ class Electron : public RecParticle {
     m_ecalPFClusterIso = 0;
     m_hcalPFClusterIso = 0;
     m_dr03TkSumPt = 0;
-    m_mvaGeneralPurpose = 0;
-    m_mvaHZZ = 0;
+    m_mvaIso = 0;
+    m_mvaNoIso = 0;
     m_AEff = 0;
 
     m_pfMINIIso_CH       = 0;
@@ -110,8 +110,8 @@ class Electron : public RecParticle {
   float ecalPFClusterIso() const { return m_ecalPFClusterIso; }
   float hcalPFClusterIso() const { return m_hcalPFClusterIso; }
   float dr03TkSumPt     () const { return m_dr03TkSumPt; }
-  float mvaGeneralPurpose() const{return m_mvaGeneralPurpose;}
-  float mvaHZZ() const{return m_mvaHZZ;}  
+  float mvaIso() const { return m_mvaIso; }
+  float mvaNoIso() const { return m_mvaNoIso; }
   float effArea() const{return m_AEff;}
 
   float pfMINIIso_CH      () const { return m_pfMINIIso_CH; }
@@ -150,8 +150,8 @@ class Electron : public RecParticle {
   void set_ecalPFClusterIso(float x){ m_ecalPFClusterIso = x; }
   void set_hcalPFClusterIso(float x){ m_hcalPFClusterIso = x; }
   void set_dr03TkSumPt     (float x){ m_dr03TkSumPt      = x; }
-  void set_mvaGeneralPurpose(float x){m_mvaGeneralPurpose=x;}
-  void set_mvaHZZ(float x){m_mvaHZZ=x;}
+  void set_mvaIso(float x){m_mvaIso=x;}
+  void set_mvaNoIso(float x){m_mvaNoIso=x;}
   void set_effArea(float x){m_AEff=x;}
 
   void set_pfMINIIso_CH      (float x){ m_pfMINIIso_CH       = x; }
@@ -247,8 +247,8 @@ class Electron : public RecParticle {
   float m_ecalPFClusterIso;
   float m_hcalPFClusterIso;
   float m_dr03TkSumPt;
-  float m_mvaGeneralPurpose;
-  float m_mvaHZZ;
+  float m_mvaIso;
+  float m_mvaNoIso;
   float m_AEff;
 
   float m_pfMINIIso_CH;

--- a/core/include/Electron.h
+++ b/core/include/Electron.h
@@ -14,19 +14,31 @@ class Electron : public RecParticle {
   enum tag {
     twodcut_dRmin,
     twodcut_pTrel,
-    heepElectronID_HEEPV70,
     cutBasedElectronID_Fall17_94X_V1_Preliminary_veto,
     cutBasedElectronID_Fall17_94X_V1_Preliminary_loose,
     cutBasedElectronID_Fall17_94X_V1_Preliminary_medium,
-    cutBasedElectronID_Fall17_94X_V1_Preliminary_tight
+    cutBasedElectronID_Fall17_94X_V1_Preliminary_tight,
+    heepElectronID_HEEPV70,
+    mvaEleID_Fall17_noIso_V1_wp90,
+    mvaEleID_Fall17_noIso_V1_wp80,
+    mvaEleID_Fall17_noIso_V1_wpLoose,
+    mvaEleID_Fall17_iso_V1_wp90,
+    mvaEleID_Fall17_iso_V1_wp80,
+    mvaEleID_Fall17_iso_V1_wpLoose
   };
 
   static tag tagname2tag(const std::string & tagname){
-    if(tagname == "heepElectronID_HEEPV70") return heepElectronID_HEEPV70;
     if(tagname == "cutBasedElectronID_Fall17_94X_V1_Preliminary_veto") return cutBasedElectronID_Fall17_94X_V1_Preliminary_veto;
     if(tagname == "cutBasedElectronID_Fall17_94X_V1_Preliminary_loose") return cutBasedElectronID_Fall17_94X_V1_Preliminary_loose;
     if(tagname == "cutBasedElectronID_Fall17_94X_V1_Preliminary_medium") return cutBasedElectronID_Fall17_94X_V1_Preliminary_medium;
     if(tagname == "cutBasedElectronID_Fall17_94X_V1_Preliminary_tight") return cutBasedElectronID_Fall17_94X_V1_Preliminary_tight;
+    if(tagname == "heepElectronID_HEEPV70") return heepElectronID_HEEPV70;
+    if(tagname == "mvaEleID_Fall17_noIso_V1_wp90") return mvaEleID_Fall17_noIso_V1_wp90;
+    if(tagname == "mvaEleID_Fall17_noIso_V1_wp80") return mvaEleID_Fall17_noIso_V1_wp80;
+    if(tagname == "mvaEleID_Fall17_noIso_V1_wpLoose") return mvaEleID_Fall17_noIso_V1_wpLoose;
+    if(tagname == "mvaEleID_Fall17_iso_V1_wp90") return mvaEleID_Fall17_iso_V1_wp90;
+    if(tagname == "mvaEleID_Fall17_iso_V1_wp80") return mvaEleID_Fall17_iso_V1_wp80;
+    if(tagname == "mvaEleID_Fall17_iso_V1_wpLoose") return mvaEleID_Fall17_iso_V1_wpLoose;
     throw std::runtime_error("unknown Electron::tag '" + tagname + "'");
   }
 

--- a/core/include/Electron.h
+++ b/core/include/Electron.h
@@ -14,7 +14,7 @@ class Electron : public RecParticle {
   enum tag {
     twodcut_dRmin,
     twodcut_pTrel,
-    heepElectronID_HEEPV60,		
+    heepElectronID_HEEPV70,
     cutBasedElectronID_Fall17_94X_V1_Preliminary_veto,
     cutBasedElectronID_Fall17_94X_V1_Preliminary_loose,
     cutBasedElectronID_Fall17_94X_V1_Preliminary_medium,
@@ -24,7 +24,7 @@ class Electron : public RecParticle {
   };
 
   static tag tagname2tag(const std::string & tagname){
-    if(tagname == "heepElectronID_HEEPV60") return heepElectronID_HEEPV60;
+    if(tagname == "heepElectronID_HEEPV70") return heepElectronID_HEEPV70;
     if(tagname == "cutBasedElectronID_Fall17_94X_V1_Preliminary_veto") return cutBasedElectronID_Fall17_94X_V1_Preliminary_veto;
     if(tagname == "cutBasedElectronID_Fall17_94X_V1_Preliminary_loose") return cutBasedElectronID_Fall17_94X_V1_Preliminary_loose;
     if(tagname == "cutBasedElectronID_Fall17_94X_V1_Preliminary_medium") return cutBasedElectronID_Fall17_94X_V1_Preliminary_medium;

--- a/core/plugins/NtupleWriterLeptons.cxx
+++ b/core/plugins/NtupleWriterLeptons.cxx
@@ -77,8 +77,8 @@ void NtupleWriterElectrons::process(const edm::Event & event, uhh2::Event & ueve
         ele.set_hcalPFClusterIso(pat_ele.hcalPFClusterIso());
         ele.set_dr03TkSumPt     (pat_ele.dr03TkSumPt());
 
-	ele.set_mvaGeneralPurpose   (pat_ele.hasUserFloat("mvaGeneralPurpose")   ? pat_ele.userFloat("mvaGeneralPurpose")   : -999.);
-	ele.set_mvaHZZ   (pat_ele.hasUserFloat("mvaHZZ")   ? pat_ele.userFloat("mvaHZZ")   : -999.);
+        ele.set_mvaIso   (pat_ele.hasUserFloat("ElectronMVAEstimatorIso") ? pat_ele.userFloat("ElectronMVAEstimatorIso") : -999.);
+        ele.set_mvaNoIso   (pat_ele.hasUserFloat("ElectronMVAEstimatorNoIso") ? pat_ele.userFloat("ElectronMVAEstimatorNoIso") : -999.);
 
         ele.set_effArea(pat_ele.hasUserFloat("EffArea") ? pat_ele.userFloat("EffArea") : -999.);
 

--- a/core/plugins/PATElectronUserData.cc
+++ b/core/plugins/PATElectronUserData.cc
@@ -39,8 +39,8 @@ class PATElectronUserData : public edm::EDProducer {
 
   EffectiveAreas effAreas_;
 
-  std::string mva_GeneralPurpose_;
-  std::string mva_HZZ_;
+  std::string mva_Iso_;
+  std::string mva_NoIso_;
 };
 
 PATElectronUserData::PATElectronUserData(const edm::ParameterSet& iConfig):
@@ -75,8 +75,8 @@ PATElectronUserData::PATElectronUserData(const edm::ParameterSet& iConfig):
     }
   }
 
-  if(iConfig.exists("mva_GeneralPurpose")) mva_GeneralPurpose_ = iConfig.getParameter<std::string>("mva_GeneralPurpose"); 
-  if(iConfig.exists("mva_HZZ"))   mva_HZZ_   = iConfig.getParameter<std::string>("mva_HZZ"); 
+  if(iConfig.exists("mva_Iso")) mva_Iso_ = iConfig.getParameter<std::string>("mva_Iso"); 
+  if(iConfig.exists("mva_NoIso"))   mva_NoIso_   = iConfig.getParameter<std::string>("mva_NoIso"); 
 
   produces< pat::ElectronCollection >();
 }
@@ -148,15 +148,7 @@ void PATElectronUserData::produce(edm::Event& iEvent, const edm::EventSetup& iSe
 
     const float eA  = effAreas_.getEffectiveArea(fabs(ele.superCluster()->eta()));
     ele.addUserFloat("EffArea", eA);
-    /*
-    if(!ele.hasUserFloat(mva_GeneralPurpose_)) throw cms::Exception("InputError") << "@@@ PATElectronUserData::produce -- PAT user-float for 'mvaGeneralPurpose' not found";
-    if(!ele.hasUserFloat(mva_HZZ_))   throw cms::Exception("InputError") << "@@@ PATElectronUserData::produce -- PAT user-float for 'mvaHZZ' not found"; 
 
-    const float GeneralPurposeMVA = ele.userFloat(mva_GeneralPurpose_); 
-    const float HZZMVA   = ele.userFloat(mva_HZZ_);                                                                                                                                                                                                              
-    ele.addUserFloat("mvaGeneralPurpose", GeneralPurposeMVA); 
-    ele.addUserFloat("mvaHZZ"  ,   HZZMVA); 
-    */
   }
 
   iEvent.put(std::move(newElecs));

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -1002,7 +1002,18 @@ process.slimmedElectronsUSER = cms.EDProducer('PATElectronUserData',
                                                       'egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V1-Preliminary-tight'),
                                                   heepElectronID_HEEPV70=cms.InputTag(
                                                       'egmGsfElectronIDs:heepElectronID-HEEPV70'),
-
+                                                  mvaEleID_Fall17_noIso_V1_wp90=cms.InputTag(
+                                                    'egmGsfElectronIDs:mvaEleID-Fall17-noIso-V1-wp90'),
+                                                  mvaEleID_Fall17_noIso_V1_wp80=cms.InputTag(
+                                                    'egmGsfElectronIDs:mvaEleID-Fall17-noIso-V1-wp80'),
+                                                  mvaEleID_Fall17_noIso_V1_wpLoose=cms.InputTag(
+                                                    'egmGsfElectronIDs:mvaEleID-Fall17-noIso-V1-wpLoose'),
+                                                  mvaEleID_Fall17_iso_V1_wp90=cms.InputTag(
+                                                    'egmGsfElectronIDs:mvaEleID-Fall17-iso-V1-wp90'),
+                                                  mvaEleID_Fall17_iso_V1_wp80=cms.InputTag(
+                                                    'egmGsfElectronIDs:mvaEleID-Fall17-iso-V1-wp80'),
+                                                  mvaEleID_Fall17_iso_V1_wpLoose=cms.InputTag(
+                                                    'egmGsfElectronIDs:mvaEleID-Fall17-iso-V1-wpLoose'),
                                               ),
 
                                                vmaps_float = cms.PSet(
@@ -1065,6 +1076,12 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
                                     'cutBasedElectronID_Fall17_94X_V1_Preliminary_medium',
                                     'cutBasedElectronID_Fall17_94X_V1_Preliminary_tight',
                                     'heepElectronID_HEEPV70',
+                                    'mvaEleID_Fall17_noIso_V1_wp90',
+                                    'mvaEleID_Fall17_noIso_V1_wp80',
+                                    'mvaEleID_Fall17_noIso_V1_wpLoose',
+                                    'mvaEleID_Fall17_iso_V1_wp90',
+                                    'mvaEleID_Fall17_iso_V1_wp80',
+                                    'mvaEleID_Fall17_iso_V1_wpLoose',
                                 ),
                                 # #Add variables to trace possible issues with the ECAL slew rate mitigation
                                 # #https://twiki.cern.ch/twiki/bin/view/CMSPublic/ReMiniAOD03Feb2017Notes#EGM

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -976,7 +976,6 @@ switchOnVIDElectronIdProducer(process, DataFormat.MiniAOD)
 
 elecID_mod_ls = [
     'RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Fall17_94X_V1_Preliminary_cff',
-    #  'RecoEgamma.ElectronIdentification.Identification.cutBasedElectronHLTPreselecition_Summer16_V1_cff',
     'RecoEgamma.ElectronIdentification.Identification.heepElectronID_HEEPV70_cff',
     #  'RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Spring16_GeneralPurpose_V1_cff',
     #  'RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Spring16_HZZ_V1_cff',
@@ -1067,7 +1066,6 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
                                     'cutBasedElectronID_Fall17_94X_V1_Preliminary_loose',
                                     'cutBasedElectronID_Fall17_94X_V1_Preliminary_medium',
                                     'cutBasedElectronID_Fall17_94X_V1_Preliminary_tight',
-                                    #'cutBasedElectronHLTPreselection_Summer16_V1',
                                     'heepElectronID_HEEPV70',
                                 ),
                                 # #Add variables to trace possible issues with the ECAL slew rate mitigation

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -978,8 +978,8 @@ switchOnVIDElectronIdProducer(process, DataFormat.MiniAOD)
 elecID_mod_ls = [
     'RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Fall17_94X_V1_Preliminary_cff',
     'RecoEgamma.ElectronIdentification.Identification.heepElectronID_HEEPV70_cff',
-    #  'RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Spring16_GeneralPurpose_V1_cff',
-    #  'RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Spring16_HZZ_V1_cff',
+    'RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Fall17_noIso_V1_cff',
+    'RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Fall17_iso_V1_cff',
 ]
 
 for mod in elecID_mod_ls:
@@ -1005,19 +1005,16 @@ process.slimmedElectronsUSER = cms.EDProducer('PATElectronUserData',
 
                                               ),
 
-                                              #  vmaps_float = cms.PSet(
-                                              #    ElectronMVAEstimatorRun2Spring16GeneralPurposeV1Values__user01 = cms.InputTag('electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring16GeneralPurposeV1Values'),
-                                              #    ElectronMVAEstimatorRun2Spring16HZZV1Values__user01 = cms.InputTag('electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring16HZZV1Values'),
-                                              #  ),
+                                               vmaps_float = cms.PSet(
+                                                   ElectronMVAEstimatorIso = cms.InputTag('electronMVAValueMapProducer:ElectronMVAEstimatorRun2Fall17IsoV1Values'),
+                                                   ElectronMVAEstimatorNoIso = cms.InputTag('electronMVAValueMapProducer:ElectronMVAEstimatorRun2Fall17NoIsoV1Values')
+                                               ),
 
                                               vmaps_double=cms.vstring(
                                                   el_isovals),
 
                                               effAreas_file=cms.FileInPath(
                                                   'RecoEgamma/ElectronIdentification/data/Fall17/effAreaElectrons_cone03_pfNeuHadronsAndPhotons_92X.txt'),
-
-                                              #  mva_GeneralPurpose = cms.string('ElectronMVAEstimatorRun2Spring16GeneralPurposeV1Values__user01'),
-                                              #  mva_HZZ = cms.string('ElectronMVAEstimatorRun2Spring16HZZV1Values__user01'),
                                               )
 task.add(process.egmGsfElectronIDs)
 task.add(process.slimmedElectronsUSER)

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -970,19 +970,18 @@ for m in el_isovals:
 
 
 # electron ID from VID
-from PhysicsTools.SelectorUtils.tools.vid_id_tools import *
+from PhysicsTools.SelectorUtils.tools.vid_id_tools import switchOnVIDElectronIdProducer, setupAllVIDIdsInModule, DataFormat, setupVIDElectronSelection
 
 switchOnVIDElectronIdProducer(process, DataFormat.MiniAOD)
 
 elecID_mod_ls = [
     'RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Fall17_94X_V1_Preliminary_cff',
     #  'RecoEgamma.ElectronIdentification.Identification.cutBasedElectronHLTPreselecition_Summer16_V1_cff',
-    #  'RecoEgamma.ElectronIdentification.Identification.heepElectronID_HEEPV6_0cff',
+    'RecoEgamma.ElectronIdentification.Identification.heepElectronID_HEEPV70_cff',
     #  'RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Spring16_GeneralPurpose_V1_cff',
     #  'RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Spring16_HZZ_V1_cff',
 ]
 
-from PhysicsTools.SelectorUtils.tools.vid_id_tools import *
 for mod in elecID_mod_ls:
     setupAllVIDIdsInModule(process, mod, setupVIDElectronSelection)
 
@@ -1001,6 +1000,8 @@ process.slimmedElectronsUSER = cms.EDProducer('PATElectronUserData',
                                                       'egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V1-Preliminary-medium'),
                                                   cutBasedElectronID_Fall17_94X_V1_Preliminary_tight=cms.InputTag(
                                                       'egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V1-Preliminary-tight'),
+                                                  heepElectronID_HEEPV70=cms.InputTag(
+                                                      'egmGsfElectronIDs:heepElectronID-HEEPV70'),
 
                                               ),
 
@@ -1067,7 +1068,7 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
                                     'cutBasedElectronID_Fall17_94X_V1_Preliminary_medium',
                                     'cutBasedElectronID_Fall17_94X_V1_Preliminary_tight',
                                     #'cutBasedElectronHLTPreselection_Summer16_V1',
-                                    #'heepElectronID_HEEPV60',
+                                    'heepElectronID_HEEPV70',
                                 ),
                                 # #Add variables to trace possible issues with the ECAL slew rate mitigation
                                 # #https://twiki.cern.ch/twiki/bin/view/CMSPublic/ReMiniAOD03Feb2017Notes#EGM
@@ -1334,8 +1335,11 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
 #process.content = cms.EDAnalyzer("EventContentAnalyzer")
 
 # Note: we run in unscheduled mode, i.e. all modules are run as required;
-# just make sure that MyNtuple runs:
-process.p = cms.Path(process.MyNtuple)
+# just make sure that the electron IDs run before MyNtuple
+process.p = cms.Path(
+    process.egmGsfElectronIDSequence *
+    process.MyNtuple
+)
 process.p.associate(task)
 process.p.associate(process.patAlgosToolsTask)
 

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -63,14 +63,15 @@ process.source = cms.Source("PoolSource",
                                 # '/store/data/Run2017B/JetHT/MINIAOD/22Jun2017-v1/00000/00063668-8858-E711-9C49-001E67792486.root'
                                 # '/store/data/Run2017D/JetHT/MINIAOD/PromptReco-v1/000/302/031/00000/24C14AB9-488F-E711-A2D5-02163E019D41.root'
                                 '/store/data/Run2017B/JetHT/MINIAOD/17Nov2017-v1/20000/0016BE6B-FACC-E711-88D8-B499BAAC0068.root'
-                                #'/store/mc/RunIIFall17MiniAOD/QCD_Pt-15to7000_TuneCP5_Flat_13TeV_pythia8/MINIAODSIM/94X_mc2017_realistic_v10-v1/50000/00197229-2FDD-E711-9070-0025904AC2C4.root'
+                                # '/store/data/Run2017B/SingleElectron/MINIAOD/17Nov2017-v1/40000/00701B6B-E9DB-E711-B111-02163E019D6D.root'
+                                # '/store/mc/RunIIFall17MiniAOD/QCD_Pt-15to7000_TuneCP5_Flat_13TeV_pythia8/MINIAODSIM/94X_mc2017_realistic_v10-v1/50000/00197229-2FDD-E711-9070-0025904AC2C4.root'
                                 # '/store/data/Run2017B/SingleMuon/MINIAOD/PromptReco-v1/000/297/046/00000/32AC3177-7A56-E711-BE34-02163E019D73.root'
                             ]),
                             skipEvents=cms.untracked.uint32(0)
                             )
 
-# process.maxEvents = cms.untracked.PSet(input=cms.untracked.int32(100))
-process.maxEvents = cms.untracked.PSet(input=cms.untracked.int32(10))
+process.maxEvents = cms.untracked.PSet(input=cms.untracked.int32(100))
+# process.maxEvents = cms.untracked.PSet(input=cms.untracked.int32(10))
 
 # Grid-control changes:
 gc_maxevents = '__MAX_EVENTS__'

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -87,8 +87,10 @@ cd $CMSSW_BASE/src
 
 time git cms-init -y  # not needed if not addpkg ing
 
-# Add in preliminary EGamma VID
+# Add in preliminary cut-based EGamma VID
 git cms-merge-topic lsoffi:CMSSW_9_4_0_pre3_TnP
+# Add in preliminary MVA EGamma VID
+git cms-merge-topic guitargeek:ElectronID_MVA2017_940pre3
 
 # Necessary for using our FastJet
 git cms-addpkg RecoJets/JetProducers
@@ -115,6 +117,15 @@ scram setup fastjet-contrib-archive
 
 scram b clean
 time scram b $MAKEFLAGS
+
+# Some manual hacking to get the MVA files - in future they should be
+# in the main release, and you can remove this
+# Note: the “external” area appears after “scram build” is run at least once
+cd $CMSSW_BASE/external/$SCRAM_ARCH
+git clone https://github.com/lsoffi/RecoEgamma-ElectronIdentification.git data/RecoEgamma/ElectronIdentification/data
+cd data/RecoEgamma/ElectronIdentification/data
+git checkout CMSSW_9_4_0_pre3_TnP
+cd $CMSSW_BASE/src
 
 # Get the UHH2 repo & JEC files
 cd $CMSSW_BASE/src


### PR DESCRIPTION
Update electron IDs to store HEEPv7.0, and the latest MVA IDs.
See https://hypernews.cern.ch/HyperNews/CMS/get/egamma/2013.html

**NOTE** This requires doing an extra bit of setup, see changes in `install.sh`. You should also `make clean && make` to ensure all the changes in `uhh::Electron` are picked up properly.

For HEEP, we only store the pass/fail bool.
For MVA IDs, we store both the MVA values and the pass/fail bools.
The changes to the MVA bits are more extensive as now there are 2 MVA IDs, iso & non-iso, so `uhh::Electron` methods have been updated, as have IDs.
Since the wp80 and wp90 are now not just simple cut values but a formula, I haven't included them in the `ElectronIds.cxx`.
If they ever change, we can redo the calculation using the stored MVA values.
The loose working point is a simple cut value, so I've added it in.