### PR TITLE
[94X] Remove CA15 pruned mass

### DIFF
--- a/core/include/TopJet.h
+++ b/core/include/TopJet.h
@@ -81,7 +81,7 @@ public:
    }
 
   TopJet(){
-      m_qjets_volatility = m_tau1 = m_tau2 = m_tau3 = m_tau4 = m_mvahiggsdiscr = m_prunedmass = m_softdropmass = m_tau1_groomed = m_tau2_groomed = m_tau3_groomed = m_tau4_groomed = -1.0f;
+      m_qjets_volatility = m_tau1 = m_tau2 = m_tau3 = m_tau4 = m_mvahiggsdiscr = m_prunedmass = m_softdropmass = m_tau1_groomed = m_tau2_groomed = m_tau3_groomed = m_tau4_groomed = m_ecfN2_beta1 = m_ecfN2_beta2 = m_ecfN3_beta1 = m_ecfN3_beta2 = -1.0f;
   }
 
   // getters
@@ -95,6 +95,13 @@ public:
   float tau3_groomed() const {return m_tau3_groomed;}
   float tau4_groomed() const {return m_tau3_groomed;}
   
+  // energy correlation functions, N2 & N3, each with beta=1 or beta=2
+  // calculated on softdrop jets
+  float ecfN2_beta1() const {return m_ecfN2_beta1;}
+  float ecfN2_beta2() const {return m_ecfN2_beta2;}
+  float ecfN3_beta1() const {return m_ecfN3_beta1;}
+  float ecfN3_beta2() const {return m_ecfN3_beta2;}
+
   float mvahiggsdiscr() const {return m_mvahiggsdiscr;}
 
   float prunedmass() const {return m_prunedmass;}
@@ -117,6 +124,11 @@ public:
   void set_tau2_groomed(float x){m_tau2_groomed = x;}
   void set_tau3_groomed(float x){m_tau3_groomed = x;}
   void set_tau4_groomed(float x){m_tau4_groomed = x;}
+
+  void set_ecfN2_beta1(float x){m_ecfN2_beta1 = x;}
+  void set_ecfN2_beta2(float x){m_ecfN2_beta2 = x;}
+  void set_ecfN3_beta1(float x){m_ecfN3_beta1 = x;}
+  void set_ecfN3_beta2(float x){m_ecfN3_beta2 = x;}
 
   void set_mvahiggsdiscr(float x){m_mvahiggsdiscr = x;}
 
@@ -144,6 +156,11 @@ private:
   float m_tau3_groomed;
   float m_tau4_groomed;
   
+  float m_ecfN2_beta1;
+  float m_ecfN2_beta2;
+  float m_ecfN3_beta1;
+  float m_ecfN3_beta2;
+
   float m_mvahiggsdiscr;
 
   float m_prunedmass;

--- a/core/include/TopJet.h
+++ b/core/include/TopJet.h
@@ -81,7 +81,7 @@ public:
    }
 
   TopJet(){
-      m_qjets_volatility = m_tau1 = m_tau2 = m_tau3 = m_mvahiggsdiscr = m_prunedmass = m_softdropmass = m_tau1_groomed = m_tau2_groomed = m_tau3_groomed = -1.0f;
+      m_qjets_volatility = m_tau1 = m_tau2 = m_tau3 = m_tau4 = m_mvahiggsdiscr = m_prunedmass = m_softdropmass = m_tau1_groomed = m_tau2_groomed = m_tau3_groomed = m_tau4_groomed = -1.0f;
   }
 
   // getters
@@ -89,9 +89,11 @@ public:
   float tau1() const {return m_tau1;}
   float tau2() const {return m_tau2;}
   float tau3() const {return m_tau3;}
+  float tau4() const {return m_tau3;}
   float tau1_groomed() const {return m_tau1_groomed;}
   float tau2_groomed() const {return m_tau2_groomed;}
   float tau3_groomed() const {return m_tau3_groomed;}
+  float tau4_groomed() const {return m_tau3_groomed;}
   
   float mvahiggsdiscr() const {return m_mvahiggsdiscr;}
 
@@ -110,9 +112,11 @@ public:
   void set_tau1(float x){m_tau1 = x;}
   void set_tau2(float x){m_tau2 = x;}
   void set_tau3(float x){m_tau3 = x;}
+  void set_tau4(float x){m_tau4 = x;}
   void set_tau1_groomed(float x){m_tau1_groomed = x;}
   void set_tau2_groomed(float x){m_tau2_groomed = x;}
   void set_tau3_groomed(float x){m_tau3_groomed = x;}
+  void set_tau4_groomed(float x){m_tau4_groomed = x;}
 
   void set_mvahiggsdiscr(float x){m_mvahiggsdiscr = x;}
 
@@ -134,9 +138,11 @@ private:
   float m_tau1;
   float m_tau2;
   float m_tau3;
+  float m_tau4;
   float m_tau1_groomed;
   float m_tau2_groomed;
   float m_tau3_groomed;
+  float m_tau4_groomed;
   
   float m_mvahiggsdiscr;
 

--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -377,19 +377,20 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
           cfg.njettiness_groomed_src = topjets_list[j].getParameter<std::string>("njettiness_groomed_source");
           substructure_groomed_variables = true;
         }
