### PR TITLE
[94X] update electron cut-based ID names

### DIFF
--- a/core/include/Electron.h
+++ b/core/include/Electron.h
@@ -14,10 +14,10 @@ class Electron : public RecParticle {
   enum tag {
     twodcut_dRmin,
     twodcut_pTrel,
-    cutBasedElectronID_Fall17_94X_V1_Preliminary_veto,
-    cutBasedElectronID_Fall17_94X_V1_Preliminary_loose,
-    cutBasedElectronID_Fall17_94X_V1_Preliminary_medium,
-    cutBasedElectronID_Fall17_94X_V1_Preliminary_tight,
+    cutBasedElectronID_Fall17_94X_V1_veto,
+    cutBasedElectronID_Fall17_94X_V1_loose,
+    cutBasedElectronID_Fall17_94X_V1_medium,
+    cutBasedElectronID_Fall17_94X_V1_tight,
     heepElectronID_HEEPV70,
     mvaEleID_Fall17_noIso_V1_wp90,
     mvaEleID_Fall17_noIso_V1_wp80,
@@ -28,10 +28,10 @@ class Electron : public RecParticle {
   };
 
   static tag tagname2tag(const std::string & tagname){
-    if(tagname == "cutBasedElectronID_Fall17_94X_V1_Preliminary_veto") return cutBasedElectronID_Fall17_94X_V1_Preliminary_veto;
-    if(tagname == "cutBasedElectronID_Fall17_94X_V1_Preliminary_loose") return cutBasedElectronID_Fall17_94X_V1_Preliminary_loose;
-    if(tagname == "cutBasedElectronID_Fall17_94X_V1_Preliminary_medium") return cutBasedElectronID_Fall17_94X_V1_Preliminary_medium;
-    if(tagname == "cutBasedElectronID_Fall17_94X_V1_Preliminary_tight") return cutBasedElectronID_Fall17_94X_V1_Preliminary_tight;
+    if(tagname == "cutBasedElectronID_Fall17_94X_V1_veto") return cutBasedElectronID_Fall17_94X_V1_veto;
+    if(tagname == "cutBasedElectronID_Fall17_94X_V1_loose") return cutBasedElectronID_Fall17_94X_V1_loose;
+    if(tagname == "cutBasedElectronID_Fall17_94X_V1_medium") return cutBasedElectronID_Fall17_94X_V1_medium;
+    if(tagname == "cutBasedElectronID_Fall17_94X_V1_tight") return cutBasedElectronID_Fall17_94X_V1_tight;
     if(tagname == "heepElectronID_HEEPV70") return heepElectronID_HEEPV70;
     if(tagname == "mvaEleID_Fall17_noIso_V1_wp90") return mvaEleID_Fall17_noIso_V1_wp90;
     if(tagname == "mvaEleID_Fall17_noIso_V1_wp80") return mvaEleID_Fall17_noIso_V1_wp80;

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -1003,13 +1003,13 @@ process.slimmedElectronsUSER = cms.EDProducer('PATElectronUserData',
                                               vmaps_bool=cms.PSet(
 
                                                   cutBasedElectronID_Fall17_94X_V1_veto=cms.InputTag(
-                                                      'egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V1--veto'),
+                                                      'egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V1-veto'),
                                                   cutBasedElectronID_Fall17_94X_V1_loose=cms.InputTag(
-                                                      'egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V1--loose'),
+                                                      'egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V1-loose'),
                                                   cutBasedElectronID_Fall17_94X_V1_medium=cms.InputTag(
-                                                      'egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V1--medium'),
+                                                      'egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V1-medium'),
                                                   cutBasedElectronID_Fall17_94X_V1_tight=cms.InputTag(
-                                                      'egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V1--tight'),
+                                                      'egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V1-tight'),
                                                   heepElectronID_HEEPV70=cms.InputTag(
                                                       'egmGsfElectronIDs:heepElectronID-HEEPV70'),
                                                   mvaEleID_Fall17_noIso_V1_wp90=cms.InputTag(

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -986,7 +986,7 @@ from PhysicsTools.SelectorUtils.tools.vid_id_tools import switchOnVIDElectronIdP
 switchOnVIDElectronIdProducer(process, DataFormat.MiniAOD)
 
 elecID_mod_ls = [
-    'RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Fall17_94X_V1_Preliminary_cff',
+    'RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Fall17_94X_V1_cff',
     'RecoEgamma.ElectronIdentification.Identification.heepElectronID_HEEPV70_cff',
     'RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Fall17_noIso_V1_cff',
     'RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Fall17_iso_V1_cff',
@@ -1002,14 +1002,14 @@ process.slimmedElectronsUSER = cms.EDProducer('PATElectronUserData',
 
                                               vmaps_bool=cms.PSet(
 
-                                                  cutBasedElectronID_Fall17_94X_V1_Preliminary_veto=cms.InputTag(
-                                                      'egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V1-Preliminary-veto'),
-                                                  cutBasedElectronID_Fall17_94X_V1_Preliminary_loose=cms.InputTag(
-                                                      'egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V1-Preliminary-loose'),
-                                                  cutBasedElectronID_Fall17_94X_V1_Preliminary_medium=cms.InputTag(
-                                                      'egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V1-Preliminary-medium'),
-                                                  cutBasedElectronID_Fall17_94X_V1_Preliminary_tight=cms.InputTag(
-                                                      'egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V1-Preliminary-tight'),
+                                                  cutBasedElectronID_Fall17_94X_V1_veto=cms.InputTag(
+                                                      'egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V1--veto'),
+                                                  cutBasedElectronID_Fall17_94X_V1_loose=cms.InputTag(
+                                                      'egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V1--loose'),
+                                                  cutBasedElectronID_Fall17_94X_V1_medium=cms.InputTag(
+                                                      'egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V1--medium'),
+                                                  cutBasedElectronID_Fall17_94X_V1_tight=cms.InputTag(
+                                                      'egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V1--tight'),
                                                   heepElectronID_HEEPV70=cms.InputTag(
                                                       'egmGsfElectronIDs:heepElectronID-HEEPV70'),
                                                   mvaEleID_Fall17_noIso_V1_wp90=cms.InputTag(
@@ -1072,10 +1072,10 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
                                     # each string should correspond to a variable saved
                                     # via the "userInt" method in the pat::Electron collection used 'electron_source'
                                     # [the configuration of the pat::Electron::userInt variables should be done in PATElectronUserData]
-                                    'cutBasedElectronID_Fall17_94X_V1_Preliminary_veto',
-                                    'cutBasedElectronID_Fall17_94X_V1_Preliminary_loose',
-                                    'cutBasedElectronID_Fall17_94X_V1_Preliminary_medium',
-                                    'cutBasedElectronID_Fall17_94X_V1_Preliminary_tight',
+                                    'cutBasedElectronID_Fall17_94X_V1_veto',
+                                    'cutBasedElectronID_Fall17_94X_V1_loose',
+                                    'cutBasedElectronID_Fall17_94X_V1_medium',
+                                    'cutBasedElectronID_Fall17_94X_V1_tight',
                                     'heepElectronID_HEEPV70',
                                     'mvaEleID_Fall17_noIso_V1_wp90',
                                     'mvaEleID_Fall17_noIso_V1_wp80',


### PR DESCRIPTION
EGamma took out the "preliminary" from their ID names in the `lsoffi:CMSSW_9_4_0_pre3_TnP` branch. This updates all the relevant names etc. There's no physics difference as far as I can tell. I _hope_ it won't change again in the near future...

If you pull and find your ntuplewriter.py now complains about missing things:

```
An exception of category 'ProductNotFound' occurred while
  [0] Processing  Event run: 297675 lumi: 7 event: 9478453 stream: 0
  [1] Running path 'p'
  [2] Prefetching for module NtupleWriter/'MyNtuple'
  [3] Calling method for module PATElectronUserData/'slimmedElectronsUSER'
Exception Message:
Principal::getByToken: Found zero products matching all criteria
Looking for type: edm::ValueMap<bool>
Looking for module label: egmGsfElectronIDs
Looking for productInstanceName: cutBasedElectronID-Fall17-94X-V1-loose
```

then you'll need to update the changes from egamma:

```
cd $CMSSW_BASE/src
git cms-merge-topic lsoffi:CMSSW_9_4_0_pre3_TnP
scram b clean && scram b -j12
cd UHH2
make -j12
```