### PR TITLE
[94X] Move HOTVR & XCone to separate producers; add in HOTVR w/Puppi

### DIFF
--- a/core/plugins/HOTVRProducer.cc
+++ b/core/plugins/HOTVRProducer.cc
@@ -104,15 +104,15 @@ HOTVRProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   // Convert particles to PseudoJets
   std::vector<PseudoJet> _psj;
   for (const auto & cand: *particles) {
-    if (std::isnan(cand.p4().Px()) || 
-        std::isnan(cand.p4().Py()) || 
-        std::isnan(cand.p4().Pz()) || 
-        std::isinf(cand.p4().Px()) || 
-        std::isinf(cand.p4().Py()) ||
-        std::isinf(cand.p4().Pz()))
+    if (std::isnan(cand.px()) ||
+        std::isnan(cand.py()) ||
+        std::isnan(cand.pz()) ||
+        std::isinf(cand.px()) ||
+        std::isinf(cand.py()) ||
+        std::isinf(cand.pz()))
       continue;
 
-    _psj.push_back(PseudoJet(cand.p4().X(), cand.p4().Y(), cand.p4().Z(), cand.p4().T()));
+    _psj.push_back(PseudoJet(cand.px(), cand.py(), cand.pz(), cand.energy()));
   }
 
   // Do the clustering, make jets, nsub, store

--- a/core/plugins/HOTVRProducer.cc
+++ b/core/plugins/HOTVRProducer.cc
@@ -273,7 +273,7 @@ HOTVRProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 pat::Jet HOTVRProducer::createPatJet(const PseudoJet & psj)
 {
   pat::Jet newJet;
-  newJet.setP4(math::XYZTLorentzVector(psj.pt(), psj.eta(), psj.phi(), psj.E()));
+  newJet.setP4(math::XYZTLorentzVector(psj.px(), psj.py(), psj.pz(), psj.E()));
   return newJet;
 }
 

