### PR TITLE
[94X] Remove our CHS MET producer, store the official one from MiniAOD

### DIFF
--- a/core/include/MET.h
+++ b/core/include/MET.h
@@ -33,6 +33,8 @@ public:
       m_shiftedPy_TauEnDown = 0;
       m_shiftedPy_MuonEnDown = 0;
       m_shiftedPy_MuonEnUp = 0;
+      m_corrPx_CHS = 0;
+      m_corrPy_CHS = 0;
       /* m_corr_x = 0; */
       /* m_corr_y = 0; */
       /* //  m_corr_SumEt = 0; */
@@ -104,7 +106,11 @@ public:
 
    float shiftedPy_MuonEnUp() const{return m_shiftedPy_MuonEnUp;}
    
-   
+   float corrPx_CHS() const{return m_corrPx_CHS;}
+
+   float corrPy_CHS() const{return m_corrPy_CHS;}
+
+
    /// set transverse momentum
    void set_pt(float pt){m_pt=pt;}  
    /// set phi
@@ -170,6 +176,10 @@ public:
 
    void set_shiftedPy_MuonEnUp(float shiftedPy_MuonEnUp) {m_shiftedPy_MuonEnUp = shiftedPy_MuonEnUp;}
 
+   void set_corrPx_CHS(float corrPx_CHS){m_corrPx_CHS = corrPx_CHS;}
+
+   void set_corrPy_CHS(float corrPy_CHS){m_corrPy_CHS = corrPy_CHS;}
+
    /// convert missing transverse energy into 4-vector
    LorentzVector v4(){
       LorentzVector met(0,0,0,0);
@@ -214,6 +224,8 @@ private:
    float m_shiftedPy_TauEnDown;
    float m_shiftedPy_MuonEnDown;
    float m_shiftedPy_MuonEnUp;
+   float m_corrPx_CHS;
+   float m_corrPy_CHS;
    float m_uncorr_pt;
    float m_uncorr_phi;
    /* float m_corr_x; */

--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -1122,6 +1122,8 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
                met[j].set_shiftedPy_TauEnDown(pat_met.shiftedPy(pat::MET::METUncertainty::TauEnDown, pat::MET::METCorrectionLevel::Type1));
                met[j].set_shiftedPy_MuonEnDown(pat_met.shiftedPy(pat::MET::METUncertainty::MuonEnDown, pat::MET::METCorrectionLevel::Type1));
                met[j].set_shiftedPy_MuonEnUp(pat_met.shiftedPy(pat::MET::METUncertainty::MuonEnUp, pat::MET::METCorrectionLevel::Type1));
+               met[j].set_corrPx_CHS(pat_met.corPy(pat::MET::METCorrectionLevel::RawChs));
+               met[j].set_corrPy_CHS(pat_met.corPy(pat::MET::METCorrectionLevel::RawChs));
             }
        }
       }

