### PR TITLE
[94X] Remove CA15 pruned mass & producers

### DIFF
--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -332,14 +332,14 @@ process.ak8CHSJetsPruned = ak4PFJetsPruned.clone(
 )
 task.add(process.ak8CHSJetsPruned)
 
-process.ca15CHSJetsPruned = ak4PFJetsPruned.clone(
-    rParam=1.5,
-    jetAlgorithm="CambridgeAachen",
-    doAreaFastjet=True,
-    src='chs',
-    jetPtMin=process.ca15CHSJets.jetPtMin
-)
-task.add(process.ca15CHSJetsPruned)
+# process.ca15CHSJetsPruned = ak4PFJetsPruned.clone(
+#     rParam=1.5,
+#     jetAlgorithm="CambridgeAachen",
+#     doAreaFastjet=True,
+#     src='chs',
+#     jetPtMin=process.ca15CHSJets.jetPtMin
+# )
+# task.add(process.ca15CHSJetsPruned)
 
 ###############################################
 # PUPPI JETS
@@ -664,7 +664,7 @@ add_fatjets_subjets(process, 'ak8PuppiJetsFat', 'ak8PuppiJetsSoftDrop', genjets_
 # B-tagging not needed for pruned jets, they are just used to get the mass
 add_fatjets_subjets(process, 'ak8CHSJets', 'ak8CHSJetsPruned',
                     genjets_name=lambda s: s.replace('CHS', 'Gen'), btagging=False)
-add_fatjets_subjets(process, 'ca15CHSJets', 'ca15CHSJetsPruned', jetcorr_label=None, jetcorr_label_subjets=None)  # we only use this to make packed collection for pruned mass
+# add_fatjets_subjets(process, 'ca15CHSJets', 'ca15CHSJetsPruned', jetcorr_label=None, jetcorr_label_subjets=None)  # we only use this to make packed collection for pruned mass
 #add_fatjets_subjets(process, 'ca8PuppiJets', 'ca8PuppiJetsPruned', genjets_name = lambda s: s.replace('Puppi', 'Gen'))
 #add_fatjets_subjets(process, 'ca15PuppiJets', 'ca15PuppiJetsFiltered', genjets_name = lambda s: s.replace('Puppi', 'Gen'))
 #add_fatjets_subjets(process, 'ca8PuppiJets', 'cmsTopTagPuppi', genjets_name = lambda s: s.replace('Puppi', 'Gen'))
@@ -1268,8 +1268,8 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
                                         # Specify the module that makes reco::HTTTopJetTagInfo
                                         toptagging_source = cms.string(
                                             "hepTopTagCHS"),
-                                        prunedmass_source = cms.string(
-                                            "patJetsCa15CHSJetsPrunedPacked"),
+                                        # prunedmass_source = cms.string(
+                                        #     "patJetsCa15CHSJetsPrunedPacked"),
                                         # softdropmass_source  = cms.string(""),
                                         # ecf_beta1_source=cms.string(
                                         #     "ECFNbeta1CA15SoftDropCHS"),


### PR DESCRIPTION
Remove the CA15 pruned mass (for HepTopTagger collection). I don't think it will be used (we already store the mass of the groomed fat jet the top tagger produces), and it is remarkably slow for one variable (~0.15s / event).

I've left how it could be done in there in comments, incase future someone wants to do it.