--- a/core/plugins/HOTVRProducer.cc
+++ b/core/plugins/HOTVRProducer.cc
@@ -1,0 +1,277 @@
+// -*- C++ -*-
+//
+// Package:    UHH2/HOTVRProducer
+// Class:      HOTVRProducer
+//
+/**\class HOTVRProducer HOTVRProducer.cc UHH2/HOTVRProducer/plugins/HOTVRProducer.cc
+
+ Description: [one line class summary]
+
+ Implementation:
+    [Notes on implementation]
+*/
+//
+// Original Author:  Robin Aggleton
+//         Created:  Tue, 23 Jan 2018 13:27:50 GMT
+//
+//
+
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "DataFormats/PatCandidates/interface/Jet.h"
+#include "DataFormats/Math/interface/LorentzVector.h"
+
+#include "fastjet/ClusterSequence.hh"
+#include "fastjet/ClusterSequenceArea.hh"
+#include "fastjet/contrib/HOTVR.hh"
+#include "fastjet/contrib/HOTVRinfo.hh"
+#include "fastjet/contrib/Nsubjettiness.hh"
+#include "fastjet/contrib/XConePlugin.hh"
+#include "fastjet/contrib/SoftDrop.hh"
+
+#include "vector"
+
+using namespace fastjet;
+using namespace contrib;
+
+//
+// class declaration
+//
+
+class HOTVRProducer : public edm::stream::EDProducer<> {
+  public:
+    explicit HOTVRProducer(const edm::ParameterSet&);
+    ~HOTVRProducer();
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  private:
+    virtual void beginStream(edm::StreamID) override;
+    virtual void produce(edm::Event&, const edm::EventSetup&) override;
+    virtual void endStream() override;
+
+    virtual pat::Jet createPatJet(const PseudoJet &);
+    virtual pat::Jet createPatJet(const PseudoJet &, const std::vector<PseudoJet> &, double, double, double, double, std::vector<double>);
+
+    // ----------member data ---------------------------
+    edm::EDGetToken src_token_;
+};
+
+//
+// constructors and destructor
+//
+HOTVRProducer::HOTVRProducer(const edm::ParameterSet& iConfig):
+  src_token_(consumes<edm::View<pat::PackedCandidate>>(iConfig.getParameter<edm::InputTag>("src")))
+{
+  produces<pat::JetCollection>();
+}
+
+
+HOTVRProducer::~HOTVRProducer()
+{
+
+  // do anything here that needs to be done at destruction time
+  // (e.g. close files, deallocate resources etc.)
+
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+void
+HOTVRProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+
+  edm::Handle<edm::View<pat::PackedCandidate>> particles;
+  iEvent.getByToken(src_token_, particles);
+
+  // Convert particles to PseudoJets
+  std::vector<PseudoJet> _psj;
+  for (const auto & cand: *particles) {
+    if (std::isnan(cand.p4().Px()) || 
+        std::isnan(cand.p4().Py()) || 
+        std::isnan(cand.p4().Pz()) || 
+        std::isinf(cand.p4().Px()) || 
+        std::isinf(cand.p4().Py()) ||
+        std::isinf(cand.p4().Pz()))
+      continue;
+
+    _psj.push_back(PseudoJet(cand.p4().X(), cand.p4().Y(), cand.p4().Z(), cand.p4().T()));
+  }
+
+  // Do the clustering, make jets, nsub, store
+  double mu(30.),                      // massjump threshold
+         theta(0.7),                   // massjump parameter
+         max_r(1.5),                   // maximum allowed distance R
+         min_r(0.1),                   // minimum allowed distance R
+         rho(600.),                    // cone shrinking parameter
+         hotvr_pt_min(30.);            // minimum pT of subjet
+
+  // jet definition with HOTVR plugin
+  HOTVR hotvr_plugin(mu, theta, min_r, max_r, rho, hotvr_pt_min, HOTVR::CALIKE);
+  JetDefinition jet_def(&hotvr_plugin);
+
+   // Setup cluster sequence
+  ClusterSequence cs(_psj, jet_def);
+  vector<PseudoJet> hotvr_jets = hotvr_plugin.get_jets();
+
+  // NOTE: There is a problem when getting Nsubjettiness directly
+  // from HOTVR jets, because the link to the cluster sequence got lost
+  // somehow. Thus the approach here will be to identify the Jets from
+  // the cluster sequence with the hotvr_jets by comparing their
+  // four-vectors.
+
+  // area definition
+  double ghost_maxrap = 4.0;      // maxiumum y of ghost particles
+  AreaDefinition area_def(active_area_explicit_ghosts, GhostedAreaSpec(ghost_maxrap, 1, 0.02));
+
+  // setup cluster sequence with area
+  HOTVR hotvr_plugin_area(mu, theta, min_r, max_r, rho, hotvr_pt_min, HOTVR::CALIKE);
+  JetDefinition jet_def_area(&hotvr_plugin_area);
+  ClusterSequenceArea cs_area(_psj, jet_def_area, area_def);
+  vector<PseudoJet> hotvr_jets_area = hotvr_plugin_area.get_jets();
+
+  //in a few cases, there are jets in the original clustering without a corresponding jet in the area clustering
+  //->add a dummy jet into the area collection and throw a warning because we cannot determine the area for these jets
+  if (hotvr_jets_area.size() != hotvr_jets.size()) {
+
+    for (unsigned int i = 0; i < hotvr_jets.size(); ++i) {
+        bool matched = false;
+        for (unsigned int j = 0; j < hotvr_jets_area.size(); ++j) {
+            if( fabs(hotvr_jets[i].pt() - hotvr_jets_area[j].pt())<0.0001 &&
+                fabs(hotvr_jets[i].eta() - hotvr_jets_area[j].eta())<0.0001) {
+              matched = true;
+              break;
+            }
+        }
+
+        if(!matched) {
+          PseudoJet dummy_jet(0, 0, 0, 0);
+          hotvr_jets_area.insert(hotvr_jets_area.begin()+i, dummy_jet);
+        }
+      }
+
+    //sometimes, there are more jets in the area clustering
+    //->filter out jets from the area collection which are not matched to any jet in the original clustering
+    for (unsigned int i = 0; i < hotvr_jets_area.size(); ++i) {
+        //skip dummy jets from previous iteration
+        if (hotvr_jets_area[i].pt() == 0) continue;
+
+        bool matched=false;
+        for (unsigned int j = 0; j < hotvr_jets.size(); ++j) {
+            if( fabs(hotvr_jets[j].pt() - hotvr_jets_area[i].pt())<0.0001 &&
+                fabs(hotvr_jets[j].eta() - hotvr_jets_area[i].eta())<0.0001) {
+              matched = true;
+              break;
+            }
+        }
+        if(!matched) {
+          hotvr_jets_area.erase(hotvr_jets_area.begin()+i);
+          i--;
+        }
+    }
+  }
+
+  if (hotvr_jets_area.size() != hotvr_jets.size()) {
+    throw cms::Exception("MismatchedSizes", "Number of HOTVR jets found with ClusterSequence does not match number of jets with ClusterSequenceArea.");
+  }
+
+  auto outputJets = std::make_unique<pat::JetCollection>();
+
+  for (unsigned int i = 0; i < hotvr_jets.size(); ++i) {
+    double beta = 1.0;
+    HOTVRinfo hi = hotvr_jets[i].user_info<HOTVRinfo>();
+    Nsubjettiness nSub1(1, OnePass_WTA_KT_Axes(), NormalizedMeasure(beta, hi.max_distance()));
+    Nsubjettiness nSub2(2, OnePass_WTA_KT_Axes(), NormalizedMeasure(beta, hi.max_distance()));
+    Nsubjettiness nSub3(3, OnePass_WTA_KT_Axes(), NormalizedMeasure(beta, hi.max_distance()));
+    double tau1 = nSub1(hotvr_jets[i]);
+    double tau2 = nSub2(hotvr_jets[i]);
+    double tau3 = nSub3(hotvr_jets[i]);
+
+    // getting jet and subjet area
+    double jet_area = 0;
+    std::vector<double> subjet_area;
+    std::vector<PseudoJet> subjets;
+    if (hotvr_jets_area[i].pt()>0) {
+      jet_area = hotvr_jets_area[i].area();
+      HOTVRinfo hi_area = hotvr_jets_area[i].user_info<HOTVRinfo>();
+      subjets = hi_area.subjets();
+      for (unsigned int j = 0; j < subjets.size(); ++j) {
+        subjet_area.push_back(subjets[j].area());
+      }
+    } else {
+      subjets = hi.subjets();
+      for (unsigned int j = 0; j < subjets.size(); ++j) {
+        subjet_area.push_back(0);
+      }
+      edm::LogWarning("NoJetArea") << "HOTVRProducer: could not find area jet for a HOTVR jet; set area and subjet areas to 0.";
+    }
+    outputJets->push_back(createPatJet(hotvr_jets[i], subjets, tau1, tau2, tau3, jet_area, subjet_area));
+  }
+
+  iEvent.put(std::move(outputJets));
+}
+
+pat::Jet HOTVRProducer::createPatJet(const PseudoJet & psj)
+{
+  pat::Jet newJet;
+  newJet.setP4(math::XYZTLorentzVector(psj.pt(), psj.eta(), psj.phi(), psj.E()));
+  return newJet;
+}
+
+pat::Jet HOTVRProducer::createPatJet(const PseudoJet & psj, const std::vector<PseudoJet> &subpsj, double tau1, double tau2, double tau3, double jet_area, std::vector<double> subjet_area)
+{
+  pat::Jet newJet = createPatJet(psj);
+  newJet.setJetArea(jet_area);
+  newJet.addUserFloat("tau1", tau1);
+  newJet.addUserFloat("tau2", tau2);
+  newJet.addUserFloat("tau3", tau3);
+
+  for (uint i=0; i<subpsj.size(); i++) {
+    pat::Jet subjet = createPatJet(subpsj[i]);
+    subjet.setJetArea(subjet_area[i]);
+  }
+
+  return newJet;
+}
+
+
+// ------------ method called once each stream before processing any runs, lumis or events  ------------
+void
+HOTVRProducer::beginStream(edm::StreamID)
+{
+}
+
+// ------------ method called once each stream after processing all runs, lumis and events  ------------
+void
+HOTVRProducer::endStream() {
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+HOTVRProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(HOTVRProducer);

--- a/core/plugins/HOTVRProducer.cc
+++ b/core/plugins/HOTVRProducer.cc
@@ -112,7 +112,8 @@ HOTVRProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
         std::isnan(cand.pz()) ||
         std::isinf(cand.px()) ||
         std::isinf(cand.py()) ||
-        std::isinf(cand.pz()))
+        std::isinf(cand.pz()) ||
+        (cand.pt() == 0))
       continue;
 
     _psj.push_back(PseudoJet(cand.px(), cand.py(), cand.pz(), cand.energy()));

