### PR TITLE
[94X] Bring back the CHS HepTopTagger (& CA15 jets)

### DIFF
--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -351,6 +351,10 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
           cfg.higgstaginfo_src = topjets_list[j].getParameter<std::string>("higgstaginfo_source");
         }
 
+        if (topjets_list[j].exists("toptagging_source")){
+          cfg.toptagging_src = topjets_list[j].getParameter<std::string>("toptagging_source");
+        }
+
         bool substructure_variables = false;
         bool substructure_groomed_variables = false;
         if(topjets_list[j].exists("njettiness_source")){

--- a/core/plugins/NtupleWriterJets.cxx
+++ b/core/plugins/NtupleWriterJets.cxx
@@ -10,7 +10,7 @@
 #include "RecoBTau/JetTagComputer/interface/JetTagComputer.h"
 #include "RecoBTau/JetTagComputer/interface/JetTagComputerRecord.h"
 #include "FWCore/Framework/interface/ESHandle.h"
-//#include "DataFormats/JetReco/interface/HTTTopJetTagInfo.h"
+#include "DataFormats/BTauReco/interface/HTTTopJetTagInfo.h"
 #include "RecoBTag/SecondaryVertex/interface/CandidateBoostedDoubleSecondaryVertexComputer.h"
 #include "TrackingTools/Records/interface/TransientTrackRecord.h"
 #include "RecoBTau/JetTagComputer/interface/JetTagComputerRecord.h"
@@ -316,8 +316,8 @@ NtupleWriterTopJets::NtupleWriterTopJets(Config & cfg, bool set_jets_member): pt
     subjet_src = cfg.subjet_src;
     higgs_src= cfg.higgs_src;
 
-//    src_hepTopTagCHS_token = cfg.cc.consumes<edm::View<reco::HTTTopJetTagInfo> >(edm::InputTag("hepTopTagCHS"));
-//    src_hepTopTagPuppi_token = cfg.cc.consumes<edm::View<reco::HTTTopJetTagInfo> >(edm::InputTag("hepTopTagPuppi"));
+    src_hepTopTagCHS_token = cfg.cc.consumes<edm::View<reco::HTTTopJetTagInfo> >(edm::InputTag("hepTopTagCHS"));
+    src_hepTopTagPuppi_token = cfg.cc.consumes<edm::View<reco::HTTTopJetTagInfo> >(edm::InputTag("hepTopTagPuppi"));
 
     pruned_src = cfg.pruned_src;
     if(pruned_src.find("Mass")==string::npos){
@@ -419,11 +419,11 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
       }
     }
     vector<TopJet> topjets;
-/*    edm::Handle<edm::View<reco::HTTTopJetTagInfo>> top_jet_infos;
+    edm::Handle<edm::View<reco::HTTTopJetTagInfo>> top_jet_infos;
     if (topjet_collection.find("CHS")!=string::npos) event.getByToken(src_hepTopTagCHS_token, top_jet_infos);
     if (topjet_collection.find("Puppi")!=string::npos) event.getByToken(src_hepTopTagPuppi_token, top_jet_infos); // Make sure both collections have the same size
     if (topjet_collection.find("Hep")!=string::npos) assert(pat_topjets.size()==top_jet_infos->size());
-*/
+
     /*--- lepton keys ---*/
     std::vector<long int> lepton_keys;
     if(save_lepton_keys_){
@@ -604,18 +604,18 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
         }
 
         /*--- HEP Top Tagger variables -----*/