-        if(substructure_groomed_variables){
-          if(!topjets_list[j].exists("substructure_groomed_variables_source")){
-            cerr << "Exception: groomed njettiness source defined without definition of substructure_groomed_variables_source" << endl;
-            throw;
-          }
-          cfg.substructure_groomed_variables_src = topjets_list[j].getParameter<std::string>("substructure_groomed_variables_source");
-        }
-
         if (topjets_list[j].exists("ecf_beta1_source")) {
           cfg.ecf_beta1_src = topjets_list[j].getParameter<std::string>("ecf_beta1_source");
+          substructure_groomed_variables = true;
         }
         if (topjets_list[j].exists("ecf_beta2_source")) {
           cfg.ecf_beta2_src = topjets_list[j].getParameter<std::string>("ecf_beta2_source");
+          substructure_groomed_variables = true;
+        }
+        if(substructure_groomed_variables){
+          if(!topjets_list[j].exists("substructure_groomed_variables_source")){
+            cerr << "Exception: groomed njettiness or ECF sources defined without definition of substructure_groomed_variables_source" << endl;
+            throw;
+          }
+          cfg.substructure_groomed_variables_src = topjets_list[j].getParameter<std::string>("substructure_groomed_variables_source");
         }
 
         std::string topbranch=topjet_source+"_"+subjet_source;

--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -387,8 +387,7 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
         }
         if(substructure_groomed_variables){
           if(!topjets_list[j].exists("substructure_groomed_variables_source")){
-            cerr << "Exception: groomed njettiness or ECF sources defined without definition of substructure_groomed_variables_source" << endl;
-            throw;
+            throw cms::Exception("MissingSourceName", "Groomed njettiness or ECF sources defined without definition of substructure_groomed_variables_source for topjets " + topjet_source);
           }
           cfg.substructure_groomed_variables_src = topjets_list[j].getParameter<std::string>("substructure_groomed_variables_source");
         }

--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -385,6 +385,13 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
           cfg.substructure_groomed_variables_src = topjets_list[j].getParameter<std::string>("substructure_groomed_variables_source");
         }
 
+        if (topjets_list[j].exists("ecf_beta1_source")) {
+          cfg.ecf_beta1_src = topjets_list[j].getParameter<std::string>("ecf_beta1_source");
+        }
+        if (topjets_list[j].exists("ecf_beta2_source")) {
+          cfg.ecf_beta2_src = topjets_list[j].getParameter<std::string>("ecf_beta2_source");
+        }
+
         std::string topbranch=topjet_source+"_"+subjet_source;
         cfg.dest_branchname = topbranch;
         cfg.dest = topbranch;

--- a/core/plugins/NtupleWriterJets.cxx
+++ b/core/plugins/NtupleWriterJets.cxx
@@ -313,11 +313,13 @@ NtupleWriterTopJets::NtupleWriterTopJets(Config & cfg, bool set_jets_member): pt
     src_njettiness1_token = cfg.cc.consumes<edm::ValueMap<float> >(edm::InputTag(njettiness_src, "tau1"));
     src_njettiness2_token = cfg.cc.consumes<edm::ValueMap<float> >(edm::InputTag(njettiness_src, "tau2"));
     src_njettiness3_token = cfg.cc.consumes<edm::ValueMap<float> >(edm::InputTag(njettiness_src, "tau3"));
+    src_njettiness4_token = cfg.cc.consumes<edm::ValueMap<float> >(edm::InputTag(njettiness_src, "tau4"));
 
     njettiness_groomed_src = cfg.njettiness_groomed_src;    
     src_njettiness1_groomed_token = cfg.cc.consumes<edm::ValueMap<float> >(edm::InputTag(njettiness_groomed_src, "tau1"));
     src_njettiness2_groomed_token = cfg.cc.consumes<edm::ValueMap<float> >(edm::InputTag(njettiness_groomed_src, "tau2"));
     src_njettiness3_groomed_token = cfg.cc.consumes<edm::ValueMap<float> >(edm::InputTag(njettiness_groomed_src, "tau3"));
+    src_njettiness4_groomed_token = cfg.cc.consumes<edm::ValueMap<float> >(edm::InputTag(njettiness_groomed_src, "tau4"));
 
     qjets_src = cfg.qjets_src;
     src_qjets_token = cfg.cc.consumes<edm::ValueMap<float> >(edm::InputTag(qjets_src, "QjetsVolatility"));
@@ -390,8 +392,8 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
     event.getByToken(src_token, h_pat_topjets);
     const vector<pat::Jet> & pat_topjets = *h_pat_topjets;
 
-    edm::Handle<edm::ValueMap<float>> h_njettiness1, h_njettiness2, h_njettiness3;
-    edm::Handle<edm::ValueMap<float>> h_njettiness1_groomed, h_njettiness2_groomed, h_njettiness3_groomed;
+    edm::Handle<edm::ValueMap<float>> h_njettiness1, h_njettiness2, h_njettiness3, h_njettiness4;
+    edm::Handle<edm::ValueMap<float>> h_njettiness1_groomed, h_njettiness2_groomed, h_njettiness3_groomed, h_njettiness4_groomed;
     edm::Handle<edm::ValueMap<float>> h_qjets;
     
     edm::Handle<reco::BasicJetCollection> topjets_with_cands;
@@ -404,11 +406,13 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
         event.getByToken(src_njettiness1_token, h_njettiness1);
         event.getByToken(src_njettiness2_token, h_njettiness2);
         event.getByToken(src_njettiness3_token, h_njettiness3);