--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -562,37 +562,24 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
 
   if (doHOTVR) {
     auto hotvr_sources = iConfig.getParameter<std::vector<edm::InputTag> >("HOTVR_sources");
-    newHotvrJets.resize(hotvr_sources.size());
+    hotvrJets.resize(hotvr_sources.size());
     for (size_t j=0; j<hotvr_sources.size(); ++j) {
       hotvr_tokens.push_back(consumes<pat::JetCollection>(hotvr_sources[j]));
       hotvr_subjet_tokens.push_back(consumes<pat::JetCollection>(edm::InputTag(hotvr_sources[j].label(), "SubJets")));
-      branch(tr, hotvr_sources[j].encode().c_str(), "std::vector<TopJet>", &newHotvrJets[j]);
+      branch(tr, hotvr_sources[j].encode().c_str(), "std::vector<TopJet>", &hotvrJets[j]);
     }
   }
 
   if (doXCone) {
     auto xcone_sources = iConfig.getParameter<std::vector<edm::InputTag> >("XCone_sources");
-    newXConeJets.resize(xcone_sources.size());
+    xconeJets.resize(xcone_sources.size());
     for (size_t j=0; j<xcone_sources.size(); ++j) {
       xcone_tokens.push_back(consumes<pat::JetCollection>(xcone_sources[j]));
       xcone_subjet_tokens.push_back(consumes<pat::JetCollection>(edm::InputTag(xcone_sources[j].label(), "SubJets")));
-      branch(tr, xcone_sources[j].encode().c_str(), "std::vector<TopJet>", &newXConeJets[j]);
+      branch(tr, xcone_sources[j].encode().c_str(), "std::vector<TopJet>", &xconeJets[j]);
     }
   }
 
