### PR TITLE
Refreshed muons to store additional information

### DIFF
--- a/common/include/MuonIds.h
+++ b/common/include/MuonIds.h
@@ -5,25 +5,15 @@
 
 // see also ElectronIds.h for general comments
 
-// https://twiki.cern.ch/twiki/bin/view/CMS/SWGuideMuonIdRun2
-class MuonIDLoose {
+class MuonID{
  public:
-  bool operator()(const Muon&, const uhh2::Event&) const;
-};
+  explicit MuonID(Muon::Selector sel_);
 
-class MuonIDMedium {
- public:
-  bool operator()(const Muon&, const uhh2::Event&) const;
-};
+  bool operator()(const Muon & mu, const uhh2::Event & event) const;
 
-class MuonIDTight {
- public:
-  bool operator()(const Muon&, const uhh2::Event&) const;
-};
+ private:
+  Muon::Selector sel;
 
-class MuonIDHighPt {
- public:
-  bool operator()(const Muon&, const uhh2::Event&) const;
 };
 
 // only kinematic cuts, with no further id
@@ -57,9 +47,4 @@ class Muon_MINIIso {
  protected:
   float iso_cut_;
   std::string iso_key_;
-};
-
-class MuonIDMedium_ICHEP {
- public:
-  bool operator()(const Muon&, const uhh2::Event&) const;
 };

--- a/common/src/MuonIds.cxx
+++ b/common/src/MuonIds.cxx
@@ -2,16 +2,16 @@
 
 using namespace uhh2;
 
+MuonID::MuonID(Muon::Selector sel_): sel(sel_) {}
+bool MuonID::operator()(const Muon & mu, const Event &) const{
+  return mu.get_selector(sel);
+}
+
 MuonIDKinematic::MuonIDKinematic(double ptmin_, double etamax_): ptmin(ptmin_), etamax(etamax_){}
 
 bool MuonIDKinematic::operator()(const Muon & muon, const Event &) const {
     return muon.pt() > ptmin and fabs(muon.eta()) < etamax;
 }
-
-bool MuonIDLoose ::operator()(const Muon& muo, const Event&) const { return muo.get_bool(Muon::loose);  }
-bool MuonIDMedium::operator()(const Muon& muo, const Event&) const { return muo.get_bool(Muon::medium); }
-bool MuonIDTight ::operator()(const Muon& muo, const Event&) const { return muo.get_bool(Muon::tight);  }
-bool MuonIDHighPt::operator()(const Muon& muo, const Event&) const { return muo.get_bool(Muon::highpt); }
 MuonIso::MuonIso(double iso_):iso(iso_){}
 
 bool MuonIso::operator()(const Muon & muon, const uhh2::Event &) const {
@@ -32,18 +32,4 @@ bool Muon_MINIIso::operator()(const Muon& muo, const uhh2::Event&) const {
   else throw std::runtime_error("Muon_MINIIso::operator() -- invalid key for MINI-Isolation pileup correction: "+iso_key_);
 
   return (iso < iso_cut_);
-}
-
-bool MuonIDMedium_ICHEP::operator()(const Muon& muo, const Event&) const { 
-   
-   bool goodglobalmu = false;
-   bool tightsegmentcomp =false;
-   
-   if (!muo.get_bool(Muon::loose)) return false;
-   if (!(muo.innerTrack_validFraction() > 0.49 )) return false;
-   
-   if((muo.get_bool(Muon::global)) &&  (muo.globalTrack_normalizedChi2() < 3) && (muo.combinedQuality_chi2LocalPosition() < 12) && (muo.combinedQuality_trkKink() < 20) && (muo.segmentCompatibility() > 0.303)) goodglobalmu =true;
-   if(muo.segmentCompatibility() > 0.451) tightsegmentcomp = true;
-
-   return (goodglobalmu || tightsegmentcomp);
 }

--- a/common/src/PrintingModules.cxx
+++ b/common/src/PrintingModules.cxx
@@ -20,7 +20,7 @@ bool MuonPrinter::process(Event & event){
     for(const Muon & mu : *event.muons){
         ++i;
         cout << " mu[" << i << "]: E=" << mu.energy() << "; pt=" << mu.pt() << ", eta=" << mu.eta() << "; phi=" << mu.phi() << "; reliso=" << mu.relIso()
-             << "; global=" << mu.get_bool(Muon::global) << "; pf=" << mu.get_bool(Muon::pf)
+             << "; global=" << mu.get_selector(Muon::Global) << "; pf=" << mu.get_selector(Muon::PF)
              << "; dxy=" << mu.dxy() << "; dz=" << mu.dz() << endl;
     }
     return true;

--- a/common/test/TestJetLeptonCleaner.cpp
+++ b/common/test/TestJetLeptonCleaner.cpp
@@ -82,7 +82,7 @@ public:
         jet_printer.reset(new JetPrinter("jets", 30.0));
         jet_cleaner.reset(new JetCleaner(ctx, 30.0, 2.4));
         muon_printer.reset(new MuonPrinter());
-        muon_cleaner.reset(new MuonCleaner(AndId<Muon>(PtEtaCut(30., 2.4), MuonIDTight(), MuonIso(0.12))));
+        muon_cleaner.reset(new MuonCleaner(AndId<Muon>(PtEtaCut(30., 2.4), MuonID(Muon::CutBasedIdTight), MuonIso(0.12))));
     }
     
     virtual bool process(Event & e) override{

--- a/common/test/test_JLCkey.cpp
+++ b/common/test/test_JLCkey.cpp
@@ -44,7 +44,7 @@ test_JLCkey::test_JLCkey(uhh2::Context& ctx){
   ////
 
   //// OBJ CLEANING
-  const     MuonId muo(AndId<Muon>    (PtEtaCut  (50., 2.1), MuonIDMedium()));
+  const     MuonId muo(AndId<Muon>    (PtEtaCut  (50., 2.1), MuonID(Muon::CutBasedIdMedium)));
   const ElectronId ele(AndId<Electron>(PtEtaSCCut(50., 2.5), ElectronID_Spring15_25ns_tight_noIso));
 
   muo_cleaner.reset(new     MuonCleaner(muo));

--- a/core/plugins/NtupleWriterLeptons.cxx
+++ b/core/plugins/NtupleWriterLeptons.cxx
@@ -168,15 +168,58 @@ void NtupleWriterMuons::process(const edm::Event & event, uhh2::Event & uevent, 
      // mu.set_phiError( pat_mu.phiError());
      // mu.set_energyError( pat_mu.energyError());
 
-     mu.set_bool(Muon::global    , pat_mu.isGlobalMuon());
-     mu.set_bool(Muon::pf        , pat_mu.isPFMuon());
-     mu.set_bool(Muon::tracker   , pat_mu.isTrackerMuon());
-     mu.set_bool(Muon::standalone, pat_mu.isStandAloneMuon());
-     mu.set_bool(Muon::soft      , pat_mu.isSoftMuon(PV));
-     mu.set_bool(Muon::loose     , pat_mu.isLooseMuon());
-     mu.set_bool(Muon::medium    , pat_mu.isMediumMuon());
-     mu.set_bool(Muon::tight     , pat_mu.isTightMuon(PV));
-     mu.set_bool(Muon::highpt    , pat_mu.isHighPtMuon(PV));
+     mu.set_selector(Muon::Global    , pat_mu.isGlobalMuon());
+     mu.set_selector(Muon::PF        , pat_mu.isPFMuon());
+     mu.set_selector(Muon::Tracker   , pat_mu.isTrackerMuon());
+     mu.set_selector(Muon::Standalone, pat_mu.isStandAloneMuon());
+
+     mu.set_selector(Muon::CutBasedIdLoose       , pat_mu.passed(reco::Muon::CutBasedIdLoose));
+     mu.set_selector(Muon::CutBasedIdMedium      , pat_mu.passed(reco::Muon::CutBasedIdMedium));
+     mu.set_selector(Muon::CutBasedIdMediumPrompt, pat_mu.passed(reco::Muon::CutBasedIdMediumPrompt));
+     mu.set_selector(Muon::CutBasedIdTight       , pat_mu.passed(reco::Muon::CutBasedIdTight));
+     mu.set_selector(Muon::CutBasedIdGlobalHighPt, pat_mu.passed(reco::Muon::CutBasedIdGlobalHighPt));
+     mu.set_selector(Muon::CutBasedIdTrkHighPt   , pat_mu.passed(reco::Muon::CutBasedIdTrkHighPt));
+     mu.set_selector(Muon::SoftCutBasedId        , pat_mu.passed(reco::Muon::SoftCutBasedId));
+     mu.set_selector(Muon::SoftMvaId             , pat_mu.passed(reco::Muon::SoftMvaId));
+     mu.set_selector(Muon::MvaLoose              , pat_mu.passed(reco::Muon::MvaLoose));
+     mu.set_selector(Muon::MvaMedium             , pat_mu.passed(reco::Muon::MvaMedium));
+     mu.set_selector(Muon::MvaTight              , pat_mu.passed(reco::Muon::MvaTight));
+
+     mu.set_selector(Muon::PFIsoVeryLoose  , pat_mu.passed(reco::Muon::PFIsoVeryLoose));
+     mu.set_selector(Muon::PFIsoLoose      , pat_mu.passed(reco::Muon::PFIsoLoose));
+     mu.set_selector(Muon::PFIsoMedium     , pat_mu.passed(reco::Muon::PFIsoMedium));
+     mu.set_selector(Muon::PFIsoTight      , pat_mu.passed(reco::Muon::PFIsoTight));
+     mu.set_selector(Muon::PFIsoVeryTight  , pat_mu.passed(reco::Muon::PFIsoVeryTight));
+     mu.set_selector(Muon::TkIsoLoose      , pat_mu.passed(reco::Muon::TkIsoLoose));
+     mu.set_selector(Muon::TkIsoTight      , pat_mu.passed(reco::Muon::TkIsoTight));
+     mu.set_selector(Muon::MiniIsoLoose    , pat_mu.passed(reco::Muon::MiniIsoLoose));
+     mu.set_selector(Muon::MiniIsoMedium   , pat_mu.passed(reco::Muon::MiniIsoMedium));
+     mu.set_selector(Muon::MiniIsoTight    , pat_mu.passed(reco::Muon::MiniIsoTight));
+     mu.set_selector(Muon::MiniIsoVeryTight, pat_mu.passed(reco::Muon::MiniIsoVeryTight));
+
+     if(pat_mu.simType() == reco::NotMatched)                       mu.set_simType(Muon::NotMatched);
+     else if(pat_mu.simType() == reco::MatchedPunchthrough)         mu.set_simType(Muon::MatchedPunchthrough);
+     else if(pat_mu.simType() == reco::MatchedElectron)             mu.set_simType(Muon::MatchedElectron);
+     else if(pat_mu.simType() == reco::MatchedPrimaryMuon)          mu.set_simType(Muon::MatchedPrimaryMuon);
+     else if(pat_mu.simType() == reco::MatchedMuonFromLightFlavour) mu.set_simType(Muon::MatchedLightQuark);
+     else if(pat_mu.simType() == reco::GhostPunchthrough)           mu.set_simType(Muon::GhostPunchthrough);
+     else if(pat_mu.simType() == reco::GhostElectron)               mu.set_simType(Muon::GhostElectron);
+     else if(pat_mu.simType() == reco::GhostPrimaryMuon)            mu.set_simType(Muon::GhostPrimaryMuon);
+     else if(pat_mu.simType() == reco::GhostMuonFromLightFlavour)   mu.set_simType(Muon::GhostLightQuark);
+     else if(pat_mu.simType() == reco::MatchedMuonFromHeavyFlavour){
+       if(pat_mu.simExtType() == reco::MatchedMuonFromTau)          mu.set_simType(Muon::MatchedTau);
+       else                                                         mu.set_simType(Muon::MatchedHeavyQuark);
+     }
+     else if(pat_mu.simType() == reco::GhostMuonFromHeavyFlavour){
+       if(pat_mu.simExtType() == reco::GhostMuonFromTau)            mu.set_simType(Muon::GhostTau);
+       else                                                         mu.set_simType(Muon::GhostHeavyQuark);
+     }
+     else                                                           mu.set_simType(Muon::Unknown);
+
+     mu.set_simFlavor(pat_mu.simFlavour());
+     mu.set_simPdgId(pat_mu.simPdgId());
+     mu.set_simMotherPdgId(pat_mu.simMotherPdgId());
+     mu.set_simHeaviestMotherFlavor(pat_mu.simHeaviestMotherFlavour());
 
      mu.set_dxy      (pat_mu.muonBestTrack()->dxy(PV.position()));
      mu.set_dxy_error(pat_mu.muonBestTrack()->dxyError());

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -887,34 +887,34 @@ process.load('UHH2.core.pfCandidatesByType_cff')
 process.load('CommonTools.ParticleFlow.deltaBetaWeights_cff')
 
 # MUON # WILL BE IN MINIAOD OF 9_1_0 RELEASE
-#from UHH2.core.muon_pfMiniIsolation_cff import *
+from UHH2.core.muon_pfMiniIsolation_cff import *
 
-#mu_isovals = []
+mu_isovals = []
 
-# load_muonPFMiniIso(process, 'muonPFMiniIsoSequenceSTAND', algo = 'STAND',
-#  src = 'slimmedMuons',
-#  src_charged_hadron = 'pfAllChargedHadrons',
-#  src_neutral_hadron = 'pfAllNeutralHadrons',
-#  src_photon         = 'pfAllPhotons',
-#  src_charged_pileup = 'pfPileUpAllChargedParticles',
-#  isoval_list = mu_isovals
-#)
-#
-# load_muonPFMiniIso(process, 'muonPFMiniIsoSequencePFWGT', algo = 'PFWGT',
-#  src = 'slimmedMuons',
-#  src_neutral_hadron = 'pfWeightedNeutralHadrons',
-#  src_photon         = 'pfWeightedPhotons',
-#  isoval_list = mu_isovals
-#)
-# for m in mu_isovals:
-#  task.add(getattr(process,m))
-#  task.add(getattr(process,m.replace("Value","Deposit")))
-#
-# process.slimmedMuonsUSER = cms.EDProducer('PATMuonUserData',
-#  src = cms.InputTag('slimmedMuons'),
-#  vmaps_double = cms.vstring(mu_isovals),
-#)
-# task.add(process.slimmedMuonsUSER)
+load_muonPFMiniIso(process, 'muonPFMiniIsoSequenceSTAND', algo = 'STAND',
+                   src = 'slimmedMuons',
+                   src_charged_hadron = 'pfAllChargedHadrons',
+                   src_neutral_hadron = 'pfAllNeutralHadrons',
+                   src_photon         = 'pfAllPhotons',
+                   src_charged_pileup = 'pfPileUpAllChargedParticles',
+                   isoval_list = mu_isovals
+                   )
+
+load_muonPFMiniIso(process, 'muonPFMiniIsoSequencePFWGT', algo = 'PFWGT',
+                   src = 'slimmedMuons',
+                   src_neutral_hadron = 'pfWeightedNeutralHadrons',
+                   src_photon         = 'pfWeightedPhotons',
+                   isoval_list = mu_isovals
+                   )
+for m in mu_isovals:
+    task.add(getattr(process,m))
+    task.add(getattr(process,m.replace("Value","Deposit")))
+
+process.slimmedMuonsUSER = cms.EDProducer('PATMuonUserData',
+                                          src = cms.InputTag('slimmedMuons'),
+                                          vmaps_double = cms.vstring(mu_isovals),
+                                          )
+task.add(process.slimmedMuonsUSER)
 
 # ELECTRON
 
@@ -1075,7 +1075,7 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
                                 doEleAddVars=cms.bool(False),
 
                                 doMuons=cms.bool(True),
-                                muon_sources=cms.vstring("slimmedMuons"),
+                                muon_sources=cms.vstring("slimmedMuonsUSER"),
 
                                 doTaus=cms.bool(True),
                                 tau_sources=cms.vstring("slimmedTaus"),

--- a/examples/src/ExampleModule2.cxx
+++ b/examples/src/ExampleModule2.cxx
@@ -49,7 +49,7 @@ private:
 ExampleModule2::ExampleModule2(Context & ctx): ele_selection(ctx, "ele"), mu_selection(ctx, "mu") {
     jet_kinematic = PtEtaCut(30.0, 2.4);
     btag = CSVBTag(CSVBTag::WP_LOOSE);
-    muid = AndId<Muon>(MuonIDTight(), PtEtaCut(20.0, 2.4));
+    muid = AndId<Muon>(MuonID(Muon::CutBasedIdTight), PtEtaCut(20.0, 2.4));
     eleid = AndId<Electron>(ElectronID_PHYS14_25ns_medium, PtEtaCut(20.0, 2.5));
     
     // clean the objects:

--- a/examples/src/ExampleTTbarRec.cxx
+++ b/examples/src/ExampleTTbarRec.cxx
@@ -43,7 +43,7 @@ private:
 ExampleTTbarRec::ExampleTTbarRec(Context & ctx): selection(ctx, "selection") {
     jet_kinematic = PtEtaCut(50.0, 2.4);
     topjet_kinematic = PtEtaCut(150.0,2.4);
-    muid = AndId<Muon>(MuonIDTight(), PtEtaCut(20.0, 2.4));
+    muid = AndId<Muon>(MuonID(Muon::CutBasedIdTight), PtEtaCut(20.0, 2.4));
     
     // clean the objects:
     cleanermodules.emplace_back(new JetCleaner(ctx, jet_kinematic));


### PR DESCRIPTION
- Enabled muon variables that were still missing
- Now we store all pre-computed IDs and isolations provided by MUO as bits.
- Changed to a more flexible way to access muon ID, isolation. Note that this requires most analyses to tweak their code a bit
- Now we store additional information about the muon type (primary, punchthrough, from quark decays, ...)