+        event.getByToken(src_njettiness4_token, h_njettiness4);
     }
     if(!njettiness_groomed_src.empty()){
         event.getByToken(src_njettiness1_groomed_token, h_njettiness1_groomed);
         event.getByToken(src_njettiness2_groomed_token, h_njettiness2_groomed);
         event.getByToken(src_njettiness3_groomed_token, h_njettiness3_groomed);
+        event.getByToken(src_njettiness4_groomed_token, h_njettiness4_groomed);
     }
     if(!qjets_src.empty()){
         event.getByToken(src_qjets_token, h_qjets);
@@ -559,6 +563,7 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
                 topjet.set_tau1((*h_njettiness1)[ref]);
                 topjet.set_tau2((*h_njettiness2)[ref]);
                 topjet.set_tau3((*h_njettiness3)[ref]);
+                topjet.set_tau4((*h_njettiness4)[ref]);
               }
               if(!qjets_src.empty()){
                 topjet.set_qjets_volatility((*h_qjets)[ref]);
@@ -570,6 +575,7 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
                 topjet.set_tau1((*h_njettiness1)[ref]);
                 topjet.set_tau2((*h_njettiness2)[ref]);
                 topjet.set_tau3((*h_njettiness3)[ref]);
+                topjet.set_tau4((*h_njettiness4)[ref]);
               }
               if(!qjets_src.empty()){
                 topjet.set_qjets_volatility((*h_qjets)[ref]);
@@ -605,6 +611,7 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
                 topjet.set_tau1_groomed((*h_njettiness1_groomed)[ref]);
                 topjet.set_tau2_groomed((*h_njettiness2_groomed)[ref]);
                 topjet.set_tau3_groomed((*h_njettiness3_groomed)[ref]);
+                topjet.set_tau4_groomed((*h_njettiness4_groomed)[ref]);
               }
             }
             else{
@@ -613,6 +620,7 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
                 topjet.set_tau1_groomed((*h_njettiness1_groomed)[ref]);
                 topjet.set_tau2_groomed((*h_njettiness2_groomed)[ref]);
                 topjet.set_tau3_groomed((*h_njettiness3_groomed)[ref]);
+                topjet.set_tau4_groomed((*h_njettiness4_groomed)[ref]);
               }
             }
           }
@@ -655,12 +663,14 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
           topjet.set_tau1(pat_topjet.userFloat("NjettinessAK8Puppi:tau1"));
           topjet.set_tau2(pat_topjet.userFloat("NjettinessAK8Puppi:tau2"));
           topjet.set_tau3(pat_topjet.userFloat("NjettinessAK8Puppi:tau3"));
+          topjet.set_tau4(pat_topjet.userFloat("NjettinessAK8Puppi:tau4"));
         }