-  if(doHOTVR || doXCone)
-    // HOTVR and XCone need full pf_collection for clustering
-    {
-      pf_collection_token = consumes<vector<pat::PackedCandidate>>(iConfig.getParameter<edm::InputTag>("pf_collection_source"));
-      if(doHOTVR)
-        {
-          branch(tr, "HOTVRTopJets", "std::vector<TopJet>", &hotvrJets);
-        }
-      if(doXCone)
-        {
-          branch(tr, "XConeTopJets", "std::vector<TopJet>", &xconeJets);
-        }
-    }
   // GenJets
   if(doGenHOTVR || doGenXCone)
     {
@@ -1311,7 +1298,7 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
    // ------------- HOTVR and XCone Jets  -------------
    if (doHOTVR) {
     for (size_t j=0; j < hotvr_tokens.size(); ++j){
-      newHotvrJets[j].clear();
+      hotvrJets[j].clear();
       edm::Handle<pat::JetCollection> hotvr_patjets;
       iEvent.getByToken(hotvr_tokens[j], hotvr_patjets);
       edm::Handle<pat::JetCollection> hotvr_subjet_patjets;
@@ -1338,14 +1325,14 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
           thisJet.add_subjet(subjet);
         }
 
-        newHotvrJets[j].push_back(thisJet);
+        hotvrJets[j].push_back(thisJet);
       }
     }
    }
 
    if (doXCone) {
     for (size_t j=0; j < xcone_tokens.size(); ++j){
-      newXConeJets[j].clear();
+      xconeJets[j].clear();
       edm::Handle<pat::JetCollection> xcone_patjets;
       iEvent.getByToken(xcone_tokens[j], xcone_patjets);
       edm::Handle<pat::JetCollection> xcone_subjet_patjets;
@@ -1371,44 +1358,10 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
           thisJet.add_subjet(subjet);
         }
 
-        newXConeJets[j].push_back(thisJet);
+        xconeJets[j].push_back(thisJet);
       }
     }
    }
-
-   if(doHOTVR || doXCone)
-     {
-       // get PFParticles
-       edm::Handle<vector<pat::PackedCandidate>> pfColl_handle;
-       iEvent.getByToken(pf_collection_token, pfColl_handle);
-
-       const std::vector<pat::PackedCandidate>& pf_coll = *(pfColl_handle.product());
-       std::vector<PFParticle> pfparticles;
-       for ( unsigned int j = 0; j<pf_coll.size(); ++j){
-         const pat::PackedCandidate pf = pf_coll.at(j);
-
-         PFParticle part;
-         part.set_pt(pf.pt());
-         part.set_eta(pf.eta());
-         part.set_phi(pf.phi());
-         part.set_energy(pf.energy());
-         pfparticles.push_back(part);
-       }
-       print_times(timer, "HOTVR_loop_packedCands");
-
-       UniversalJetCluster jetCluster(&pfparticles,doHOTVR,doXCone);
-       print_times(timer, "HOTVR_jetCluster");
-       if (doHOTVR)
-         {
-       hotvrJets = jetCluster.GetHOTVRTopJets();
-       print_times(timer, "HOTVR_GetHOTVRTopJets");
-         }
-       if (doXCone)
-         {
-           xconeJets = jetCluster.GetXCone33Jets();
-         }
-       print_times(timer, "HOTVR_end");
-     }
 
   if(doGenHOTVR || doGenXCone)
      {

--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -12,6 +12,7 @@
 #include "DataFormats/PatCandidates/interface/PackedGenParticle.h"
 #include "DataFormats/PatCandidates/interface/Photon.h"
 #include "DataFormats/PatCandidates/interface/MET.h"
+#include "DataFormats/PatCandidates/interface/Jet.h"
 #include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
 #include "SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h"
@@ -556,8 +557,29 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
     pf_collection_token = consumes<vector<pat::PackedCandidate>>(iConfig.getParameter<edm::InputTag>("pf_collection_source"));
     branch(tr, "PFParticles", "std::vector<PFParticle>", &event->pfparticles);
   }
+
   // HOTVR and XCone Jet Cluster - added by Alex and Dennis
