### PR TITLE
[94X] Make Puppi use existing weights in PFCandidates to speed up

### DIFF
--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -348,6 +348,7 @@ process.load('CommonTools/PileupAlgos/Puppi_cff')
 process.puppi.candName = cms.InputTag('packedPFCandidates')
 process.puppi.vertexName = cms.InputTag('offlineSlimmedPrimaryVertices')
 process.puppi.clonePackedCands = cms.bool(True)
+process.puppi.useExistingWeights = cms.bool(True)
 task.add(process.puppi)
 
 process.ca15PuppiJetsSoftDrop = ak8PFJetsCHSSoftDrop.clone(


### PR DESCRIPTION
Tip from @ahinzmann : turns out the packedPfCandidates already have puppiWeights stored, so no need to recalculate them.
Puppi module goes from ~0.4s/event to ~0.02s/event ! 🚀 

(This also sped up `hotvrPuppi`, ~1.17s/evt -> ~0.6s/evt ... not sure why but yay)