-	if(njettiness_groomed_src.empty()){
-
+        if(njettiness_groomed_src.empty()){
+          // as miniaod doesn't calculate groomed tau_i
           topjet.set_tau1_groomed(-9999.);
           topjet.set_tau2_groomed(-9999.);
           topjet.set_tau3_groomed(-9999.);
+          topjet.set_tau4_groomed(-9999.);
         }
         /*---------------------*/
 

--- a/core/plugins/NtupleWriterJets.cxx
+++ b/core/plugins/NtupleWriterJets.cxx
@@ -705,36 +705,36 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
         /*--- Njettiness ------*/
         if(njettiness_src.empty()){
 
-          topjet.set_tau1(getPatJetUserFloat(pat_topjet, "NjettinessAK8Puppi:tau1"));
-          topjet.set_tau2(getPatJetUserFloat(pat_topjet, "NjettinessAK8Puppi:tau2"));
-          topjet.set_tau3(getPatJetUserFloat(pat_topjet, "NjettinessAK8Puppi:tau3"));
-          topjet.set_tau4(getPatJetUserFloat(pat_topjet, "NjettinessAK8Puppi:tau4"));
+          topjet.set_tau1(getPatJetUserFloat(pat_topjet, "NjettinessAK8Puppi:tau1", -1.));
+          topjet.set_tau2(getPatJetUserFloat(pat_topjet, "NjettinessAK8Puppi:tau2", -1.));
+          topjet.set_tau3(getPatJetUserFloat(pat_topjet, "NjettinessAK8Puppi:tau3", -1.));
+          topjet.set_tau4(getPatJetUserFloat(pat_topjet, "NjettinessAK8Puppi:tau4", -1.));
         }
         if(njettiness_groomed_src.empty()){
           // as miniaod doesn't calculate groomed tau_i
-          topjet.set_tau1_groomed(-9999.);
-          topjet.set_tau2_groomed(-9999.);
-          topjet.set_tau3_groomed(-9999.);
-          topjet.set_tau4_groomed(-9999.);
+          topjet.set_tau1_groomed(-1.);
+          topjet.set_tau2_groomed(-1.);
+          topjet.set_tau3_groomed(-1.);
+          topjet.set_tau4_groomed(-1.);
         }
         /*---------------------*/
 
         /*--- energy correlation functions -----*/
         if (ecf_beta1_src.empty()) {
-          topjet.set_ecfN2_beta1(getPatJetUserFloat(pat_topjet, "ak8PFJetsPuppiSoftDropValueMap:nb1AK8PuppiSoftDropN2"));
-          topjet.set_ecfN3_beta1(getPatJetUserFloat(pat_topjet, "ak8PFJetsPuppiSoftDropValueMap:nb1AK8PuppiSoftDropN3"));
+          topjet.set_ecfN2_beta1(getPatJetUserFloat(pat_topjet, "ak8PFJetsPuppiSoftDropValueMap:nb1AK8PuppiSoftDropN2", -1.));
+          topjet.set_ecfN3_beta1(getPatJetUserFloat(pat_topjet, "ak8PFJetsPuppiSoftDropValueMap:nb1AK8PuppiSoftDropN3", -1.));
         }
 
         if (ecf_beta2_src.empty()) {
-          topjet.set_ecfN2_beta2(getPatJetUserFloat(pat_topjet, "ak8PFJetsPuppiSoftDropValueMap:nb2AK8PuppiSoftDropN2"));
-          topjet.set_ecfN3_beta2(getPatJetUserFloat(pat_topjet, "ak8PFJetsPuppiSoftDropValueMap:nb2AK8PuppiSoftDropN3"));
+          topjet.set_ecfN2_beta2(getPatJetUserFloat(pat_topjet, "ak8PFJetsPuppiSoftDropValueMap:nb2AK8PuppiSoftDropN2", -1.));
+          topjet.set_ecfN3_beta2(getPatJetUserFloat(pat_topjet, "ak8PFJetsPuppiSoftDropValueMap:nb2AK8PuppiSoftDropN3", -1.));
         }
         /*---------------------*/
 
         /*--- pruned mass -----*/
         if(pruned_src.find("Mass")!=string::npos){
 
-          topjet.set_prunedmass(getPatJetUserFloat(pat_topjet, pruned_src));
+          topjet.set_prunedmass(getPatJetUserFloat(pat_topjet, pruned_src, -1.));
         }
         else if(pruned_src!=""){//pruned mass set through matching with pruned-jet collection
 
@@ -766,7 +766,7 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
         /*--- softdrop mass ---*/
         if(softdrop_src.find("Mass")!=string::npos){
 
-          topjet.set_softdropmass(getPatJetUserFloat(pat_topjet, softdrop_src));
+          topjet.set_softdropmass(getPatJetUserFloat(pat_topjet, softdrop_src, -1.));
         }
         else if(softdrop_src!=""){//softdrop mass set through matching with softdrop-jet collection
 

--- a/core/plugins/NtupleWriterJets.cxx
+++ b/core/plugins/NtupleWriterJets.cxx
@@ -34,6 +34,13 @@ using namespace std;
 
 bool btag_warning;
 
+// Get userFloat entry, with some default return value if it doesn't exist
+// TODO: template this?
+float getPatJetUserFloat(const pat::Jet & jet, const std::string & key, float defaultValue=-9999.){
+  return (jet.hasUserFloat(key) ? jet.userFloat(key) : defaultValue);
+}
+
+
 NtupleWriterJets::NtupleWriterJets(Config & cfg, bool set_jets_member){
     handle = cfg.ctx.declare_event_output<vector<Jet>>(cfg.dest_branchname, cfg.dest);
     ptmin = cfg.ptmin;
@@ -698,10 +705,10 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
         /*--- Njettiness ------*/
         if(njettiness_src.empty()){
 
-          topjet.set_tau1(pat_topjet.userFloat("NjettinessAK8Puppi:tau1"));
-          topjet.set_tau2(pat_topjet.userFloat("NjettinessAK8Puppi:tau2"));
-          topjet.set_tau3(pat_topjet.userFloat("NjettinessAK8Puppi:tau3"));
-          topjet.set_tau4(pat_topjet.userFloat("NjettinessAK8Puppi:tau4"));
+          topjet.set_tau1(getPatJetUserFloat(pat_topjet, "NjettinessAK8Puppi:tau1"));
+          topjet.set_tau2(getPatJetUserFloat(pat_topjet, "NjettinessAK8Puppi:tau2"));
+          topjet.set_tau3(getPatJetUserFloat(pat_topjet, "NjettinessAK8Puppi:tau3"));
+          topjet.set_tau4(getPatJetUserFloat(pat_topjet, "NjettinessAK8Puppi:tau4"));
         }
         if(njettiness_groomed_src.empty()){
           // as miniaod doesn't calculate groomed tau_i
@@ -714,20 +721,20 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
 
         /*--- energy correlation functions -----*/
         if (ecf_beta1_src.empty()) {
-          topjet.set_ecfN2_beta1(pat_topjet.userFloat("ak8PFJetsPuppiSoftDropValueMap:nb1AK8PuppiSoftDropN2"));
-          topjet.set_ecfN3_beta1(pat_topjet.userFloat("ak8PFJetsPuppiSoftDropValueMap:nb1AK8PuppiSoftDropN3"));
+          topjet.set_ecfN2_beta1(getPatJetUserFloat(pat_topjet, "ak8PFJetsPuppiSoftDropValueMap:nb1AK8PuppiSoftDropN2"));
+          topjet.set_ecfN3_beta1(getPatJetUserFloat(pat_topjet, "ak8PFJetsPuppiSoftDropValueMap:nb1AK8PuppiSoftDropN3"));
         }
 
         if (ecf_beta2_src.empty()) {
-          topjet.set_ecfN2_beta2(pat_topjet.userFloat("ak8PFJetsPuppiSoftDropValueMap:nb2AK8PuppiSoftDropN2"));
-          topjet.set_ecfN3_beta2(pat_topjet.userFloat("ak8PFJetsPuppiSoftDropValueMap:nb2AK8PuppiSoftDropN3"));
+          topjet.set_ecfN2_beta2(getPatJetUserFloat(pat_topjet, "ak8PFJetsPuppiSoftDropValueMap:nb2AK8PuppiSoftDropN2"));
+          topjet.set_ecfN3_beta2(getPatJetUserFloat(pat_topjet, "ak8PFJetsPuppiSoftDropValueMap:nb2AK8PuppiSoftDropN3"));
         }
         /*---------------------*/
 
         /*--- pruned mass -----*/
         if(pruned_src.find("Mass")!=string::npos){
 
-          topjet.set_prunedmass(pat_topjet.userFloat(pruned_src));
+          topjet.set_prunedmass(getPatJetUserFloat(pat_topjet, pruned_src));
         }
         else if(pruned_src!=""){//pruned mass set through matching with pruned-jet collection
 
@@ -759,7 +766,7 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
         /*--- softdrop mass ---*/
         if(softdrop_src.find("Mass")!=string::npos){
 
-          topjet.set_softdropmass(pat_topjet.userFloat(softdrop_src));
+          topjet.set_softdropmass(getPatJetUserFloat(pat_topjet, softdrop_src));
         }
         else if(softdrop_src!=""){//softdrop mass set through matching with softdrop-jet collection
 

--- a/core/plugins/NtupleWriterJets.cxx
+++ b/core/plugins/NtupleWriterJets.cxx
@@ -118,9 +118,7 @@ void NtupleWriterJets::process(const edm::Event & event, uhh2::Event & uevent,  
           fill_jet_info(pat_jet, jet, true, false);
         }
         catch(runtime_error & ex){
-
-          cerr << "Exception in fill_jet_info in NtupleWriterJets::process for jets with src=" << src << endl;
-          throw;
+          throw cms::Exception("fill_jet_info error", "Error in fill_jet_info NtupleWriterJets::process for jets with src = " + src.label());
         }
 
         /*--- lepton keys ---*/
@@ -536,8 +534,7 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
 	}
 
         }catch(runtime_error &){
-           cerr << "Error in fill_jet_info for topjets in NtupleWriterTopJets with src = " << src << "." << endl;
-           throw;
+          throw cms::Exception("fill_jet_info error", "Error in fill_jet_info for topjets in NtupleWriterTopJets with src = " + src.label());
         }
 
         /*--- lepton keys ---*/
@@ -897,8 +894,7 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
 	      try{
 		NtupleWriterJets::fill_jet_info(*patsubjetd, subjet, do_btagging_subjets, do_taginfo_subjets);
 	      }catch(runtime_error &){
-		cerr << "Error in fill_jet_info for subjets in NtupleWriterTopJets with src = " << src << "." << endl;
-		throw;
+                throw cms::Exception("fill_jet_info error", "Error in fill_jet_info for daughters in NtupleWriterTopJets with src = " + src.label());
 	      }
             }
             else {
@@ -911,7 +907,7 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
 		subjet.set_energy(daughter->energy());
 	      }
 	      else{
-		throw runtime_error("subjet was nullptr");
+		throw cms::Exception("NullSubjet", "daughter is nullptr");
 	      }
             }
             topjet.add_subjet(subjet);
@@ -927,8 +923,7 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
 	      try{
 		NtupleWriterJets::fill_jet_info(*tpatsubjet, subjet, do_btagging_subjets, do_taginfo_subjets);
 	      }catch(runtime_error &){
-		cerr << "Error in fill_jet_info for subjets in NtupleWriterTopJets with src = " << src << "." << endl;
-		throw;
+                throw cms::Exception("fill_jet_info error", "Error in fill_jet_info for subjets in NtupleWriterTopJets with src = " + src.label());
 	      }
 
               /*--- lepton keys ---*/
@@ -949,8 +944,7 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
               /*-------------------*/
             }
 	    else{
-	      cerr << "Error in fill_jet_info for subjets in NtupleWriterTopJets with src = " << src << "." << endl;
-	      throw;
+              throw cms::Exception("MissingSubjet", "Cannot get subjets from topjet src = " + src.label());
 	    }
 	    topjet.add_subjet(subjet);
 	  }//loop over subjets

--- a/core/plugins/NtupleWriterJets.cxx
+++ b/core/plugins/NtupleWriterJets.cxx
@@ -602,8 +602,9 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
             }
           }
         }