-  // PF Jets
+
+  if (doHOTVR) {
+    auto hotvr_sources = iConfig.getParameter<std::vector<edm::InputTag> >("HOTVR_sources");
+    newHotvrJets.resize(hotvr_sources.size());
+    for (size_t j=0; j<hotvr_sources.size(); ++j) {
+      hotvr_tokens.push_back(consumes<pat::JetCollection>(hotvr_sources[j]));
+      hotvr_subjet_tokens.push_back(consumes<pat::JetCollection>(edm::InputTag(hotvr_sources[j].label(), "SubJets")));
+      branch(tr, hotvr_sources[j].encode().c_str(), "std::vector<TopJet>", &newHotvrJets[j]);
+    }
+  }
+
+  if (doXCone) {
+    auto xcone_sources = iConfig.getParameter<std::vector<edm::InputTag> >("XCone_sources");
+    newXConeJets.resize(xcone_sources.size());
+    for (size_t j=0; j<xcone_sources.size(); ++j) {
+      xcone_tokens.push_back(consumes<pat::JetCollection>(xcone_sources[j]));
+      xcone_subjet_tokens.push_back(consumes<pat::JetCollection>(edm::InputTag(xcone_sources[j].label(), "SubJets")));
+      branch(tr, xcone_sources[j].encode().c_str(), "std::vector<TopJet>", &newXConeJets[j]);
+    }
+  }
+
   if(doHOTVR || doXCone)
     // HOTVR and XCone need full pf_collection for clustering
     {
@@ -1287,6 +1309,73 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
    print_times(timer, "trigger");
 
    // ------------- HOTVR and XCone Jets  -------------
+   if (doHOTVR) {
+    for (size_t j=0; j < hotvr_tokens.size(); ++j){
+      newHotvrJets[j].clear();
+      edm::Handle<pat::JetCollection> hotvr_patjets;
+      iEvent.getByToken(hotvr_tokens[j], hotvr_patjets);
+      edm::Handle<pat::JetCollection> hotvr_subjet_patjets;
+      iEvent.getByToken(hotvr_subjet_tokens[j], hotvr_subjet_patjets);
+
+      // Convert from pat::Jet to TopJet, with special userFloats, and with subjets
+      for (const auto & patJet : *hotvr_patjets) {
+        TopJet thisJet;
+        thisJet.set_pt(patJet.p4().pt());
+        thisJet.set_eta(patJet.p4().eta());
+        thisJet.set_phi(patJet.p4().phi());
+        thisJet.set_energy(patJet.p4().E());
+        thisJet.set_jetArea(patJet.jetArea());
+        thisJet.set_tau1_groomed(patJet.userFloat("tau1"));
+        thisJet.set_tau2_groomed(patJet.userFloat("tau2"));
+        thisJet.set_tau3_groomed(patJet.userFloat("tau3"));
+        for (const auto & subItr : patJet.subjets()) {
+          Jet subjet;
+          subjet.set_pt(subItr->p4().pt());
+          subjet.set_eta(subItr->p4().eta());
+          subjet.set_phi(subItr->p4().phi());
+          subjet.set_energy(subItr->p4().E());
+          subjet.set_jetArea(subItr->jetArea());
+          thisJet.add_subjet(subjet);
+        }
+
+        newHotvrJets[j].push_back(thisJet);
+      }
+    }
+   }
+
+   if (doXCone) {
+    for (size_t j=0; j < xcone_tokens.size(); ++j){
+      newXConeJets[j].clear();
+      edm::Handle<pat::JetCollection> xcone_patjets;
+      iEvent.getByToken(xcone_tokens[j], xcone_patjets);
+      edm::Handle<pat::JetCollection> xcone_subjet_patjets;
+      iEvent.getByToken(xcone_subjet_tokens[j], xcone_subjet_patjets);
+
+      // Convert from pat::Jet to TopJet, with special userFloats, and with subjets
+      for (const auto & patJet : *xcone_patjets) {
+        TopJet thisJet;
+        thisJet.set_pt(patJet.p4().pt());
+        thisJet.set_eta(patJet.p4().eta());
+        thisJet.set_phi(patJet.p4().phi());
+        thisJet.set_energy(patJet.p4().E());
+        thisJet.set_jetArea(patJet.jetArea());
+        thisJet.set_softdropmass(patJet.userFloat("softdropmass"));
+
+        for (const auto & subItr : patJet.subjets()) {
+          Jet subjet;
+          subjet.set_pt(subItr->p4().pt());
+          subjet.set_eta(subItr->p4().eta());
+          subjet.set_phi(subItr->p4().phi());
+          subjet.set_energy(subItr->p4().E());
+          subjet.set_jetArea(subItr->jetArea());
+          thisJet.add_subjet(subjet);
+        }
+
+        newXConeJets[j].push_back(thisJet);
+      }
+    }
+   }
+
    if(doHOTVR || doXCone)
      {
        // get PFParticles

--- a/core/plugins/NtupleWriter.h
+++ b/core/plugins/NtupleWriter.h
@@ -19,8 +19,7 @@
 
 #include <memory>
 
-// Jet Cluster for HOTVR & XCone by Alex and Dennis
-#include "UHH2/core/include/UniversalJetCluster.h"
+// GenJet Cluster for HOTVR & XCone by Alex and Dennis
 #include "UHH2/core/include/UniversalGenJetCluster.h"
 
 namespace uhh2 {
@@ -142,14 +141,12 @@ class NtupleWriter : public edm::EDFilter {
 
       std::vector<edm::EDGetToken> hotvr_tokens;
       std::vector<edm::EDGetToken> hotvr_subjet_tokens;
-      std::vector<std::vector<TopJet>> newHotvrJets;
+      std::vector<std::vector<TopJet>> hotvrJets;
 
       std::vector<edm::EDGetToken> xcone_tokens;
       std::vector<edm::EDGetToken> xcone_subjet_tokens;
-      std::vector<std::vector<TopJet>> newXConeJets;
+      std::vector<std::vector<TopJet>> xconeJets;
 
-      std::vector<TopJet> hotvrJets;
-      std::vector<TopJet> xconeJets;
       std::vector<GenTopJet> genhotvrJets;
       std::vector<GenTopJet> genxcone33Jets;
       std::vector<GenTopJet> genxcone33Jets_softdrop;

--- a/core/plugins/NtupleWriter.h
+++ b/core/plugins/NtupleWriter.h
@@ -140,6 +140,14 @@ class NtupleWriter : public edm::EDFilter {
 
       std::vector<bool> puppi;
 
+      std::vector<edm::EDGetToken> hotvr_tokens;
+      std::vector<edm::EDGetToken> hotvr_subjet_tokens;
+      std::vector<std::vector<TopJet>> newHotvrJets;
+
+      std::vector<edm::EDGetToken> xcone_tokens;
+      std::vector<edm::EDGetToken> xcone_subjet_tokens;
+      std::vector<std::vector<TopJet>> newXConeJets;
+
       std::vector<TopJet> hotvrJets;
       std::vector<TopJet> xconeJets;
       std::vector<GenTopJet> genhotvrJets;

--- a/core/plugins/XConeProducer.cc
+++ b/core/plugins/XConeProducer.cc
@@ -1,0 +1,252 @@
+// -*- C++ -*-
+//
+// Package:    UHH2/XConeProducer
+// Class:      XConeProducer
+//
+/**\class XConeProducer XConeProducer.cc UHH2/XConeProducer/plugins/XConeProducer.cc
+
+ Description: [one line class summary]
+
+ Implementation:
+    [Notes on implementation]
+*/
+//
+// Original Author:  Robin Aggleton
+//         Created:  Tue, 23 Jan 2018 13:27:56 GMT
+//
+//
+
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "DataFormats/PatCandidates/interface/Jet.h"
+
+#include "fastjet/ClusterSequence.hh"
+#include "fastjet/ClusterSequenceArea.hh"
+#include "fastjet/contrib/HOTVR.hh"
+#include "fastjet/contrib/HOTVRinfo.hh"
+#include "fastjet/contrib/Nsubjettiness.hh"
+#include "fastjet/contrib/XConePlugin.hh"
+#include "fastjet/contrib/SoftDrop.hh"
+
+#include "vector"
+
+using namespace fastjet;
+using namespace contrib;
+
+//
+// class declaration
+//
+
+class XConeProducer : public edm::stream::EDProducer<> {
+  public:
+    explicit XConeProducer(const edm::ParameterSet&);
+    ~XConeProducer();
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  private:
+    virtual void beginStream(edm::StreamID) override;
+    virtual void produce(edm::Event&, const edm::EventSetup&) override;
+    virtual void endStream() override;
+    
+    virtual pat::Jet createPatJet(const fastjet::PseudoJet &);
+    virtual pat::Jet createPatJet(const fastjet::PseudoJet & , const std::vector<fastjet::PseudoJet> &, double , std::vector<double>, float);
+
+    // ----------member data ---------------------------
+    edm::EDGetToken src_token_;
+
+    // ----------member data ---------------------------
+};
+
+//
+// constants, enums and typedefs
+//
+
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+XConeProducer::XConeProducer(const edm::ParameterSet& iConfig):
+  src_token_(consumes<edm::View<pat::PackedCandidate>>(iConfig.getParameter<edm::InputTag>("src")))
+{
+  produces<pat::JetCollection>();
+}
+
+
+XConeProducer::~XConeProducer()
+{
+
+  // do anything here that needs to be done at destruction time
+  // (e.g. close files, deallocate resources etc.)
+
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+void
+XConeProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+  edm::Handle<std::vector<pat::PackedCandidate>> particles;
+  iEvent.getByToken(src_token_, particles);
+
+
+  if (particles->size() < 15) {
+    auto outputJets = std::make_unique<pat::JetCollection>();
+    iEvent.put(std::move(outputJets));
+    return;
+  }
+
+  // Convert particles to PseudoJets
+  std::vector<PseudoJet> _psj;
+  for (const auto & cand: *particles) {
+    if (std::isnan(cand.p4().Px()) ||
+        std::isnan(cand.p4().Py()) ||
+        std::isnan(cand.p4().Pz()) ||
+        std::isinf(cand.p4().Px()) ||
+        std::isinf(cand.p4().Py()) ||
+        std::isinf(cand.p4().Pz()))
+      continue;
+
+    _psj.push_back(PseudoJet(cand.p4().X(), cand.p4().Y(), cand.p4().Z(), cand.p4().T()));
+  }
+
+  // Run first clustering step (N=2, R=1.2)
+  vector<PseudoJet> fatjets;
+  XConePlugin plugin_xcone(2, 1.2, 2.0);
+  double ghost_maxrap = 4.0;      // maxiumum y of ghost particles
+  AreaDefinition area_def(active_area, GhostedAreaSpec(ghost_maxrap));
+  JetDefinition jet_def_xcone(&plugin_xcone);
+  ClusterSequence clust_seq_xcone(_psj, jet_def_xcone);
+  fatjets = sorted_by_pt(clust_seq_xcone.inclusive_jets(0));
+
+  // get SoftDrop Mass
+  SoftDrop sd(0.0, 0.1, 1.2);
+  PseudoJet sdjet1 = sd(fatjets[0]);
+  PseudoJet sdjet2 = sd(fatjets[1]);
+  float sd_mass1 = sdjet1.m();
+  float sd_mass2 = sdjet2.m();
+
+  // get and wirte list: if particle i is clustered in jet j, the i-th entry of the list == j
+  vector<int> list_fat;
+  list_fat.clear();
+  list_fat = clust_seq_xcone.particle_jet_indices(fatjets);
+  vector<PseudoJet> particle_in_fat1, particle_in_fat2;
+
+  // get one set of particles for each jet
+  for (unsigned int ipart=0; ipart < _psj.size(); ++ipart) {
+    if (list_fat[ipart]==0) {
+      particle_in_fat1.push_back(_psj.at(ipart)); // get vector as PseudoJet for fatjet 1
+    }
+    if (list_fat[ipart]==1) {
+      particle_in_fat2.push_back(_psj.at(ipart)); // get vector as PseudoJet for fatjet 2
+    }
+  }
+
+  if(particle_in_fat1.size() < 3 || particle_in_fat2.size()<3) {
+    cms::Exception("InsufficientParticles", 
+                   "Not enough particles to run second XCone step");
+  }
+
+  // Run second clustering step (N=3, R=0.4) for each fat jet
+  vector<PseudoJet> subjets_1, subjets_2;
+
+  // subjets from fat jet 1
+  XConePlugin plugin_xcone_sub1(3, 0.4, 2.0);
+  JetDefinition jet_def_sub1(&plugin_xcone_sub1);
+  ClusterSequenceArea clust_seq_sub1(particle_in_fat1, jet_def_sub1, area_def);
+  subjets_1 = sorted_by_pt(clust_seq_sub1.inclusive_jets(0));
+
+  //subjets from fat jet 2
+  XConePlugin plugin_xcone_sub2(3, 0.4, 2.0);
+  JetDefinition jet_def_sub2(&plugin_xcone_sub2);
+  ClusterSequenceArea clust_seq_sub2(particle_in_fat2, jet_def_sub2, area_def);
+  subjets_2 = sorted_by_pt(clust_seq_sub2.inclusive_jets(0));
+
+  // set TopJets with subjets and JetArea
+
+  //double jet1_area = fatjets[0].area();
+  //double jet2_area = fatjets[1].area();
+  vector<double> subjet1_area;
+  vector<double> subjet2_area;
+  for (unsigned int j = 0; j < subjets_1.size(); ++j) subjet1_area.push_back(subjets_1[j].area());
+  for (unsigned int k = 0; k < subjets_2.size(); ++k) subjet2_area.push_back(subjets_2[k].area());
+
+  double jet1_area = 0;
+  double jet2_area = 0;
+  /*
+  vector<double> subjet1_area;
+  vector<double> subjet2_area;
+  for (unsigned int j = 0; j < subjets_1.size(); ++j) subjet1_area.push_back(0.);
+  for (unsigned int k = 0; k < subjets_2.size(); ++k) subjet2_area.push_back(0.);
+  */
+  auto outputJets = std::make_unique<pat::JetCollection>();
+  outputJets->push_back(createPatJet(fatjets[0], subjets_1, jet1_area, subjet1_area, sd_mass1));
+  outputJets->push_back(createPatJet(fatjets[1], subjets_2, jet2_area, subjet2_area, sd_mass2));
+  iEvent.put(std::move(outputJets));
+}
+
+pat::Jet XConeProducer::createPatJet(const PseudoJet & psj)
+{
+  pat::Jet newJet;
+  newJet.setP4(math::XYZTLorentzVector(psj.pt(), psj.eta(), psj.phi(), psj.E()));
+  return newJet;
+}
+
+pat::Jet XConeProducer::createPatJet(const PseudoJet & psj, const vector<PseudoJet> &subpsj, double jet_area, vector<double> subjet_area, float sd_mass)
+{
+  pat::Jet newJet = createPatJet(psj);
+  newJet.setJetArea(jet_area);
+  newJet.addUserFloat("softdropmass", sd_mass);
+  for (uint i=0; i<subpsj.size(); i++) {
+    pat::Jet subjet = createPatJet(subpsj[i]);
+    subjet.setJetArea(subjet_area[i]);
+  }
+
+  return newJet;
+}
+
+// ------------ method called once each stream before processing any runs, lumis or events  ------------
+void
+XConeProducer::beginStream(edm::StreamID)
+{
+}
+
+// ------------ method called once each stream after processing all runs, lumis and events  ------------
+void
+XConeProducer::endStream() {
+}
+
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+XConeProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(XConeProducer);

--- a/core/plugins/XConeProducer.cc
+++ b/core/plugins/XConeProducer.cc
@@ -127,7 +127,8 @@ XConeProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
         std::isnan(cand.pz()) ||
         std::isinf(cand.px()) ||
         std::isinf(cand.py()) ||
-        std::isinf(cand.pz()))
+        std::isinf(cand.pz()) ||
+        (cand.pt() == 0))
       continue;
 
     _psj.push_back(PseudoJet(cand.px(), cand.py(), cand.pz(), cand.energy()));

--- a/core/plugins/XConeProducer.cc
+++ b/core/plugins/XConeProducer.cc
@@ -110,25 +110,26 @@ XConeProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   edm::Handle<std::vector<pat::PackedCandidate>> particles;
   iEvent.getByToken(src_token_, particles);
 
-
   if (particles->size() < 15) {
-    auto outputJets = std::make_unique<pat::JetCollection>();
-    iEvent.put(std::move(outputJets));
+    auto jetCollection = std::make_unique<pat::JetCollection>();
+    iEvent.put(std::move(jetCollection));
+    auto subjetCollection = std::make_unique<pat::JetCollection>();
+    iEvent.put(std::move(subjetCollection), subjetCollName_);
     return;
   }
 
   // Convert particles to PseudoJets
   std::vector<PseudoJet> _psj;
   for (const auto & cand: *particles) {
-    if (std::isnan(cand.p4().Px()) ||
-        std::isnan(cand.p4().Py()) ||
-        std::isnan(cand.p4().Pz()) ||
-        std::isinf(cand.p4().Px()) ||
-        std::isinf(cand.p4().Py()) ||
-        std::isinf(cand.p4().Pz()))
+    if (std::isnan(cand.px()) ||
+        std::isnan(cand.py()) ||
+        std::isnan(cand.pz()) ||
+        std::isinf(cand.px()) ||
+        std::isinf(cand.py()) ||
+        std::isinf(cand.pz()))
       continue;
 
-    _psj.push_back(PseudoJet(cand.p4().X(), cand.p4().Y(), cand.p4().Z(), cand.p4().T()));
+    _psj.push_back(PseudoJet(cand.px(), cand.py(), cand.pz(), cand.energy()));
   }
 
   // Run first clustering step (N=2, R=1.2)

--- a/core/plugins/XConeProducer.cc
+++ b/core/plugins/XConeProducer.cc
@@ -108,7 +108,7 @@ XConeProducer::~XConeProducer()
 void
 XConeProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
-  edm::Handle<std::vector<pat::PackedCandidate>> particles;
+  edm::Handle<edm::View<pat::PackedCandidate>> particles;
   iEvent.getByToken(src_token_, particles);
 
   if (particles->size() < 15) {

--- a/core/plugins/XConeProducer.cc
+++ b/core/plugins/XConeProducer.cc
@@ -242,7 +242,7 @@ XConeProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 pat::Jet XConeProducer::createPatJet(const PseudoJet & psj)
 {
   pat::Jet newJet;
-  newJet.setP4(math::XYZTLorentzVector(psj.pt(), psj.eta(), psj.phi(), psj.E()));
+  newJet.setP4(math::XYZTLorentzVector(psj.px(), psj.py(), psj.pz(), psj.E()));
   return newJet;
 }
 

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -837,6 +837,22 @@ task.add(process.pfBoostedDoubleSVTagInfos)
 
 process.pfBoostedDoubleSVTagInfos.trackSelection.jetDeltaRMax = cms.double(0.8)
 
+# HOTVR & XCONE
+process.hotvrPuppi = cms.EDProducer("HOTVRProducer",
+    src=cms.InputTag("puppi")
+)
+task.add(process.hotvrPuppi)
+
+process.hotvrPfCand = cms.EDProducer("HOTVRProducer",
+    src=cms.InputTag("packedPFCandidates")
+)
+task.add(process.hotvrPfCand)
+
+process.xconePfCand = cms.EDProducer("XConeProducer",
+    src=cms.InputTag("packedPFCandidates")
+)
+task.add(process.xconePfCand)
+
 # MET
 
 # MET CHS (not available as slimmedMET collection)
@@ -1350,6 +1366,12 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
                                 # *** HOTVR & XCone stuff
                                 doHOTVR=cms.bool(True),
                                 doXCone=cms.bool(True),
+                                HOTVR_sources=cms.VInputTag(
+                                    cms.InputTag("hotvrPfCand"),
+                                    cms.InputTag("hotvrPuppi")
+                                ),
+                                XCone_sources=cms.VInputTag(cms.InputTag("xconePfCand")),
+
                                 doGenHOTVR=cms.bool(not useData),
                                 doGenXCone=cms.bool(not useData),
                                 )


### PR DESCRIPTION
This moves the HOTVR & XCone clusterings to their own EDProducers.
The NTupleWriter has been updated to allow storing any number of HOTVR & XCone outputs.
NTuples now have HOTVR run over both pfCandidates and Puppi particles, along with XCone run over pfCandidates as before.

Each producer makes 2 jet collections
- the subjets (`pat::JetCollection`), with instance label `SubJets`
- the main jets (`pat::JetCollection`) with links to the subjets

The NTupleWriter then reads both of these in & converts them to TopJets.
The EDProducers have no clustering parameters options - I just copied & pasted the code from `UniversalJetCluster` class.
I did however add in a rejection of input particles with pt==0, since Puppi can produce such particles which screws up the clustering.