-/*
+
         if (topjet_collection.find("Hep")!=string::npos)
-           {
-              const reco::HTTTopJetTagInfo& jet_info = top_jet_infos->at(i);
-              topjet.set_tag(TopJet::tagname2tag("fRec"), jet_info.properties().fRec);
-              topjet.set_tag(TopJet::tagname2tag("Ropt"), jet_info.properties().Ropt);
-              topjet.set_tag(TopJet::tagname2tag("massRatioPassed"), jet_info.properties().massRatioPassed);
-              topjet.set_tag(TopJet::tagname2tag("mass"),pat_topjet.mass());
-              topjet.set_tag(TopJet::tagname2tag("RoptCalc"), jet_info.properties().RoptCalc);
-              topjet.set_tag(TopJet::tagname2tag("ptForRoptCalc"), jet_info.properties().ptForRoptCalc);
-           }
-*/
+        {
+          const reco::HTTTopJetTagInfo& jet_info = top_jet_infos->at(i);
+          topjet.set_tag(TopJet::tagname2tag("fRec"), jet_info.properties().fRec);
+          topjet.set_tag(TopJet::tagname2tag("Ropt"), jet_info.properties().ropt);
+          topjet.set_tag(TopJet::tagname2tag("massRatioPassed"), jet_info.properties().massRatioPassed);
+          topjet.set_tag(TopJet::tagname2tag("mass"),pat_topjet.mass());
+          topjet.set_tag(TopJet::tagname2tag("RoptCalc"), jet_info.properties().roptCalc);
+          topjet.set_tag(TopJet::tagname2tag("ptForRoptCalc"), jet_info.properties().ptForRoptCalc);
+        }
+
         /*--- Njettiness ------*/
         if(njettiness_src.empty()){
 

--- a/core/plugins/NtupleWriterJets.cxx
+++ b/core/plugins/NtupleWriterJets.cxx
@@ -164,15 +164,24 @@ void NtupleWriterJets::fill_jet_info(const pat::Jet & pat_jet, Jet & jet, bool d
     jet.set_photonMultiplicity (pat_jet.photonMultiplicity());
   }
 
-  jet.set_JEC_factor_raw(pat_jet.jecFactor("Uncorrected"));
-  //L1 factor needed for JEC propagation to MET
-  const std::vector< std::string > factors_jet = pat_jet.availableJECLevels();
-  bool isL1 = false;
-  for(unsigned int i=0;i<factors_jet.size();i++)
-    if(factors_jet[i]=="L1FastJet")
-      isL1 = true;
-  if(isL1) jet.set_JEC_L1factor_raw(pat_jet.jecFactor("L1FastJet"));
-  else jet.set_JEC_L1factor_raw(1.);//PUPPI jets don't have L1 factor
+  // ensures you can still store jets without any JEC applied
+  if (pat_jet.jecSetsAvailable()) {
+    jet.set_JEC_factor_raw(pat_jet.jecFactor("Uncorrected"));
+
+    //L1 factor needed for JEC propagation to MET
+    const std::vector< std::string > factors_jet = pat_jet.availableJECLevels();
+    bool isL1 = false;
+    for(unsigned int i=0;i<factors_jet.size();i++)
+      if(factors_jet[i]=="L1FastJet")
+        isL1 = true;
+    if(isL1) jet.set_JEC_L1factor_raw(pat_jet.jecFactor("L1FastJet"));
+    else jet.set_JEC_L1factor_raw(1.);//PUPPI jets don't have L1 factor
+
+  } else {
+    jet.set_JEC_factor_raw(1.);
+    jet.set_JEC_L1factor_raw(1.);
+  }
+
 
   if(do_taginfo){
     JetBTagInfo jetbtaginfo;

--- a/core/plugins/NtupleWriterJets.h
+++ b/core/plugins/NtupleWriterJets.h
@@ -55,17 +55,18 @@ public:
         bool do_btagging = true, do_btagging_subjets = true, do_taginfo_subjets;
 
         edm::InputTag substructure_variables_src;// a jet collection from where to take the subjet variables (after DeltaR-matching)
-	edm::InputTag substructure_groomed_variables_src;
-	edm::InputTag SVComputer;
+        edm::InputTag substructure_groomed_variables_src;
+        edm::InputTag SVComputer;
         std::string njettiness_src;
-	std::string njettiness_groomed_src;
+        std::string njettiness_groomed_src;
         std::string qjets_src;
-	std::string subjet_src;
-	std::string higgs_src;
-	std::string higgs_name;
+        std::string subjet_src;
+        std::string higgs_src;
+        std::string higgs_name;
         std::string higgstaginfo_src;
-	std::string pruned_src;
+        std::string pruned_src;
         std::string softdrop_src;
+        std::string toptagging_src;
     };
 
     explicit NtupleWriterTopJets(Config & cfg, bool set_jets_member);
@@ -78,11 +79,11 @@ public:
 private:
     edm::InputTag src;
     float ptmin, etamax;
-    bool do_btagging, do_btagging_subjets, do_taginfo_subjets;
+    bool do_btagging, do_btagging_subjets, do_taginfo_subjets, do_toptagging;
     edm::EDGetToken src_token, src_higgs_token, src_pruned_token, src_softdrop_token, substructure_variables_src_token, substructure_variables_src_tokenreco, substructure_groomed_variables_src_token, substructure_groomed_variables_src_tokenreco;
     edm::EDGetToken src_njettiness1_token, src_njettiness2_token, src_njettiness3_token, src_qjets_token;
     edm::EDGetToken src_njettiness1_groomed_token, src_njettiness2_groomed_token, src_njettiness3_groomed_token;
-    edm::EDGetToken src_hepTopTagCHS_token, src_hepTopTagPuppi_token;
+    edm::EDGetToken src_hepTopTag_token;
     edm::EDGetToken src_higgstaginfo_token;
     std::string njettiness_src, njettiness_groomed_src, qjets_src, subjet_src, higgs_src, higgs_name, higgstaginfo_src, pruned_src, softdrop_src, topjet_collection;
     Event::Handle<std::vector<TopJet>> handle;

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -1120,20 +1120,29 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
 
                                 TopJets=cms.VPSet(
                                     cms.PSet(
-                                        # THESE ARE PUPPI JETS IN 91X
+                                        # Each PSet outputs a TopJet collection, with name {topjet_source}_{subjet_source}
+                                        # For each, we store the jets in topjet_source as TopJet objects,
+                                        # with its subjets stored depending on subjet_source.
+                                        # Tagging info can also be stored, as well as various substructure variables.
                                         topjet_source=cms.string(
-                                            "slimmedJetsAK8"),
-                                        # Note: use label "daughters" for  subjet_source if you want to store as subjets the linked daughters of the topjets (NOT for slimmedJetsAK8 in miniAOD!)
-                                        # to store a subjet collection present in miniAOD indicate the
-                                        # proper label of the subjets method in pat::Jet: SoftDrop or
-                                        # CMSTopTag
+                                            "slimmedJetsAK8"),  # puppi jets in 2017 MiniAOD
+                                        # For subjet_source, use label "daughters" if you want to store as
+                                        # subjets the linked daughters of the topjets (NOT for slimmedJetsAK8 in miniAOD!).
+                                        # Otherwise, to store a subjet collection present in miniAOD indicate the
+                                        # proper label to be passed to pat::Jet::subjet(...)
+                                        # e.g. SoftDropPuppi or CMSTopTag
+                                        # If you include "CHS" in this string,
+                                        # it will use the matched CHS 4-vector for the *main* jet 4-vector.
                                         subjet_source=cms.string(
                                             "SoftDropPuppi"),
-                                        # Specify if you want to store b-tagging taginfos for subjet collection, make sure to have included them with .addTagInfos = True
-                                        # addTagInfos = True is currently true by default, however, only for collections produced and not read directly from miniAOD
+                                        # Specify if you want to store b-tagging taginfos for subjet collection,
+                                        # make sure to have included them with .addTagInfos = True
+                                        # addTagInfos = True is currently true by default, however,
+                                        # only for collections produced and not read directly from miniAOD
                                         # Default is do_subjet_taginfo=False
                                         do_subjet_taginfo=cms.bool(False),
-                                        # Note: if you want to store the MVA Higgs tagger discriminator, specify the jet collection from which to pick it up and the tagger name
+                                        # Note: if you want to store the MVA Higgs tagger discriminator,
+                                        # specify the jet collection from which to pick it up and the tagger name
                                         # currently the discriminator is trained on ungroomed jets, so
                                         # the discriminator has to be taken
                                         # from ungroomed jets
@@ -1141,15 +1150,17 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
                                             "patJetsAk8PuppiJetsFat"),
                                         higgstag_name=cms.string(
                                             "pfBoostedDoubleSecondaryVertexAK8BJetTags"),
-                                        # Note: if empty, njettiness is directly taken from MINIAOD UserFloat and added to jets, otherwise taken from the provided source (for Run II CMSSW_74 ntuples)
+                                        # If empty, njettiness is directly taken from MINIAOD UserFloat
+                                        # and added to jets, otherwise taken from the provided source
                                         #njettiness_source = cms.string(""),
                                         #substructure_variables_source = cms.string(""),
                                         #njettiness_groomed_source = cms.string(""),
                                         #substructure_groomed_variables_source = cms.string(""),
-                                        # Note: for slimmedJetsAK8 on miniAOD, the pruned mass is available as user float, with label ak8PFJetsCHSPrunedMass.
-                                        # Alternatively it is possible to specify another pruned jet collection (to be produced here), from which to get it by jet-matching.
-                                        # Finally, it is also possible to leave the pruned mass empty
-                                        # with ""
+                                        # Note: for slimmedJetsAK8 on miniAOD, the pruned mass is
+                                        # available as user float, with label ak8PFJetsCHSPrunedMass.
+                                        # Alternatively it is possible to specify another pruned jet collection
+                                        # (to be produced here), from which to get it by jet-matching.
+                                        # Finally, it is also possible to leave the pruned mass empty with ""
                                         prunedmass_source=cms.string(
                                             "ak8PFJetsCHSValueMap:ak8PFJetsCHSPrunedMass"),
                                         softdropmass_source=cms.string(

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -337,8 +337,9 @@ process.ca15CHSJetsPruned = ak4PFJetsPruned.clone(
     jetAlgorithm="CambridgeAachen",
     doAreaFastjet=True,
     src='chs',
-    jetPtMin=70
+    jetPtMin=process.ca15CHSJets.jetPtMin
 )
+task.add(process.ca15CHSJetsPruned)
 
 ###############################################
 # PUPPI JETS
@@ -662,7 +663,7 @@ add_fatjets_subjets(process, 'ak8PuppiJetsFat', 'ak8PuppiJetsSoftDrop', genjets_
 # B-tagging not needed for pruned jets, they are just used to get the mass
 add_fatjets_subjets(process, 'ak8CHSJets', 'ak8CHSJetsPruned',
                     genjets_name=lambda s: s.replace('CHS', 'Gen'), btagging=False)
-# add_fatjets_subjets(process, 'ca15CHSJets', 'ca15CHSJetsPruned', genjets_name=lambda s: s.replace('CHS', 'Gen'), btagging=False)
+add_fatjets_subjets(process, 'ca15CHSJets', 'ca15CHSJetsPruned', jetcorr_label=None, jetcorr_label_subjets=None)  # we only use this to make packed collection for pruned mass
 #add_fatjets_subjets(process, 'ca8PuppiJets', 'ca8PuppiJetsPruned', genjets_name = lambda s: s.replace('Puppi', 'Gen'))
 #add_fatjets_subjets(process, 'ca15PuppiJets', 'ca15PuppiJetsFiltered', genjets_name = lambda s: s.replace('Puppi', 'Gen'))
 #add_fatjets_subjets(process, 'ca8PuppiJets', 'cmsTopTagPuppi', genjets_name = lambda s: s.replace('Puppi', 'Gen'))
@@ -1198,7 +1199,8 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
                                         # Specify the module that makes reco::HTTTopJetTagInfo
                                         toptagging_source = cms.string(
                                             "hepTopTagCHS"),
-                                        # prunedmass_source = cms.string("patJetsCa15CHSJetsPrunedPacked"),
+                                        prunedmass_source = cms.string(
+                                            "patJetsCa15CHSJetsPrunedPacked"),
                                         # softdropmass_source  = cms.string(""),
                                     ) ,
                                     # cms.PSet(

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -223,10 +223,10 @@ process.ca8CHSJetsPruned = ak4PFJetsPruned.clone(
 from RecoJets.JetProducers.AnomalousCellParameters_cfi import *
 from RecoJets.JetProducers.PFJetParameters_cfi import *
 # The HTTTopJetProducer does its own clustering producing a BasicJet of
-# (ungroomed jets), as well as producing PFJet (SubJets), and HTTTopJetTagInfo
-# Since we cannot store the BasicJet collection using addJetCollection
-# (which expects a reco::PFJet) we will have to create the CA15 jets separately
-# using the same parameters to ensure they stay in sync.
+# Top candidates (i.e. sum of subjects),
+# as well as producing PFJet (SubJets), and HTTTopJetTagInfo
+# The CA15 jets here are the "original" fatjets going into the HTT, and thus will
+# be different from the BAsicJEt collection that HTTTopJetProducer produces
 ca15_clustering_params = dict(
     useExplicitGhosts   = cms.bool(True),
     jetAlgorithm        = cms.string("CambridgeAachen"),
@@ -298,7 +298,7 @@ process.ca15CHSJetsSoftDropforsub = process.ca15CHSJets.clone(
     beta=cms.double(0.0),
     useSoftDrop=cms.bool(True),
     useExplicitGhosts=cms.bool(True),
-    R0=cms.double(0.8)
+    R0=cms.double(1.5)
 )
 task.add(process.ca15CHSJetsSoftDropforsub)
 
@@ -646,7 +646,7 @@ def add_fatjets_subjets(process, fatjets_name, groomed_jets_name, jetcorr_label=
 # add_fatjets_subjets(process, 'ca15CHSJets', 'ca15CHSJetsFiltered', genjets_name=lambda s: s.replace('CHS', 'Gen'))
 #add_fatjets_subjets(process, 'ca15CHSJets', 'hepTopTagCHS')
 #add_fatjets_subjets(process, 'ca8CHSJets', 'cmsTopTagCHS', genjets_name = lambda s: s.replace('CHS', 'Gen'))
-add_fatjets_subjets(process, 'ca15CHSJets', 'hepTopTagCHS', top_tagging=True)  # really we should use CA JEC but they don't exist...it's OK though as we store the JEC factor and can uncorrect.
+add_fatjets_subjets(process, 'ca15CHSJets', 'hepTopTagCHS', top_tagging=True, jetcorr_label=None, jetcorr_label_subjets=None)  # CA JEC don't exist so use nothing
 add_fatjets_subjets(process, 'ak8CHSJets', 'ak8CHSJetsSoftDrop',
                     genjets_name=lambda s: s.replace('CHS', 'Gen'))
 # add_fatjets_subjets(process, 'ca15CHSJets', 'ca15CHSJetsSoftDrop', genjets_name=lambda s: s.replace('CHS', 'Gen'))
@@ -1171,6 +1171,9 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
                                             "patJetsAk8CHSJetsSoftDropPacked"),
                                     ),
                                     cms.PSet(
+                                        # The fat jets that HepTopTag produces are the Top jet candidates,
+                                        # i.e. the sum of its subjets. Therefore they will NOT have
+                                        # the same pt/eta/phi as normal ca15 jets.
                                         topjet_source = cms.string(
                                             "patJetsHepTopTagCHSPacked"),
                                         subjet_source = cms.string("daughters"),

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -539,6 +539,10 @@ def add_fatjets_subjets(process, fatjets_name, groomed_jets_name, jetcorr_label=
     if useData:
         jetcorr_list = ['L1FastJet', 'L2Relative',
                         'L3Absolute', 'L2L3Residual']
+    if jetcorr_label:
+        jetcorr_arg = (jetcorr_label, cms.vstring(jetcorr_list), 'None')
+    else:
+        jetcorr_arg = None
 
     # patify ungroomed jets, if not already done:
     ungroomed_patname = 'patJets' + cap(fatjets_name)
@@ -551,8 +555,7 @@ def add_fatjets_subjets(process, fatjets_name, groomed_jets_name, jetcorr_label=
                          jetSource=cms.InputTag(fatjets_name),
                          algo=algo,
                          rParam=rParam,
-                         jetCorrections=(jetcorr_label, cms.vstring(
-                             jetcorr_list), 'None'),
+                         jetCorrections=jetcorr_arg,
                          genJetCollection=cms.InputTag(ungroomed_genjets_name),
                          **common_btag_parameters
                          )
@@ -567,8 +570,7 @@ def add_fatjets_subjets(process, fatjets_name, groomed_jets_name, jetcorr_label=
                      jetSource=cms.InputTag(groomed_jets_name),
                      algo=algo,
                      rParam=rParam,
-                     jetCorrections=(jetcorr_label, cms.vstring(
-                         jetcorr_list), 'None'),
+                     jetCorrections=jetcorr_arg,
                      # genJetCollection = cms.InputTag(groomed_genjets_name), #
                      # nice try, but PAT looks for GenJets, whereas jets with
                      # subjets are BasicJets, so PAT cannot be used for this
@@ -584,13 +586,16 @@ def add_fatjets_subjets(process, fatjets_name, groomed_jets_name, jetcorr_label=
     subjets_patname = "patJets" + cap(subjets_name)
     if verbose:
         print "adding groomed jets' subjets", subjets_patname
+    if jetcorr_label_subjets:
+        jetcorr_arg = (jetcorr_label_subjets, cms.vstring(jetcorr_list), 'None')
+    else:
+        jetcorr_arg = None
     addJetCollection(process,
                      labelName=subjets_name,
                      jetSource=cms.InputTag(groomed_jets_name, 'SubJets'),
                      algo=algo,
                      rParam=rParam,
-                     jetCorrections=(jetcorr_label_subjets,
-                                     cms.vstring(jetcorr_list), 'None'),
+                     jetCorrections=jetcorr_arg,
                      explicitJTA=True,
                      svClustering=True,
                      fatJets=cms.InputTag(fatjets_name),

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -1032,15 +1032,6 @@ task.add(process.slimmedElectronsUSER)
 
 # NtupleWriter
 
-isreHLT = False
-for x in process.source.fileNames:
-    if "reHLT" in x:
-        isreHLT = True
-
-triggerpath = "HLT"
-if isreHLT:
-    triggerpath = "HLT2"
-
 if useData:
     metfilterpath = "RECO"
 else:
@@ -1245,7 +1236,7 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
 
                                 doTrigger=cms.bool(True),
                                 trigger_bits=cms.InputTag(
-                                    "TriggerResults", "", triggerpath),
+                                    "TriggerResults", "", "HLT"),
                                 # MET filters (HBHE noise, CSC, etc.) are stored as trigger Bits in
                                 # MINIAOD produced in path "PAT"/"RECO" with
                                 # prefix "Flag_"

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -1187,6 +1187,9 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
                                             "NjettinessCa15SoftDropCHS"),
                                         substructure_groomed_variables_source = cms.string(
                                             "ca15CHSJetsSoftDropforsub"),
+                                        # Specify the module that makes reco::HTTTopJetTagInfo
+                                        toptagging_source = cms.string(
+                                            "hepTopTagCHS"),
                                         # prunedmass_source = cms.string("patJetsCa15CHSJetsPrunedPacked"),
                                         # softdropmass_source  = cms.string(""),
                                     ) ,

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -482,9 +482,11 @@ def modify_patjetproducer_for_data(producer):
 # Note that gen jets are produced but genjet *matching* is currently only working for the fat, ungroomed jets,
 # and the subjets, but not for the groomed fat jets; this is a restriction
 # of PAT.
+#
+# One can also enable the storing of top tagging info. In this case, it will use info from
+# groomed_jets_name, and top_tagging must be set True. Additionally, btagging must be set True
 
-
-def add_fatjets_subjets(process, fatjets_name, groomed_jets_name, jetcorr_label='AK8PFchs', jetcorr_label_subjets='AK4PFchs', genjets_name=None, verbose=True, btagging=True):
+def add_fatjets_subjets(process, fatjets_name, groomed_jets_name, jetcorr_label='AK8PFchs', jetcorr_label_subjets='AK4PFchs', genjets_name=None, verbose=True, btagging=True, top_tagging=False):
     rParam = getattr(process, fatjets_name).rParam.value()
     algo_dict = {"CambridgeAachen": "ca", "AntiKt": "ak"}
     algo = algo_dict.get(getattr(process, fatjets_name).jetAlgorithm.value(), None)
@@ -575,9 +577,8 @@ def add_fatjets_subjets(process, fatjets_name, groomed_jets_name, jetcorr_label=
                      **common_btag_parameters
                      )
     getattr(process, groomed_patname).addTagInfos = True
-    if groomed_jets_name == "hepTopTagCHS":
-        getattr(process, groomed_patname).tagInfoSources = cms.VInputTag(
-            cms.InputTag('hepTopTagCHS'))
+    if top_tagging:
+        getattr(process, groomed_patname).tagInfoSources = cms.VInputTag(groomed_jets_name)
 
     # patify subjets, with subjet b-tagging:
     subjets_patname = "patJets" + cap(subjets_name)
@@ -645,7 +646,7 @@ def add_fatjets_subjets(process, fatjets_name, groomed_jets_name, jetcorr_label=
 # add_fatjets_subjets(process, 'ca15CHSJets', 'ca15CHSJetsFiltered', genjets_name=lambda s: s.replace('CHS', 'Gen'))
 #add_fatjets_subjets(process, 'ca15CHSJets', 'hepTopTagCHS')
 #add_fatjets_subjets(process, 'ca8CHSJets', 'cmsTopTagCHS', genjets_name = lambda s: s.replace('CHS', 'Gen'))
-add_fatjets_subjets(process, 'ca15CHSJets', 'hepTopTagCHS')  # really we should use CA JEC but they don't exist...it's OK though as we store the JEC factor and can uncorrect.
+add_fatjets_subjets(process, 'ca15CHSJets', 'hepTopTagCHS', top_tagging=True)  # really we should use CA JEC but they don't exist...it's OK though as we store the JEC factor and can uncorrect.
 add_fatjets_subjets(process, 'ak8CHSJets', 'ak8CHSJetsSoftDrop',
                     genjets_name=lambda s: s.replace('CHS', 'Gen'))
 # add_fatjets_subjets(process, 'ca15CHSJets', 'ca15CHSJetsSoftDrop', genjets_name=lambda s: s.replace('CHS', 'Gen'))

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -235,60 +235,55 @@ process.ca8CHSJetsPruned = ak4PFJetsPruned.clone(
 
 from RecoJets.JetProducers.AnomalousCellParameters_cfi import *
 from RecoJets.JetProducers.PFJetParameters_cfi import *
-from RecoJets.JetProducers.CATopJetParameters_cfi import CATopJetParameters
-# process.cmsTopTagCHS = cms.EDProducer(
-#    "CATopJetProducer",
-#    PFJetParameters.clone( src = cms.InputTag('chs'),
-#                           doAreaFastjet = cms.bool(True),
-#                           doRhoFastjet = cms.bool(False),
-#                           jetPtMin = cms.double(fatjet_ptmin)
-#                           ),
-#    AnomalousCellParameters,
-#    CATopJetParameters.clone( jetCollInstanceName = cms.string("SubJets")),
-#    jetAlgorithm = cms.string("CambridgeAachen"),
-#    rParam = cms.double(0.8),
-#    writeCompound = cms.bool(True)
-#)
+# The HTTTopJetProducer does its own clustering producing a BasicJet of
+# (ungroomed jets), as well as producing PFJet (SubJets), and HTTTopJetTagInfo
+# Since we cannot store the BasicJet collection using addJetCollection
+# (which expects a reco::PFJet) we will have to create the CA15 jets separately
+# using the same parameters to ensure they stay in sync.
+ca15_clustering_params = dict(
+    useExplicitGhosts   = cms.bool(True),
+    jetAlgorithm        = cms.string("CambridgeAachen"),
+    rParam              = cms.double(1.5),
+    **AnomalousCellParameters.parameters_()
+)
+ca15_clustering_params.update(
+    **(PFJetParameters.clone(
+        src               = cms.InputTag("chs"),
+        doAreaFastjet     = cms.bool(True),
+        doRhoFastjet      = cms.bool(False),
+        jetPtMin          = cms.double(200.0)
+     ).parameters_())
+)
 
-# process.hepTopTagCHS = process.cmsTopTagCHS.clone(
-#    rParam = cms.double(1.5),
-#    tagAlgo = cms.int32(2), #2=fastjet heptt
-#    muCut = cms.double(0.8),
-#    maxSubjetMass = cms.double(30.0),
-#    useSubjetMass = cms.bool(False),
-#)
+process.ca15CHSJets = cms.EDProducer("FastjetJetProducer",
+    **ca15_clustering_params
+)
+task.add(process.ca15CHSJets)
 
-# process.hepTopTagCHS = cms.EDProducer(
-#        "HTTTopJetProducer",
-#         PFJetParameters.clone( src = cms.InputTag('chs'),
-#                               doAreaFastjet = cms.bool(True),
-#                               doRhoFastjet = cms.bool(False),
-#                               jetPtMin = cms.double(fatjet_ptmin)
-#                               ),
-#        AnomalousCellParameters,
-#        optimalR = cms.bool(True),
-#        algorithm = cms.int32(1),
-#        jetCollInstanceName = cms.string("SubJets"),
-#        jetAlgorithm = cms.string("CambridgeAachen"),
-#        rParam = cms.double(1.5),
-#        mode = cms.int32(4),
-#        minFatjetPt = cms.double(fatjet_ptmin),
-#        minCandPt = cms.double(0.),
-#        minSubjetPt = cms.double(0.),
-#        writeCompound = cms.bool(True),
-#        minCandMass = cms.double(0.),
-#        maxCandMass = cms.double(1000),
-#        massRatioWidth = cms.double(100.),
-#        minM23Cut = cms.double(0.),
-#        minM13Cut = cms.double(0.),
-#        maxM13Cut = cms.double(2.))
-
-# also re-do the ak4 jet clustering, as this is much simpler for b-tagging (there does not seem to be a simple way of
-# re-running b-tagging on the slimmedJets ...).
-#from RecoJets.JetProducers.ak4PFJets_cfi import ak4PFJets
-#process.ak4PFCHS = ak4PFJets.clone(src = 'chs')
-#process.ak8PFCHS =process.ak4PFCHS.clone(rParam = 0.8)
-
+process.hepTopTagCHS = cms.EDProducer("HTTTopJetProducer",
+    optimalR            = cms.bool(True),
+    qJets               = cms.bool(False),
+    minFatjetPt         = cms.double(200.),
+    minSubjetPt         = cms.double(0.),
+    minCandPt           = cms.double(0.),
+    maxFatjetAbsEta     = cms.double(99.),
+    subjetMass          = cms.double(30.),
+    muCut               = cms.double(0.8),
+    filtR               = cms.double(0.3),
+    filtN               = cms.int32(5),
+    mode                = cms.int32(4),
+    minCandMass         = cms.double(0.),
+    maxCandMass         = cms.double(999999.),
+    massRatioWidth      = cms.double(999999.),
+    minM23Cut           = cms.double(0.),
+    minM13Cut           = cms.double(0.),
+    maxM13Cut           = cms.double(999999.),
+    jetCollInstanceName = cms.string("SubJets"),
+    algorithm           = cms.int32(1),
+    writeCompound       = cms.bool(True),
+    **ca15_clustering_params
+)
+task.add(process.hepTopTagCHS)
 
 #################################################
 # Softdrop
@@ -302,17 +297,24 @@ task.add(process.ak8CHSJetsSoftDrop)
 
 process.ca15CHSJetsSoftDrop = ak8PFJetsCHSSoftDrop.clone(
     src=cms.InputTag('chs'),
-    jetPtMin=fatjet_ptmin,
+    jetPtMin=process.ca15CHSJets.jetPtMin,
     jetAlgorithm=cms.string("CambridgeAachen"),
     rParam=1.5,
     R0=1.5,
     zcut=cms.double(0.2),
     beta=cms.double(1.0)
 )
+task.add(process.ca15CHSJetsSoftDrop)
 
-# process.ca15CHSJetsSoftDropforsub = process.ca8CHSJets.clone(rParam=1.5, jetPtMin=fatjet_ptmin, zcut=cms.double(
-# 0.2), beta=cms.double(1.0), useSoftDrop=cms.bool(True),
-# useExplicitGhosts=cms.bool(True), R0=cms.double(1.5))
+process.ca15CHSJetsSoftDropforsub = process.ca15CHSJets.clone(
+    zcut=cms.double(0.1),
+    beta=cms.double(0.0),
+    useSoftDrop=cms.bool(True),
+    useExplicitGhosts=cms.bool(True),
+    R0=cms.double(0.8)
+)
+task.add(process.ca15CHSJetsSoftDropforsub)
+
 process.ak8CHSJetsSoftDropforsub = process.ak8CHSJetsFat.clone(
     rParam=0.8,
     jetPtMin=fatjet_ptmin,
@@ -662,7 +664,7 @@ def add_fatjets_subjets(process, fatjets_name, groomed_jets_name, jetcorr_label=
 # add_fatjets_subjets(process, 'ca15CHSJets', 'ca15CHSJetsFiltered', genjets_name=lambda s: s.replace('CHS', 'Gen'))
 #add_fatjets_subjets(process, 'ca15CHSJets', 'hepTopTagCHS')
 #add_fatjets_subjets(process, 'ca8CHSJets', 'cmsTopTagCHS', genjets_name = lambda s: s.replace('CHS', 'Gen'))
-#add_fatjets_subjets(process, 'ca15CHSJets', 'hepTopTagCHS', genjets_name = lambda s: s.replace('CHS', 'Gen'))
+add_fatjets_subjets(process, 'ca15CHSJets', 'hepTopTagCHS')
 add_fatjets_subjets(process, 'ak8CHSJets', 'ak8CHSJetsSoftDrop',
                     genjets_name=lambda s: s.replace('CHS', 'Gen'))
 # add_fatjets_subjets(process, 'ca15CHSJets', 'ca15CHSJetsSoftDrop', genjets_name=lambda s: s.replace('CHS', 'Gen'))
@@ -700,6 +702,8 @@ process.NjettinessCa15CHS = Njettiness.clone(
     cone=cms.double(1.5),
     R0=cms.double(1.5)
 )
+task.add(process.NjettinessCa15CHS)
+
 process.NjettinessCa15SoftDropCHS = Njettiness.clone(
     src=cms.InputTag("ca15CHSJetsSoftDropforsub"),
     Njets=cms.vuint32(1, 2, 3),          # compute 1-, 2-, 3- subjettiness
@@ -716,6 +720,8 @@ process.NjettinessCa15SoftDropCHS = Njettiness.clone(
     # not used by default
     akAxesR0=cms.double(999.0)
 )
+task.add(process.NjettinessCa15SoftDropCHS)
+
 process.NjettinessCa15SoftDropPuppi = process.NjettinessCa15SoftDropCHS.clone(
     src=cms.InputTag("ca15PuppiJetsSoftDropforsub")
 )
@@ -740,8 +746,7 @@ process.NjettinessAk8SoftDropPuppi = process.NjettinessAk8SoftDropCHS.clone(
     src=cms.InputTag("ak8PuppiJetsSoftDropforsub")
 )
 task.add(process.NjettinessAk8SoftDropPuppi)
-#process.NjettinessCa15SoftDropCHS = Njettiness.clone(src = cms.InputTag("patJetsCa15CHSJetsSoftDrop"), cone = cms.double(1.5),R0 = cms.double(1.5))
-#process.NjettinessCa8Puppi = Njettiness.clone(src = cms.InputTag("patJetsCa8PuppiJets"), cone = cms.double(0.8))
+
 process.NjettinessCa15Puppi = Njettiness.clone(
     src=cms.InputTag("ca15PuppiJets"),
     cone=cms.double(1.5),
@@ -1183,19 +1188,26 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
                                         softdropmass_source=cms.string(
                                             "patJetsAk8CHSJetsSoftDropPacked"),
                                     ),
-                                    # cms.PSet(
-                                    #    topjet_source = cms.string("patJetsHepTopTagCHSPacked"),
-                                    #    subjet_source = cms.string("daughters"),
-                                    #    do_subjet_taginfo = cms.bool(True),
-                                    #    higgstag_source = cms.string("patJetsCa15CHSJets"),
-                                    #    higgstag_name = cms.string("pfBoostedDoubleSecondaryVertexAK8BJetTags"),
-                                    #    njettiness_source = cms.string("NjettinessCa15CHS"),
-                                    #    substructure_variables_source = cms.string("ca15CHSJets"),
-                                    #    njettiness_groomed_source = cms.string("NjettinessCa15SoftDropCHS"),
-                                    #    substructure_groomed_variables_source = cms.string("ca15CHSJetsSoftDropforsub"),
-                                    #    prunedmass_source = cms.string("patJetsCa15CHSJetsPrunedPacked"),
-                                    #    #softdropmass_source  = cms.string(""),
-                                    #) ,
+                                    cms.PSet(
+                                        topjet_source = cms.string(
+                                            "patJetsHepTopTagCHSPacked"),
+                                        subjet_source = cms.string("daughters"),
+                                        do_subjet_taginfo = cms.bool(True),
+                                        higgstag_source = cms.string(
+                                            "patJetsCa15CHSJets"),
+                                        higgstag_name = cms.string(
+                                            "pfBoostedDoubleSecondaryVertexAK8BJetTags"),
+                                        njettiness_source = cms.string(
+                                            "NjettinessCa15CHS"),
+                                        substructure_variables_source = cms.string(
+                                            "ca15CHSJets"),
+                                        njettiness_groomed_source = cms.string(
+                                            "NjettinessCa15SoftDropCHS"),
+                                        substructure_groomed_variables_source = cms.string(
+                                            "ca15CHSJetsSoftDropforsub"),
+                                        # prunedmass_source = cms.string("patJetsCa15CHSJetsPrunedPacked"),
+                                        # softdropmass_source  = cms.string(""),
+                                    ) ,
                                     # cms.PSet(
                                     #    topjet_source = cms.string("patJetsHepTopTagPuppiPacked"),
                                     #    subjet_source = cms.string("daughters"),


### PR DESCRIPTION
This re-enables the HepTopTagger with only CHS, as per @gkasieczka 's wishes.

The top tagging info is stored in `TopJet::tag` fields of Top candidate jets. To be able to use our standard `add_fatjets_subjets()` , and `TopJets` pattern in the NtupleWriter, I have also enabled CA15 with & without SoftDrop, and also with pruning.  (I have not brought back CA15GenJets as not needed?) 

I also added an extra arg to `add_fatjets_subjets()` to make storing of top tagging info more explicit. Similarly, to make the NtupleWriter a little nicer I have added an extra field to the `PSet`, `toptagging_source`. Before, the source was hardcoded into the depths of the Ntuplewriter.

One should note that the following info is now stored in `patJetsHepTopTagCHSPacked_daughters` branch:

- the jet pt/eta/phi is from the `BasicJet` collection the `HTTTopJetProducer` produces. This is the Top jet candidate, i.e the sum of the 3 subjets.
- the subjets are the 3 subjets of the top candidate
- the jet pt (and the subjet pts) are without any JEC applied.
- the jet has pruned mass, ungroomed & groomed tau_i. @gkasieczka do we want pruned mass?
- in the tag info, the `mass` variable is just the plain mass of the Top candidate.

BTW adding all this in adds ~ 0.4s/event on MC (beforehand was ~3.8s/event). Over 100 MC events, these are the longest running:

```
TimeReport   0.078998     0.078998     0.078998  ak8CHSJets
TimeReport   0.080221     0.080221     0.080221  ak8CHSJetsPruned
TimeReport   0.087284     0.087284     0.087284  ca15CHSJetsSoftDropforsub
TimeReport   0.087590     0.087590     0.087590  ca15CHSJets
TimeReport   0.095503     0.095503     0.095503  pfImpactParameterTagInfosAk8PuppiJetsFat
TimeReport   0.099181     0.099181     0.099181  ca15CHSJetsPruned
TimeReport   0.170172     0.170172     0.170172  hepTopTagCHS
TimeReport   0.348824     0.348824     0.348824  puppi
TimeReport   1.777899     1.777899     1.777899  MyNtuple  (<--- much longer due to HOTVR & XCONE)
```

I also tidied up a few little things, e.g. can now store jets in Ntuple without any JEC.