-	 int i_pat_topjet_wc_groomed = -1;
-	if(!njettiness_groomed_src.empty()){
+
+        int i_pat_topjet_wc_groomed = -1;
+        if(!njettiness_groomed_src.empty() || !ecf_beta1_src.empty() || !ecf_beta2_src.empty()){
           double drmin = numeric_limits<double>::infinity();
           if(checkjettypegroomed){
             for (size_t i_wc=0; i_wc < topjets_groomed_with_cands_reco->size(); ++i_wc) {

--- a/core/plugins/NtupleWriterJets.cxx
+++ b/core/plugins/NtupleWriterJets.cxx
@@ -499,22 +499,25 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
 
     for (unsigned int i = 0; i < pat_topjets.size(); i++) {
         const pat::Jet & pat_topjet =  pat_topjets[i];
-	//use CHS jet momentum in case of CHS subjet collection (see https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016#Jets)
-	if(subjet_src.find("CHS")!=string::npos){
-	  TLorentzVector puppi_v4;
-	  puppi_v4.SetPtEtaPhiM(pat_topjet.userFloat("ak8PFJetsCHSValueMap:pt"),
-				pat_topjet.userFloat("ak8PFJetsCHSValueMap:eta"),
-				pat_topjet.userFloat("ak8PFJetsCHSValueMap:phi"),
-				pat_topjet.userFloat("ak8PFJetsCHSValueMap:mass"));
-	  //skip jets with incredibly high pT (99999 seems to be a default value in MINIAOD if the puppi jet is not defined)
-	  if(puppi_v4.Pt()>=99999) continue;
-	  if(puppi_v4.Pt() < ptmin) continue;
-	  if(fabs(puppi_v4.Eta()) > etamax) continue;
-	}
-	else{
-	  if(pat_topjet.pt() < ptmin) continue;
-	  if(fabs(pat_topjet.eta()) > etamax) continue;
-	}
+        //use CHS jet momentum in case of CHS subjet collection (see https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016#Jets)
+        if(subjet_src.find("CHS")!=string::npos){
+          TLorentzVector puppi_v4;
+          if (!pat_topjet.hasUserFloat("ak8PFJetsCHSValueMap:pt")) {
+            throw cms::Exception("Missing userFloat", "You wanted CHS subjets but no ak8PFJetsCHSValueMap entries in the ValueMap");
+          }
+          puppi_v4.SetPtEtaPhiM(pat_topjet.userFloat("ak8PFJetsCHSValueMap:pt"),
+            pat_topjet.userFloat("ak8PFJetsCHSValueMap:eta"),
+            pat_topjet.userFloat("ak8PFJetsCHSValueMap:phi"),
+            pat_topjet.userFloat("ak8PFJetsCHSValueMap:mass"));
+          //skip jets with incredibly high pT (99999 seems to be a default value in MINIAOD if the puppi jet is not defined)
+          if(puppi_v4.Pt()>=99999) continue;
+          if(puppi_v4.Pt() < ptmin) continue;
+          if(fabs(puppi_v4.Eta()) > etamax) continue;
+        }
+        else{
+          if(pat_topjet.pt() < ptmin) continue;
+          if(fabs(pat_topjet.eta()) > etamax) continue;
+        }
         
         topjets.emplace_back();
         TopJet & topjet = topjets.back();

--- a/core/plugins/NtupleWriterJets.h
+++ b/core/plugins/NtupleWriterJets.h
@@ -81,8 +81,8 @@ private:
     float ptmin, etamax;
     bool do_btagging, do_btagging_subjets, do_taginfo_subjets, do_toptagging;
     edm::EDGetToken src_token, src_higgs_token, src_pruned_token, src_softdrop_token, substructure_variables_src_token, substructure_variables_src_tokenreco, substructure_groomed_variables_src_token, substructure_groomed_variables_src_tokenreco;
-    edm::EDGetToken src_njettiness1_token, src_njettiness2_token, src_njettiness3_token, src_qjets_token;
-    edm::EDGetToken src_njettiness1_groomed_token, src_njettiness2_groomed_token, src_njettiness3_groomed_token;
+    edm::EDGetToken src_njettiness1_token, src_njettiness2_token, src_njettiness3_token, src_njettiness4_token, src_qjets_token;
+    edm::EDGetToken src_njettiness1_groomed_token, src_njettiness2_groomed_token, src_njettiness3_groomed_token, src_njettiness4_groomed_token;
     edm::EDGetToken src_hepTopTag_token;
     edm::EDGetToken src_higgstaginfo_token;
     std::string njettiness_src, njettiness_groomed_src, qjets_src, subjet_src, higgs_src, higgs_name, higgstaginfo_src, pruned_src, softdrop_src, topjet_collection;

--- a/core/plugins/NtupleWriterJets.h
+++ b/core/plugins/NtupleWriterJets.h
@@ -67,6 +67,8 @@ public:
         std::string pruned_src;
         std::string softdrop_src;
         std::string toptagging_src;
+        std::string ecf_beta1_src;
+        std::string ecf_beta2_src;
     };
 
     explicit NtupleWriterTopJets(Config & cfg, bool set_jets_member);
@@ -83,9 +85,10 @@ private:
     edm::EDGetToken src_token, src_higgs_token, src_pruned_token, src_softdrop_token, substructure_variables_src_token, substructure_variables_src_tokenreco, substructure_groomed_variables_src_token, substructure_groomed_variables_src_tokenreco;
     edm::EDGetToken src_njettiness1_token, src_njettiness2_token, src_njettiness3_token, src_njettiness4_token, src_qjets_token;
     edm::EDGetToken src_njettiness1_groomed_token, src_njettiness2_groomed_token, src_njettiness3_groomed_token, src_njettiness4_groomed_token;
+    edm::EDGetToken src_ecf_beta1_N2_token, src_ecf_beta1_N3_token, src_ecf_beta2_N2_token, src_ecf_beta2_N3_token;
     edm::EDGetToken src_hepTopTag_token;
     edm::EDGetToken src_higgstaginfo_token;
-    std::string njettiness_src, njettiness_groomed_src, qjets_src, subjet_src, higgs_src, higgs_name, higgstaginfo_src, pruned_src, softdrop_src, topjet_collection;
+    std::string njettiness_src, njettiness_groomed_src, qjets_src, ecf_beta1_src, ecf_beta2_src, subjet_src, higgs_src, higgs_name, higgstaginfo_src, pruned_src, softdrop_src, topjet_collection;
     Event::Handle<std::vector<TopJet>> handle;
     boost::optional<Event::Handle<std::vector<TopJet>>> topjets_handle;
     std::vector<TopJet::tag> id_tags;

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -767,6 +767,47 @@ process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService
 )
 """
 
+# Add in Energy Correlation Functions for groomed jets only
+from RecoJets.JetProducers.ECF_cff import ecfNbeta1, ecfNbeta2
+process.ECFNbeta1Ak8SoftDropCHS = ecfNbeta1.clone(
+    src=cms.InputTag("ak8CHSJetsSoftDropforsub"),
+    cuts=cms.vstring('', '', 'pt > 250')
+)
+task.add(process.ECFNbeta1Ak8SoftDropCHS)
+
+process.ECFNbeta2Ak8SoftDropCHS = ecfNbeta2.clone(
+    src=cms.InputTag("ak8CHSJetsSoftDropforsub"),
+    cuts=cms.vstring('', '', 'pt > 250')
+)
+task.add(process.ECFNbeta2Ak8SoftDropCHS)
+
+
+process.ECFNbeta1Ak8SoftDropPuppi = ecfNbeta1.clone(
+    src=cms.InputTag("ak8PuppiJetsSoftDropforsub"),
+    cuts=cms.vstring('', '', 'pt > 250')
+)
+task.add(process.ECFNbeta1Ak8SoftDropPuppi)
+
+process.ECFNbeta2Ak8SoftDropPuppi = ecfNbeta2.clone(
+    src=cms.InputTag("ak8PuppiJetsSoftDropforsub"),
+    cuts=cms.vstring('', '', 'pt > 250')
+)
+task.add(process.ECFNbeta2Ak8SoftDropPuppi)
+
+
+process.ECFNbeta1CA15SoftDropCHS = ecfNbeta1.clone(
+    src=cms.InputTag("ca15CHSJetsSoftDropforsub"),
+    cuts=cms.vstring('', '', 'pt > 250')
+)
+task.add(process.ECFNbeta1CA15SoftDropCHS)
+
+process.ECFNbeta2CA15SoftDropCHS = ecfNbeta2.clone(
+    src=cms.InputTag("ca15CHSJetsSoftDropforsub"),
+    cuts=cms.vstring('', '', 'pt > 250')
+)
+task.add(process.ECFNbeta2CA15SoftDropCHS)
+
+
 # for JEC purposes, cluster AK8 jets but with lower pt (compared to higher
 # threshold in miniAOD)
 ak8_label = "AK8PFPUPPI"
@@ -1175,6 +1216,10 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
                                             "patJetsAk8CHSJetsPrunedPacked"),
                                         softdropmass_source=cms.string(
                                             "patJetsAk8CHSJetsSoftDropPacked"),
+                                        ecf_beta1_source=cms.string(
+                                            "ECFNbeta1Ak8SoftDropCHS"),
+                                        ecf_beta2_source=cms.string(
+                                            "ECFNbeta2Ak8SoftDropCHS")
                                     ),
                                     cms.PSet(
                                         # The fat jets that HepTopTag produces are the Top jet candidates,
@@ -1202,6 +1247,10 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
                                         prunedmass_source = cms.string(
                                             "patJetsCa15CHSJetsPrunedPacked"),
                                         # softdropmass_source  = cms.string(""),
+                                        ecf_beta1_source=cms.string(
+                                            "ECFNbeta1CA15SoftDropCHS"),
+                                        ecf_beta2_source=cms.string(
+                                            "ECFNbeta2CA15SoftDropCHS")
                                     ) ,
                                     # cms.PSet(
                                     #    topjet_source = cms.string("patJetsHepTopTagPuppiPacked"),
@@ -1237,6 +1286,11 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
                                             "patJetsAk8CHSJetsPrunedPacked"),
                                         softdropmass_source=cms.string(
                                             "patJetsAk8PuppiJetsSoftDropPacked"),
+                                        ecf_beta1_source=cms.string(
+                                            "ECFNbeta1Ak8SoftDropPuppi"),
+                                        ecf_beta2_source=cms.string(
+                                            "ECFNbeta2Ak8SoftDropPuppi")
+
                                     ),
 
                                 ),

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -795,18 +795,18 @@ process.ECFNbeta2Ak8SoftDropPuppi = ecfNbeta2.clone(
 )
 task.add(process.ECFNbeta2Ak8SoftDropPuppi)
 
+# Warning, can be very slow
+# process.ECFNbeta1CA15SoftDropCHS = ecfNbeta1.clone(
+#     src=cms.InputTag("ca15CHSJetsSoftDropforsub"),
+#     cuts=cms.vstring('', '', 'pt > 250')
+# )
+# task.add(process.ECFNbeta1CA15SoftDropCHS)
 
-process.ECFNbeta1CA15SoftDropCHS = ecfNbeta1.clone(
-    src=cms.InputTag("ca15CHSJetsSoftDropforsub"),
-    cuts=cms.vstring('', '', 'pt > 250')
-)
-task.add(process.ECFNbeta1CA15SoftDropCHS)
-
-process.ECFNbeta2CA15SoftDropCHS = ecfNbeta2.clone(
-    src=cms.InputTag("ca15CHSJetsSoftDropforsub"),
-    cuts=cms.vstring('', '', 'pt > 250')
-)
-task.add(process.ECFNbeta2CA15SoftDropCHS)
+# process.ECFNbeta2CA15SoftDropCHS = ecfNbeta2.clone(
+#     src=cms.InputTag("ca15CHSJetsSoftDropforsub"),
+#     cuts=cms.vstring('', '', 'pt > 250')
+# )
+# task.add(process.ECFNbeta2CA15SoftDropCHS)
 
 
 # for JEC purposes, cluster AK8 jets but with lower pt (compared to higher
@@ -1254,10 +1254,10 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
                                         prunedmass_source = cms.string(
                                             "patJetsCa15CHSJetsPrunedPacked"),
                                         # softdropmass_source  = cms.string(""),
-                                        ecf_beta1_source=cms.string(
-                                            "ECFNbeta1CA15SoftDropCHS"),
-                                        ecf_beta2_source=cms.string(
-                                            "ECFNbeta2CA15SoftDropCHS")
+                                        # ecf_beta1_source=cms.string(
+                                        #     "ECFNbeta1CA15SoftDropCHS"),
+                                        # ecf_beta2_source=cms.string(
+                                        #     "ECFNbeta2CA15SoftDropCHS")
                                     ) ,
                                     # cms.PSet(
                                     #    topjet_source = cms.string("patJetsHepTopTagPuppiPacked"),

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -768,6 +768,7 @@ process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService
 """
 
 # Add in Energy Correlation Functions for groomed jets only
+# The cut is taken from PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
 from RecoJets.JetProducers.ECF_cff import ecfNbeta1, ecfNbeta2
 process.ECFNbeta1Ak8SoftDropCHS = ecfNbeta1.clone(
     src=cms.InputTag("ak8CHSJetsSoftDropforsub"),
@@ -1192,6 +1193,12 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
                                             "ak8PFJetsPuppiSoftDropMass"),
                                         # switch off qjets for now, as it takes a long time:
                                         #qjets_source = cms.string("QJetsCa8CHS")
+                                        # Energy correlation functions, for beta=1 and beta=2
+                                        # If blank, will use the ones in the jet userFloat.
+                                        # These are assumed to be calculated from the
+                                        # substructure_groomed_variables_source
+                                        ecf_beta1_source=cms.string(""),
+                                        ecf_beta2_source=cms.string("")
                                     ),
                                     cms.PSet(
                                         topjet_source=cms.string(

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -332,14 +332,14 @@ process.ak8CHSJetsPruned = ak4PFJetsPruned.clone(
 )
 task.add(process.ak8CHSJetsPruned)
 
-process.ca15CHSJetsPruned = ak4PFJetsPruned.clone(
-    rParam=1.5,
-    jetAlgorithm="CambridgeAachen",
-    doAreaFastjet=True,
-    src='chs',
-    jetPtMin=process.ca15CHSJets.jetPtMin
-)
-task.add(process.ca15CHSJetsPruned)
+# process.ca15CHSJetsPruned = ak4PFJetsPruned.clone(
+#     rParam=1.5,
+#     jetAlgorithm="CambridgeAachen",
+#     doAreaFastjet=True,
+#     src='chs',
+#     jetPtMin=process.ca15CHSJets.jetPtMin
+# )
+# task.add(process.ca15CHSJetsPruned)
 
 ###############################################
 # PUPPI JETS
@@ -664,7 +664,7 @@ add_fatjets_subjets(process, 'ak8PuppiJetsFat', 'ak8PuppiJetsSoftDrop', genjets_
 # B-tagging not needed for pruned jets, they are just used to get the mass
 add_fatjets_subjets(process, 'ak8CHSJets', 'ak8CHSJetsPruned',
                     genjets_name=lambda s: s.replace('CHS', 'Gen'), btagging=False)
-add_fatjets_subjets(process, 'ca15CHSJets', 'ca15CHSJetsPruned', jetcorr_label=None, jetcorr_label_subjets=None)  # we only use this to make packed collection for pruned mass
+# add_fatjets_subjets(process, 'ca15CHSJets', 'ca15CHSJetsPruned', jetcorr_label=None, jetcorr_label_subjets=None)  # we only use this to make packed collection for pruned mass
 #add_fatjets_subjets(process, 'ca8PuppiJets', 'ca8PuppiJetsPruned', genjets_name = lambda s: s.replace('Puppi', 'Gen'))
 #add_fatjets_subjets(process, 'ca15PuppiJets', 'ca15PuppiJetsFiltered', genjets_name = lambda s: s.replace('Puppi', 'Gen'))
 #add_fatjets_subjets(process, 'ca8PuppiJets', 'cmsTopTagPuppi', genjets_name = lambda s: s.replace('Puppi', 'Gen'))
@@ -1268,8 +1268,8 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
                                         # Specify the module that makes reco::HTTTopJetTagInfo
                                         toptagging_source = cms.string(
                                             "hepTopTagCHS"),
-                                        prunedmass_source = cms.string(
-                                            "patJetsCa15CHSJetsPrunedPacked"),
+                                        # prunedmass_source = cms.string(
+                                        #     "patJetsCa15CHSJetsPrunedPacked"),
                                         # softdropmass_source  = cms.string(""),
                                         # ecf_beta1_source=cms.string(
                                         #     "ECFNbeta1CA15SoftDropCHS"),

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -1197,8 +1197,8 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
                                         # If blank, will use the ones in the jet userFloat.
                                         # These are assumed to be calculated from the
                                         # substructure_groomed_variables_source
-                                        ecf_beta1_source=cms.string(""),
-                                        ecf_beta2_source=cms.string("")
+                                        # ecf_beta1_source=cms.string(""),
+                                        # ecf_beta2_source=cms.string("")
                                     ),
                                     cms.PSet(
                                         topjet_source=cms.string(

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -694,7 +694,7 @@ task.add(process.NjettinessCa15CHS)
 
 process.NjettinessCa15SoftDropCHS = Njettiness.clone(
     src=cms.InputTag("ca15CHSJetsSoftDropforsub"),
-    Njets=cms.vuint32(1, 2, 3),          # compute 1-, 2-, 3- subjettiness
+    Njets=cms.vuint32(1, 2, 3, 4),          # compute 1-, 2-, 3-, 4- subjettiness
     # variables for measure definition :
     measureDefinition=cms.uint32(0),  # CMS default is normalized measure
     beta=cms.double(1.0),              # CMS default is 1
@@ -715,7 +715,7 @@ process.NjettinessCa15SoftDropPuppi = process.NjettinessCa15SoftDropCHS.clone(
 )
 process.NjettinessAk8SoftDropCHS = Njettiness.clone(
     src=cms.InputTag("ak8CHSJetsSoftDropforsub"),
-    Njets=cms.vuint32(1, 2, 3),          # compute 1-, 2-, 3- subjettiness
+    Njets=cms.vuint32(1, 2, 3, 4),          # compute 1-, 2-, 3-, 4- subjettiness
     # variables for measure definition :
     measureDefinition=cms.uint32(0),  # CMS default is normalized measure
     beta=cms.double(1.0),              # CMS default is 1


### PR DESCRIPTION
Remove the CA15 pruned mass (for HepTopTagger collection). I don't think it will be used (we already store the mass of the groomed fat jet the top tagger produces), and it is remarkably slow for one variable (~0.15s / event).