### PR TITLE
[94X] Add PUPPI multiplicities to Jets & TopJets

### DIFF
--- a/core/include/Jet.h
+++ b/core/include/Jet.h
@@ -26,6 +26,12 @@ class Jet : public FlavorParticle {
     m_muonMultiplicity = 0;
     m_electronMultiplicity = 0;
     m_photonMultiplicity = 0;
+    m_puppiMultiplicity = 0;
+    m_neutralPuppiMultiplicity = 0;
+    m_neutralHadronPuppiMultiplicity = 0;
+    m_photonPuppiMultiplicity = 0;
+    m_HFHadronPuppiMultiplicity = 0;
+    m_HFEMPuppiMultiplicity = 0;
     m_btag_combinedSecondaryVertex = 0;
     m_btag_combinedSecondaryVertexMVA = 0;
     m_btag_DeepCSV_probb = 0;
@@ -53,6 +59,12 @@ class Jet : public FlavorParticle {
   int muonMultiplicity() const{return m_muonMultiplicity;} 
   int electronMultiplicity() const{return m_electronMultiplicity;}
   int photonMultiplicity() const{return m_photonMultiplicity;}
+  float puppiMultiplicity() const{return m_puppiMultiplicity;}
+  float neutralPuppiMultiplicity() const{return m_neutralPuppiMultiplicity;}
+  float neutralHadronPuppiMultiplicity() const{return m_neutralHadronPuppiMultiplicity;}
+  float photonPuppiMultiplicity() const{return m_photonPuppiMultiplicity;}
+  float HFHadronPuppiMultiplicity() const{return m_HFHadronPuppiMultiplicity;}
+  float HFEMPuppiMultiplicity() const{return m_HFEMPuppiMultiplicity;}
   float btag_combinedSecondaryVertex() const{return m_btag_combinedSecondaryVertex;} // combinedInclusiveSecondaryVertexV2BJetTags
   float btag_combinedSecondaryVertexMVA() const{return m_btag_combinedSecondaryVertexMVA;}
   float btag_DeepCSV() const{return m_btag_DeepCSV_probb + m_btag_DeepCSV_probbb;} // pfDeepCSVJetTags:probb + pfDeepCSVJetTags:probbb
@@ -79,6 +91,12 @@ class Jet : public FlavorParticle {
   void set_muonMultiplicity(int x){m_muonMultiplicity=x;} 
   void set_electronMultiplicity(int x){m_electronMultiplicity=x;}
   void set_photonMultiplicity(int x){m_photonMultiplicity=x;}
+  void set_puppiMultiplicity(float x){m_puppiMultiplicity=x;}
+  void set_neutralPuppiMultiplicity(float x){m_neutralPuppiMultiplicity=x;}
+  void set_neutralHadronPuppiMultiplicity(float x){m_neutralHadronPuppiMultiplicity=x;}
+  void set_photonPuppiMultiplicity(float x){m_photonPuppiMultiplicity=x;}
+  void set_HFHadronPuppiMultiplicity(float x){m_HFHadronPuppiMultiplicity=x;}
+  void set_HFEMPuppiMultiplicity(float x){m_HFEMPuppiMultiplicity=x;}
   void set_btag_combinedSecondaryVertex(float x){m_btag_combinedSecondaryVertex=x;} // for 72, this is combinedInclusiveSecondaryVertexV2BJetTags
   void set_btag_combinedSecondaryVertexMVA(float x){m_btag_combinedSecondaryVertexMVA=x;}
   void set_btag_DeepCSV_probb(float x){m_btag_DeepCSV_probb=x;} // pfDeepCSVJetTags:probb
@@ -109,6 +127,12 @@ class Jet : public FlavorParticle {
   int m_muonMultiplicity;
   int m_electronMultiplicity;
   int m_photonMultiplicity;
+  float m_puppiMultiplicity;
+  float m_neutralPuppiMultiplicity;
+  float m_neutralHadronPuppiMultiplicity;
+  float m_photonPuppiMultiplicity;
+  float m_HFHadronPuppiMultiplicity;
+  float m_HFEMPuppiMultiplicity;
   float m_btag_combinedSecondaryVertex;
   float m_btag_combinedSecondaryVertexMVA;
   float m_btag_DeepCSV_probb;

--- a/core/plugins/NtupleWriterJets.h
+++ b/core/plugins/NtupleWriterJets.h
@@ -22,7 +22,7 @@ namespace uhh2 {
 
 class NtupleWriterJets: public NtupleWriterModule {
 public:
-    static void fill_jet_info(const pat::Jet & pat_jet, Jet & jet, bool do_btagging, bool do_taginfo);
+    static void fill_jet_info(const pat::Jet & pat_jet, Jet & jet, bool do_btagging, bool do_taginfo, const std::string & puppiJetSpecificProducer="");
 
     explicit NtupleWriterJets(Config & cfg, bool set_jets_member);
     explicit NtupleWriterJets(Config & cfg, bool set_jets_member, const std::vector<std::string>&, const std::vector<std::string>&);
@@ -39,7 +39,7 @@ private:
     float ptmin, etamax;
     Event::Handle<std::vector<Jet>> handle; // main handle to write output to
     boost::optional<Event::Handle<std::vector<Jet>>> jets_handle; // handle of name "jets" in case set_jets_member is true
-
+    std::string jet_puppiSpecificProducer; // hold name of puppiJetSpecificProducer for userFloat access
     bool save_lepton_keys_;
     std::vector<Event::Handle<std::vector<Muon>    >> h_muons;
     std::vector<Event::Handle<std::vector<Electron>>> h_elecs;
@@ -88,7 +88,7 @@ private:
     edm::EDGetToken src_ecf_beta1_N2_token, src_ecf_beta1_N3_token, src_ecf_beta2_N2_token, src_ecf_beta2_N3_token;
     edm::EDGetToken src_hepTopTag_token;
     edm::EDGetToken src_higgstaginfo_token;
-    std::string njettiness_src, njettiness_groomed_src, qjets_src, ecf_beta1_src, ecf_beta2_src, subjet_src, higgs_src, higgs_name, higgstaginfo_src, pruned_src, softdrop_src, topjet_collection;
+    std::string njettiness_src, njettiness_groomed_src, qjets_src, ecf_beta1_src, ecf_beta2_src, subjet_src, higgs_src, higgs_name, higgstaginfo_src, pruned_src, softdrop_src, topjet_collection, topjet_puppiSpecificProducer;
     Event::Handle<std::vector<TopJet>> handle;
     boost::optional<Event::Handle<std::vector<TopJet>>> topjets_handle;
     std::vector<TopJet::tag> id_tags;

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -865,7 +865,8 @@ if useData:
 for name in ["slimmedJetsPuppi", "patJetsAK8PFPUPPI", "slimmedJetsAK8"]:
     suffix = cap(name)
     update_name = "updatedPatJets"+suffix
-    # This is hard coded into NtupleWriterJets - should get user to specify it!
+    # This is hard coded into NtupleWriterJets - don't change it!
+    # (should get user to properly specify it)
     puppi_mult_name = "patPuppiJetSpecificProducer" + update_name
     setattr(process,
             puppi_mult_name,

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -859,6 +859,38 @@ if useData:
     producer = getattr(process, ak8chs_patname)
     modify_patjetproducer_for_data(producer)
 
+# Add puppi multiplicity producers
+# For each, we have to add a PATPuppiJetSpecificProducer,
+# then update the relevant pat::Jet collection using updateJetCollection
+for name in ["slimmedJetsPuppi", "patJetsAK8PFPUPPI", "slimmedJetsAK8"]:
+    suffix = cap(name)
+    update_name = "updatedPatJets"+suffix
+    # This is hard coded into NtupleWriterJets - should get user to specify it!
+    puppi_mult_name = "patPuppiJetSpecificProducer" + update_name
+    setattr(process,
+            puppi_mult_name,
+            cms.EDProducer("PATPuppiJetSpecificProducer",
+                src = cms.InputTag(name)
+                )
+            )
+    task.add(getattr(process, puppi_mult_name))
+
+    # produces module called "updatedPatJets"+labelName
+    updateJetCollection(
+        process,
+        labelName = suffix,
+        jetSource = cms.InputTag(name),
+    )
+    getattr(process, update_name).userData.userFloats.src = [
+        '%s:puppiMultiplicity' % puppi_mult_name,
+        '%s:neutralPuppiMultiplicity' % puppi_mult_name,
+        '%s:neutralHadronPuppiMultiplicity' % puppi_mult_name,
+        '%s:photonPuppiMultiplicity' % puppi_mult_name,
+        '%s:HFHadronPuppiMultiplicity' % puppi_mult_name,
+        '%s:HFEMPuppiMultiplicity' % puppi_mult_name
+    ]
+
+
 # Higgs tagging commissioning
 
 from RecoBTag.SecondaryVertex.trackSelection_cff import *
@@ -1105,7 +1137,8 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
                                 doJets=cms.bool(True),
                                 #jet_sources = cms.vstring("patJetsAk4PFCHS", "patJetsAk8PFCHS", "patJetsCa15CHSJets", "patJetsCa8CHSJets", "patJetsCa15PuppiJets", "patJetsCa8PuppiJets"),
                                 jet_sources=cms.vstring(
-                                    "slimmedJets", "slimmedJetsPuppi", ak8puppi_patname, ak8chs_patname),
+                                    # "slimmedJets", "slimmedJetsPuppi", ak8puppi_patname, ak8chs_patname),
+                                    "slimmedJets", "updatedPatJetsSlimmedJetsPuppi", "updatedPatJetsPatJetsAK8PFPUPPI", ak8chs_patname),
                                 jet_ptmin=cms.double(10.0),
                                 jet_etamax=cms.double(999.0),
 
@@ -1126,7 +1159,8 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
                                         # with its subjets stored depending on subjet_source.
                                         # Tagging info can also be stored, as well as various substructure variables.
                                         topjet_source=cms.string(
-                                            "slimmedJetsAK8"),  # puppi jets in 2017 MiniAOD
+                                            # "slimmedJetsAK8"),  # puppi jets in 2017 MiniAOD
+                                            "updatedPatJetsSlimmedJetsAK8"),  # puppi jets in 2017 MiniAOD
                                         # For subjet_source, use label "daughters" if you want to store as
                                         # subjets the linked daughters of the topjets (NOT for slimmedJetsAK8 in miniAOD!).
                                         # Otherwise, to store a subjet collection present in miniAOD indicate the

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -95,6 +95,14 @@ git cms-merge-topic guitargeek:ElectronID_MVA2017_940pre3
 # Necessary for using our FastJet
 git cms-addpkg RecoJets/JetProducers
 
+# For adding in Puppi multiplicities, until they get merged into a 94X release
+# Do a manual cherry-pick of the PR commits otherwise merge-topic will get loads of extra fluff
+git cms-addpkg PhysicsTools/PatAlgos
+git remote add ahinzmann git@github.com:ahinzmann/cmssw.git
+git fetch ahinzmann puppiWeightedMultiplicities94
+git cherry-pick 074af13a443
+git cherry-pick 3c96176da18
+
 # Update FastJet and contribs for HOTVR and UniversalJetCluster
 FJINSTALL=$(fastjet-config --prefix)
 OLD_FJ_VER=$(getToolVersion fastjet)


### PR DESCRIPTION
This adds in the production & storage of PUPPI multiplicities for slimmedJetsPuppi, patJetsAK8PFPUPPI, and slimmedJetsAK8. 

The production is done by PATPuppiJetSpecificProducer EDProducers, which have to be added in manually (see `install.sh`). In future, they will be in CMSSW 94X.
We then have to use `updateJetCollection` to update the pat::Jet collections, hence the new collection names.

The reading & storing is a bit of a bodge. Each jet collection has the values stored in a `userFloat` but the name of the map is different for each jet collection.
Really we should get the user to pass in the name of the producer, but at the moment the producer name is auto-generated from the jet collection name, so it can be inferred.
But not sure I can figure out how to do it easily...