--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -497,9 +497,8 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
     for(size_t j=0; j< met_sources.size(); ++j){
       met_tokens.push_back(consumes<vector<pat::MET>>(met_sources[j]));
       branch(tr, met_sources[j].c_str(), "MET", &met[j]);
-      //      if (met_sources[j]=="slimmedMETsPuppi") puppi.push_back(true);
-      if (met_sources[j]=="slimmedMETsPuppi" || met_sources[j]=="slMETsCHST1") puppi.push_back(true); //Puppi and CHS don't have METUncertainty
-      else puppi.push_back(false);
+      if (met_sources[j]=="slimmedMETsPuppi") skipMETUncertainties.push_back(true);  // Puppi doesn't have METUncertainty
+      else skipMETUncertainties.push_back(false);
     }
     if(!met_sources.empty()){
         event->met = &met[0];
@@ -1095,8 +1094,8 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
          met[j].set_mEtSig(pat_met.mEtSig());
          met[j].set_uncorr_pt(pat_met.uncorPt());
          met[j].set_uncorr_phi(pat_met.uncorPhi());
-         //      std::cout<<"MET uncorrPt = "<<pat_met.uncorPt()<<" uncorrPhi = "<<pat_met.uncorPhi()<<" corrPt = "<<pat_met.pt()<<" corrPhi = "<<pat_met.phi()<<std::endl;
-         if(!puppi.at(j))
+         // std::cout<<"MET uncorrPt = "<<pat_met.uncorPt()<<" uncorrPhi = "<<pat_met.uncorPhi()<<" corrPt = "<<pat_met.pt()<<" corrPhi = "<<pat_met.phi()<<std::endl;
+         if(!skipMETUncertainties.at(j))
             {
                met[j].set_shiftedPx_JetEnUp(pat_met.shiftedPx(pat::MET::METUncertainty::JetEnUp, pat::MET::METCorrectionLevel::Type1));
                met[j].set_shiftedPx_JetEnDown(pat_met.shiftedPx(pat::MET::METUncertainty::JetEnDown, pat::MET::METCorrectionLevel::Type1));

--- a/core/plugins/NtupleWriter.h
+++ b/core/plugins/NtupleWriter.h
@@ -137,7 +137,7 @@ class NtupleWriter : public edm::EDFilter {
       std::vector<std::vector<FlavorParticle> > triggerObjects_out;
       std::vector<std::string> triggerObjects_sources;
 
-      std::vector<bool> puppi;
+      std::vector<bool> skipMETUncertainties;
 
       std::vector<edm::EDGetToken> hotvr_tokens;
       std::vector<edm::EDGetToken> hotvr_subjet_tokens;

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -4,7 +4,7 @@ isDebug = False
 useData = True
 #useData = False
 
-met_sources_GL = cms.vstring("slimmedMETs", "slimmedMETsPuppi", "slMETsCHS")
+met_sources_GL = cms.vstring("slimmedMETs", "slimmedMETsPuppi")
 
 # minimum pt for the large-R jets (applies for all: vanilla CA8/CA15,
 # cmstoptag, heptoptag). Also applied for the corresponding genjets.
@@ -854,48 +854,6 @@ process.xconePfCand = cms.EDProducer("XConeProducer",
 )
 task.add(process.xconePfCand)
 
-# MET
-
-# MET CHS (not available as slimmedMET collection)
-# copied from
-# https://github.com/cms-jet/JMEValidator/blob/CMSSW_7_6_X/python/FrameworkConfiguration.py
-
-
-def clean_met_(met):
-    del met.t01Variation
-    del met.t1Uncertainties
-    del met.t1SmearedVarsAndUncs
-    del met.tXYUncForRaw
-    del met.tXYUncForT1
-    del met.tXYUncForT01
-    del met.tXYUncForT1Smear
-    del met.tXYUncForT01Smear
-    del met.chsMET  # FIXME: utilise the chsMET part instead of having multiple METs?
-    del met.trkMET
-
-
-from PhysicsTools.PatAlgos.tools.metTools import addMETCollection
-
-# Raw PAT METs
-process.load('RecoMET.METProducers.PFMET_cfi')
-process.pfMet.src = cms.InputTag('chs')
-task.add(process.pfMet)
-addMETCollection(process, labelName='patPFMetCHS',
-                 metSource='pfMet')  # RAW MET
-addMETCollection(process, labelName='patPFMet', metSource='pfMet')  # RAW MET
-process.patPFMet.addGenMET = False
-process.patPFMetCHS.addGenMET = False
-# Slimmed METs
-from PhysicsTools.PatAlgos.slimming.slimmedMETs_cfi import slimmedMETs
-#### CaloMET is not available in MiniAOD
-del slimmedMETs.caloMET
-# ### CHS
-process.slMETsCHS = slimmedMETs.clone()
-process.slMETsCHS.src = cms.InputTag("patPFMetCHS")
-process.slMETsCHS.rawUncertainties = cms.InputTag(
-    "patPFMetCHS")  # only central value
-task.add(process.slMETsCHS)
-clean_met_(process.slMETsCHS)
 
 # LEPTON cfg
 


### PR DESCRIPTION
This retires our slMETsCHS collection, in favour of storing the CHS "correction" like as is done in MiniAOD.
The CHS MET is now accessible from `slimmedMETs`, using the `corrPx_CHS()` and `corrPy_CHS()` methods.

The use of "corr" is in keeping with the names from pat::MET: https://github.com/cms-sw/cmssw/blob/CMSSW_9_4_1/DataFormats/PatCandidates/interface/MET.h#L151-L168
Although it should be pointed out that the MET itself **doesn't** have any Type-1 corrections.

@karavdin  / anyone that uses any of these MET corrections: is storing px and py useful? Or is storing pt/phi better? Or the whole LorentzVector?

Unfortunately this saves very little processing time, the previous modules were very efficient:
```
TimeReport   0.000789     0.000789     0.000789  pfMet
TimeReport   0.000019     0.000019     0.000019  slMETsCHS
```

I also compared the values of our slMETsCHS vs the value in MiniAOD, and they were practically identical (pt matched within ~0.005 GeV or better, difference due to lost info when we use packedPfCandidates).