### PR TITLE
[94X] Move to ungroomed AK8CHS TopJet vars + cleanup

### DIFF
--- a/core/plugins/NtupleWriterJets.cxx
+++ b/core/plugins/NtupleWriterJets.cxx
@@ -514,40 +514,40 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
     for (unsigned int i = 0; i < pat_topjets.size(); i++) {
         const pat::Jet & pat_topjet =  pat_topjets[i];
         //use CHS jet momentum in case of CHS subjet collection (see https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016#Jets)
-        if(subjet_src.find("CHS")!=string::npos){
-          TLorentzVector puppi_v4;
-          if (!pat_topjet.hasUserFloat("ak8PFJetsCHSValueMap:pt")) {
-            throw cms::Exception("Missing userFloat", "You wanted CHS subjets but no ak8PFJetsCHSValueMap entries in the ValueMap");
-          }
-          puppi_v4.SetPtEtaPhiM(pat_topjet.userFloat("ak8PFJetsCHSValueMap:pt"),
-            pat_topjet.userFloat("ak8PFJetsCHSValueMap:eta"),
-            pat_topjet.userFloat("ak8PFJetsCHSValueMap:phi"),
-            pat_topjet.userFloat("ak8PFJetsCHSValueMap:mass"));
-          //skip jets with incredibly high pT (99999 seems to be a default value in MINIAOD if the puppi jet is not defined)
-          if(puppi_v4.Pt()>=99999) continue;
-          if(puppi_v4.Pt() < ptmin) continue;
-          if(fabs(puppi_v4.Eta()) > etamax) continue;
-        }
-        else{
+        // if(subjet_src.find("CHS")!=string::npos){
+        //   TLorentzVector puppi_v4;
+        //   if (!pat_topjet.hasUserFloat("ak8PFJetsCHSValueMap:pt")) {
+        //     throw cms::Exception("Missing userFloat", "You wanted CHS subjets but no ak8PFJetsCHSValueMap entries in the ValueMap");
+        //   }
+        //   puppi_v4.SetPtEtaPhiM(pat_topjet.userFloat("ak8PFJetsCHSValueMap:pt"),
+        //     pat_topjet.userFloat("ak8PFJetsCHSValueMap:eta"),
+        //     pat_topjet.userFloat("ak8PFJetsCHSValueMap:phi"),
+        //     pat_topjet.userFloat("ak8PFJetsCHSValueMap:mass"));
+        //   //skip jets with incredibly high pT (99999 seems to be a default value in MINIAOD if the puppi jet is not defined)
+        //   if(puppi_v4.Pt()>=99999) continue;
+        //   if(puppi_v4.Pt() < ptmin) continue;
+        //   if(fabs(puppi_v4.Eta()) > etamax) continue;
+        // }
+        // else{
           if(pat_topjet.pt() < ptmin) continue;
           if(fabs(pat_topjet.eta()) > etamax) continue;
-        }
+        // }
         
         topjets.emplace_back();
         TopJet & topjet = topjets.back();
         try{
-           uhh2::NtupleWriterJets::fill_jet_info(pat_topjet, topjet, do_btagging, false, topjet_puppiSpecificProducer);
-	   if(subjet_src.find("CHS")!=string::npos){
-	     TLorentzVector puppi_v4;
-	     puppi_v4.SetPtEtaPhiM(pat_topjet.userFloat("ak8PFJetsCHSValueMap:pt"),
-				   pat_topjet.userFloat("ak8PFJetsCHSValueMap:eta"),
-				   pat_topjet.userFloat("ak8PFJetsCHSValueMap:phi"),
-				   pat_topjet.userFloat("ak8PFJetsCHSValueMap:mass"));
-	     topjet.set_pt(puppi_v4.Pt());
-	     topjet.set_eta(puppi_v4.Eta());
-	     topjet.set_phi(puppi_v4.Phi());
-	     topjet.set_energy(puppi_v4.E());
-	}
+          uhh2::NtupleWriterJets::fill_jet_info(pat_topjet, topjet, do_btagging, false, topjet_puppiSpecificProducer);
+          // if(subjet_src.find("CHS")!=string::npos){
+          //   TLorentzVector puppi_v4;
+          //   puppi_v4.SetPtEtaPhiM(pat_topjet.userFloat("ak8PFJetsCHSValueMap:pt"),
+          //                         pat_topjet.userFloat("ak8PFJetsCHSValueMap:eta"),
+          //                         pat_topjet.userFloat("ak8PFJetsCHSValueMap:phi"),
+          //                         pat_topjet.userFloat("ak8PFJetsCHSValueMap:mass"));
+          //   topjet.set_pt(puppi_v4.Pt());
+          //   topjet.set_eta(puppi_v4.Eta());
+          //   topjet.set_phi(puppi_v4.Phi());
+          //   topjet.set_energy(puppi_v4.E());
+          // }
 
         }catch(runtime_error &){
           throw cms::Exception("fill_jet_info error", "Error in fill_jet_info for topjets in NtupleWriterTopJets with src = " + src.label());

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -825,7 +825,7 @@ addJetCollection(process,
                  rParam=0.8,
                  genJetCollection=cms.InputTag('slimmedGenJetsAK8'),
 
-                 jetCorrections=('AK8PFPuppi', ['L1FastJet', 'L2Relative', 'L3Absolute'], 'None'),
+                 jetCorrections=('AK8PFPuppi', ['L2Relative', 'L3Absolute'], 'None'),
 
                  pfCandidates=cms.InputTag('packedPFCandidates'),
                  pvSource=cms.InputTag('offlineSlimmedPrimaryVertices'),

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -1199,6 +1199,8 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
                                         # For each, we store the jets in topjet_source as TopJet objects,
                                         # with its subjets stored depending on subjet_source.
                                         # Tagging info can also be stored, as well as various substructure variables.
+                                        # The topjet_source can either be groomed or ungroomed,
+                                        # but it determines the pt/eta/phi etc of the TopJet object
                                         topjet_source=cms.string(
                                             # "slimmedJetsAK8"),  # puppi jets in 2017 MiniAOD
                                             "updatedPatJetsSlimmedJetsAK8"),  # puppi jets in 2017 MiniAOD
@@ -1282,6 +1284,10 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
                                         # The fat jets that HepTopTag produces are the Top jet candidates,
                                         # i.e. the sum of its subjets. Therefore they will NOT have
                                         # the same pt/eta/phi as normal ca15 jets.
+                                        # Unlike the other TopJet collections,
+                                        # the pt/eta/phi is the groomed one, since
+                                        # we are primarily interested in the HTTTopJetTagInfo,
+                                        # which is only stored for each groomed jet.
                                         topjet_source = cms.string(
                                             "patJetsHepTopTagCHSPacked"),
                                         subjet_source = cms.string("daughters"),

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -565,6 +565,7 @@ def add_fatjets_subjets(process, fatjets_name, groomed_jets_name, jetcorr_label=
                          **common_btag_parameters
                          )
         getattr(process, ungroomed_patname).addTagInfos = True
+        delattr(process, "selectedPatJets"+cap(fatjets_name))
 
     # patify groomed fat jets, with b-tagging:
     groomed_patname = "patJets" + cap(groomed_jets_name)
@@ -586,6 +587,7 @@ def add_fatjets_subjets(process, fatjets_name, groomed_jets_name, jetcorr_label=
     getattr(process, groomed_patname).addTagInfos = True
     if top_tagging:
         getattr(process, groomed_patname).tagInfoSources = cms.VInputTag(groomed_jets_name)
+    delattr(process, "selectedPatJets"+cap(groomed_jets_name))
 
     # patify subjets, with subjet b-tagging:
     subjets_patname = "patJets" + cap(subjets_name)
@@ -612,6 +614,7 @@ def add_fatjets_subjets(process, fatjets_name, groomed_jets_name, jetcorr_label=
     # Always add taginfos to subjets, but possible not to store them,
     # configurable with ntuple writer parameter: subjet_taginfos
     getattr(process, subjets_patname).addTagInfos = True
+    delattr(process, "selectedPatJets"+cap(subjets_name))
 
     # add the merged jet collection which contains the links from fat jets to
     # subjets:
@@ -833,6 +836,7 @@ addJetCollection(process,
                  muSource=cms.InputTag('slimmedMuons'),
                  elSource=cms.InputTag('slimmedElectrons')
                  )
+delattr(process, "selectedPatJets"+cap(ak8_label))
 # For data, turn off every gen-related part - can't do this via
 # addJetCollection annoyingly
 if useData:
@@ -856,6 +860,7 @@ addJetCollection(process,
                  muSource=cms.InputTag('slimmedMuons'),
                  elSource=cms.InputTag('slimmedElectrons')
                  )
+delattr(process, "selectedPatJets"+cap(ak8_label))
 # For data, turn off every gen-related part - can't do this via
 # addJetCollection annoyingly
 if useData:

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -930,6 +930,20 @@ process.packedPatJetsAk8CHSJets = cms.EDProducer("JetSubstructurePacker",
 )
 task.add(process.packedPatJetsAk8CHSJets)
 
+# Ditto for CA15/TopTagger
+process.packedPatJetsCa15CHSJets = cms.EDProducer("JetSubstructurePacker",
+    jetSrc = cms.InputTag("patJetsCa15CHSJets"),
+    distMax = cms.double(1.5),
+    algoTags = cms.VInputTag(
+        cms.InputTag("patJetsHepTopTagCHSPacked")
+    ),
+    algoLabels = cms.vstring(
+        'HepTopTag'
+    ),
+    fixDaughters = cms.bool(False)
+)
+task.add(process.packedPatJetsCa15CHSJets)
+
 # HOTVR & XCONE
 process.hotvrPuppi = cms.EDProducer("HOTVRProducer",
     src=cms.InputTag("puppi")
@@ -1228,6 +1242,10 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
                                         # ecf_beta2_source=cms.string("")
                                     ),
                                     cms.PSet(
+                                        # Here we store as the "main" pt/et/phi
+                                        # the ungroomed AK8CHS pt/eta/phi so one can do JEC etc.
+                                        # To recover the groomed fat jet pt/eta/phi,
+                                        # one should sum the subjets.
                                         topjet_source=cms.string(
                                             "packedPatJetsAk8CHSJets"),
                                         subjet_source=cms.string("SoftDropCHS"),
@@ -1256,12 +1274,13 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
                                             "ECFNbeta2Ak8SoftDropCHS")
                                     ),
                                     cms.PSet(
-                                        # The fat jets that HepTopTag produces are the Top jet candidates,
-                                        # i.e. the sum of its subjets. Therefore they will NOT have
-                                        # the same pt/eta/phi as normal ca15 jets.
+                                        # Here we store as the "main" pt/et/phi
+                                        # the ungroomed CA15 pt/eta/phi so one can do JEC etc.
+                                        # To recover the fat jets that HepTopTag produces
+                                        # (ie Top jet candidates), one should sum the subjets.
                                         topjet_source = cms.string(
-                                            "patJetsHepTopTagCHSPacked"),
-                                        subjet_source = cms.string("daughters"),
+                                            "packedPatJetsCa15CHSJets"),
+                                        subjet_source = cms.string("HepTopTag"),
                                         do_subjet_taginfo = cms.bool(True),
                                         higgstag_source = cms.string(
                                             "patJetsCa15CHSJets"),

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -539,8 +539,11 @@ def add_fatjets_subjets(process, fatjets_name, groomed_jets_name, jetcorr_label=
 
     jetcorr_list = ['L1FastJet', 'L2Relative', 'L3Absolute']
     if useData:
-        jetcorr_list = ['L1FastJet', 'L2Relative',
-                        'L3Absolute', 'L2L3Residual']
+        jetcorr_list.append('L2L3Residual')
+    if "puppi" in fatjets_name.lower():
+        # Since used for both fat & subjets,
+        # assumes both require same level of corrections
+        jetcorr_list.remove("L1FastJet")
     if jetcorr_label:
         jetcorr_arg = (jetcorr_label, cms.vstring(jetcorr_list), 'None')
     else:

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -204,29 +204,14 @@ process.ak8CHSJetsFat = ak8PFJets.clone(
 )
 task.add(process.ak8CHSJetsFat)
 
-# from RecoJets.JetProducers.ak4PFJetsPruned_cfi import ak4PFJetsPruned
-ak4PFJetsPruned = ak4PFJets.clone(
-    SubJetParameters,
-    usePruning=cms.bool(True),
-    useExplicitGhosts=cms.bool(True),
-    writeCompound=cms.bool(True),
-    jetCollInstanceName=cms.string("SubJets")
-)
-process.ca8CHSJetsPruned = ak4PFJetsPruned.clone(
-    rParam=0.8,
-    jetAlgorithm="CambridgeAachen",
-    doAreaFastjet=True,
-    src='chs',
-    jetPtMin=fatjet_ptmin
-)
-
+# Add HepTopTagger bits
 from RecoJets.JetProducers.AnomalousCellParameters_cfi import *
 from RecoJets.JetProducers.PFJetParameters_cfi import *
 # The HTTTopJetProducer does its own clustering producing a BasicJet of
 # Top candidates (i.e. sum of subjects),
 # as well as producing PFJet (SubJets), and HTTTopJetTagInfo
 # The CA15 jets here are the "original" fatjets going into the HTT, and thus will
-# be different from the BAsicJEt collection that HTTTopJetProducer produces
+# be different from the BasicJet collection that HTTTopJetProducer produces
 ca15_clustering_params = dict(
     useExplicitGhosts   = cms.bool(True),
     jetAlgorithm        = cms.string("CambridgeAachen"),
@@ -274,13 +259,28 @@ task.add(process.hepTopTagCHS)
 
 #################################################
 # Softdrop
-
+#
+# Note that the *SoftDrop collections produce the groomed jets (as BasicJets),
+# and the subjets (as PFJets, with instance label "SubJets")
+# The *SoftDropforsub produce only the groomed jets as PFJets
 from RecoJets.Configuration.RecoPFJets_cff import ak8PFJetsCHS
+
 process.ak8CHSJetsSoftDrop = ak8PFJetsCHSSoftDrop.clone(
     src=cms.InputTag('chs'),
     jetPtMin=fatjet_ptmin
 )
 task.add(process.ak8CHSJetsSoftDrop)
+
+process.ak8CHSJetsSoftDropforsub = process.ak8CHSJetsFat.clone(
+    rParam=0.8,
+    jetPtMin=fatjet_ptmin,
+    zcut=cms.double(0.1),
+    beta=cms.double(0.0),
+    useSoftDrop=cms.bool(True),
+    useExplicitGhosts=cms.bool(True),
+    R0=cms.double(0.8)
+)
+task.add(process.ak8CHSJetsSoftDropforsub)
 
 process.ca15CHSJetsSoftDrop = ak8PFJetsCHSSoftDrop.clone(
     src=cms.InputTag('chs'),
@@ -302,20 +302,12 @@ process.ca15CHSJetsSoftDropforsub = process.ca15CHSJets.clone(
 )
 task.add(process.ca15CHSJetsSoftDropforsub)
 
-process.ak8CHSJetsSoftDropforsub = process.ak8CHSJetsFat.clone(
-    rParam=0.8,
-    jetPtMin=fatjet_ptmin,
-    zcut=cms.double(0.1),
-    beta=cms.double(0.0),
-    useSoftDrop=cms.bool(True),
-    useExplicitGhosts=cms.bool(True),
-    R0=cms.double(0.8)
-)
-task.add(process.ak8CHSJetsSoftDropforsub)
+#################################################
+# Pruning
 
-# from RecoJets.JetProducers.ak4PFJetsPruned_cfi import ak4PFJetsPruned
 # Note low pt threshold as jets currently not stored but used just to
 # derived pruned mass
+
 ak4PFJetsPruned = ak4PFJets.clone(
     SubJetParameters,
     usePruning=cms.bool(True),
@@ -331,6 +323,15 @@ process.ak8CHSJetsPruned = ak4PFJetsPruned.clone(
     jetPtMin=70
 )
 task.add(process.ak8CHSJetsPruned)
+
+# process.ca8CHSJetsPruned = ak4PFJetsPruned.clone(
+#     rParam=0.8,
+#     jetAlgorithm="CambridgeAachen",
+#     doAreaFastjet=True,
+#     src='chs',
+#     jetPtMin=fatjet_ptmin
+# )
+# task.add(process.ca8CHSJetsPruned)
 
 # process.ca15CHSJetsPruned = ak4PFJetsPruned.clone(
 #     rParam=1.5,
@@ -351,15 +352,15 @@ process.puppi.clonePackedCands = cms.bool(True)
 process.puppi.useExistingWeights = cms.bool(True)
 task.add(process.puppi)
 
-process.ca15PuppiJetsSoftDrop = ak8PFJetsCHSSoftDrop.clone(
-    src=cms.InputTag('puppi'),
-    jetPtMin=fatjet_ptmin,
-    jetAlgorithm=cms.string("CambridgeAachen"),
-    rParam=1.5,
-    R0=1.5,
-    zcut=cms.double(0.2),
-    beta=cms.double(1.0)
+process.ak8PuppiJets = ak8PFJets.clone(
+    src='puppi',
+    doAreaFastjet=True,
+    jetPtMin=10.
 )
+task.add(process.ak8PuppiJets)
+
+process.ak8PuppiJetsFat = process.ak8CHSJets.clone(src='puppi')
+task.add(process.ak8PuppiJetsFat)
 
 process.ak8PuppiJetsSoftDrop = ak8PFJetsCHSSoftDrop.clone(
     src=cms.InputTag('puppi'),
@@ -367,9 +368,6 @@ process.ak8PuppiJetsSoftDrop = ak8PFJetsCHSSoftDrop.clone(
 )
 task.add(process.ak8PuppiJetsSoftDrop)
 
-# process.ca15PuppiJetsSoftDropforsub = process.ca8CHSJets.clone(rParam=1.5, jetPtMin=fatjet_ptmin, zcut=cms.double(0.2), beta=cms.double(
-# 1.0), useSoftDrop=cms.bool(True), useExplicitGhosts=cms.bool(True),
-# R0=cms.double(1.5), src=cms.InputTag('puppi'))
 process.ak8PuppiJetsSoftDropforsub = process.ak8CHSJetsFat.clone(
     rParam=0.8,
     jetPtMin=fatjet_ptmin,
@@ -383,28 +381,30 @@ process.ak8PuppiJetsSoftDropforsub = process.ak8CHSJetsFat.clone(
 task.add(process.ak8PuppiJetsSoftDropforsub)
 
 # process.ca15PuppiJets = process.ca8CHSJets.clone(rParam=1.5, src='puppi')
+# task.add(process.ca15PuppiJets)
 
-process.ak8PuppiJets = ak8PFJets.clone(
-    src='puppi',
-    doAreaFastjet=True,
-    jetPtMin=10.
-)
-task.add(process.ak8PuppiJets)
+# process.ca15PuppiJetsSoftDrop = ak8PFJetsCHSSoftDrop.clone(
+#     src=cms.InputTag('puppi'),
+#     jetPtMin=fatjet_ptmin,
+#     jetAlgorithm=cms.string("CambridgeAachen"),
+#     rParam=1.5,
+#     R0=1.5,
+#     zcut=cms.double(0.2),
+#     beta=cms.double(1.0)
+# )
+# task.add(process.ca15PuppiJetsSoftDrop)
 
-process.ak8PuppiJetsFat = process.ak8CHSJets.clone(src='puppi')
-task.add(process.ak8PuppiJetsFat)
-
-# copy all the jet collections above; just use 'puppi' instead of 'chs' as
-# input:
-# , 'cmsTopTagCHS', 'hepTopTagCHS']:
-# for name in ['ca8CHSJets', 'ca15CHSJets', 'ca8CHSJetsPruned',
-# 'ca15CHSJetsFiltered']:
-# for name in ['ca8CHSJetsPruned']:
-#     setattr(process,
-#             name.replace('CHS', 'Puppi'),
-#             getattr(process, name).clone(src=cms.InputTag('puppi'))
-#             )
-
+# process.ca15PuppiJetsSoftDropforsub = process.ca8CHSJets.clone(
+#     rParam=1.5,
+#     jetPtMin=fatjet_ptmin,
+#     zcut=cms.double(0.2),
+#     beta=cms.double(1.0),
+#     useSoftDrop=cms.bool(True),
+#     useExplicitGhosts=cms.bool(True),
+#     R0=cms.double(1.5),
+#     src=cms.InputTag('puppi')
+# )
+# task.add(process.ca15PuppiJetsSoftDropforsub)
 
 ###############################################
 # PAT JETS and Gen Jets
@@ -413,8 +413,6 @@ task.add(process.ak8PuppiJetsFat)
 # genjets.
 
 # captitalize string; needed below to construct pat module names.
-
-
 def cap(s): return s[0].upper() + s[1:]
 
 
@@ -461,17 +459,22 @@ def modify_patjetproducer_for_data(process, producer):
     producer.embedGenPartonMatch = cms.bool(False)
     del_attr_safely(process, producer.genPartonMatch.value().split(":")[0])
     producer.genPartonMatch = cms.InputTag("")
+
     producer.addGenJetMatch = cms.bool(False)
     producer.embedGenJetMatch = cms.bool(False)
     del_attr_safely(process, producer.genJetMatch.value().split(":")[0])
     producer.genJetMatch = cms.InputTag("")
+
     del_attr_safely(process, producer.JetPartonMapSource.value().split(":")[0])
     producer.JetPartonMapSource = cms.InputTag("")
+
     if (producer.addJetFlavourInfo):
         del_attr_safely(process, producer.JetFlavourInfoSource.value().split(":")[0])
     producer.JetFlavourInfoSource = cms.InputTag("")
+
     producer.addPartonJetMatch = cms.bool(False)
     producer.partonJetSource = cms.InputTag("NOT_IMPLEMENTED")
+
     producer.getJetMCFlavour = cms.bool(False)
     producer.addJetFlavourInfo = cms.bool(False)
 
@@ -699,15 +702,37 @@ from PhysicsTools.PatAlgos.tools.pfTools import *
 adaptPVs(process, pvCollection=cms.InputTag('offlineSlimmedPrimaryVertices'))
 
 
-# Add subjet variables (on ungroomed jets only!)
+# Add subjet variables
+# For each type of jet, we add ungroomed and groomed quantities
 from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 from RecoJets.JetProducers.qjetsadder_cfi import QJetsAdder
 
+# AK8 CHS
 process.NjettinessAk8CHS = Njettiness.clone(
     src=cms.InputTag("ak8CHSJets"),
     cone=cms.double(0.8)
 )
 task.add(process.NjettinessAk8CHS)
+
+process.NjettinessAk8SoftDropCHS = Njettiness.clone(
+    src=cms.InputTag("ak8CHSJetsSoftDropforsub"),
+    Njets=cms.vuint32(1, 2, 3, 4),          # compute 1-, 2-, 3-, 4- subjettiness
+    # variables for measure definition :
+    measureDefinition=cms.uint32(0),  # CMS default is normalized measure
+    beta=cms.double(1.0),              # CMS default is 1
+    R0=cms.double(0.8),                  # CMS default is jet cone size
+    Rcutoff=cms.double(999.0),       # not used by default
+    # variables for axes
+    # definition :
+    axesDefinition=cms.uint32(6),    # CMS default is 1-pass KT axes
+    # not used by default
+    nPass=cms.int32(999),
+    # not used by default
+    akAxesR0=cms.double(999.0)
+)
+task.add(process.NjettinessAk8SoftDropCHS)
+
+# CA15 CHS
 process.NjettinessCa15CHS = Njettiness.clone(
     src=cms.InputTag("ca15CHSJets"),
     cone=cms.double(1.5),
@@ -733,49 +758,44 @@ process.NjettinessCa15SoftDropCHS = Njettiness.clone(
 )
 task.add(process.NjettinessCa15SoftDropCHS)
 
-process.NjettinessCa15SoftDropPuppi = process.NjettinessCa15SoftDropCHS.clone(
-    src=cms.InputTag("ca15PuppiJetsSoftDropforsub")
-)
-process.NjettinessAk8SoftDropCHS = Njettiness.clone(
-    src=cms.InputTag("ak8CHSJetsSoftDropforsub"),
-    Njets=cms.vuint32(1, 2, 3, 4),          # compute 1-, 2-, 3-, 4- subjettiness
-    # variables for measure definition :
-    measureDefinition=cms.uint32(0),  # CMS default is normalized measure
-    beta=cms.double(1.0),              # CMS default is 1
-    R0=cms.double(0.8),                  # CMS default is jet cone size
-    Rcutoff=cms.double(999.0),       # not used by default
-    # variables for axes
-    # definition :
-    axesDefinition=cms.uint32(6),    # CMS default is 1-pass KT axes
-    # not used by default
-    nPass=cms.int32(999),
-    # not used by default
-    akAxesR0=cms.double(999.0)
-)
-task.add(process.NjettinessAk8SoftDropCHS)
-process.NjettinessAk8SoftDropPuppi = process.NjettinessAk8SoftDropCHS.clone(
-    src=cms.InputTag("ak8PuppiJetsSoftDropforsub")
-)
-task.add(process.NjettinessAk8SoftDropPuppi)
+# CA15 PUPPI
+# process.NjettinessCa15Puppi = Njettiness.clone(
+#     src=cms.InputTag("ca15PuppiJets"),
+#     cone=cms.double(1.5),
+#     R0=cms.double(1.5)
+# )
+# task.add(process.NjettinessCa15Puppi)
 
-process.NjettinessCa15Puppi = Njettiness.clone(
-    src=cms.InputTag("ca15PuppiJets"),
-    cone=cms.double(1.5),
-    R0=cms.double(1.5)
-)
+# process.NjettinessCa15SoftDropPuppi = process.NjettinessCa15SoftDropCHS.clone(
+#     src=cms.InputTag("ca15PuppiJetsSoftDropforsub")
+# )
+# task.add(process.NjettinessCa15SoftDropPuppi)
+
+# AK8 PUPPI
 process.NjettinessAk8Puppi = Njettiness.clone(
     src=cms.InputTag("ak8PuppiJetsFat"),
     cone=cms.double(0.8)
 )
 task.add(process.NjettinessAk8Puppi)
+
+process.NjettinessAk8SoftDropPuppi = process.NjettinessAk8SoftDropCHS.clone(
+    src=cms.InputTag("ak8PuppiJetsSoftDropforsub")
+)
+task.add(process.NjettinessAk8SoftDropPuppi)
+
+# AK8 GenJets
 process.NjettinessAk8Gen = Njettiness.clone(
     src=cms.InputTag("ak8GenJets"),
     cone=cms.double(0.8)
 )
+task.add(process.NjettinessAk8Gen)
+
 process.NjettinessAk8SoftDropGen = Njettiness.clone(
     src=cms.InputTag("ak8GenJetsSoftDrop"),
     cone=cms.double(0.8)
 )
+task.add(process.NjettinessAk8SoftDropGen)
+
 """
 process.QJetsCa8CHS = QJetsAdder.clone(src = cms.InputTag("patJetsCa8CHSJets"), jetRad = cms.double(0.8))
 process.QJetsCa15CHS = QJetsAdder.clone(src = cms.InputTag("patJetsCa15CHSJets"), jetRad = cms.double(1.5))
@@ -1254,7 +1274,7 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
                                     ),
                                     cms.PSet(
                                         topjet_source=cms.string(
-                                            "packedPatJetsAk8CHSJets"),
+                                            "packedPatJetsAk8CHSJets"),  # store ungroomed vars
                                         subjet_source=cms.string("SoftDropCHS"),
                                         do_subjet_taginfo=cms.bool(True),
                                         higgstag_source=cms.string(
@@ -1285,7 +1305,7 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
                                         # i.e. the sum of its subjets. Therefore they will NOT have
                                         # the same pt/eta/phi as normal ca15 jets.
                                         # Unlike the other TopJet collections,
-                                        # the pt/eta/phi is the groomed one, since
+                                        # the pt/eta/phi here is the groomed one, since
                                         # we are primarily interested in the HTTTopJetTagInfo,
                                         # which is only stored for each groomed jet.
                                         topjet_source = cms.string(

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -953,20 +953,6 @@ process.packedPatJetsAk8CHSJets = cms.EDProducer("JetSubstructurePacker",
 )
 task.add(process.packedPatJetsAk8CHSJets)
 
-# Ditto for CA15/TopTagger
-process.packedPatJetsCa15CHSJets = cms.EDProducer("JetSubstructurePacker",
-    jetSrc = cms.InputTag("patJetsCa15CHSJets"),
-    distMax = cms.double(1.5),
-    algoTags = cms.VInputTag(
-        cms.InputTag("patJetsHepTopTagCHSPacked")
-    ),
-    algoLabels = cms.vstring(
-        'HepTopTag'
-    ),
-    fixDaughters = cms.bool(False)
-)
-task.add(process.packedPatJetsCa15CHSJets)
-
 # HOTVR & XCONE
 process.hotvrPuppi = cms.EDProducer("HOTVRProducer",
     src=cms.InputTag("puppi")
@@ -1265,10 +1251,6 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
                                         # ecf_beta2_source=cms.string("")
                                     ),
                                     cms.PSet(
-                                        # Here we store as the "main" pt/et/phi
-                                        # the ungroomed AK8CHS pt/eta/phi so one can do JEC etc.
-                                        # To recover the groomed fat jet pt/eta/phi,
-                                        # one should sum the subjets.
                                         topjet_source=cms.string(
                                             "packedPatJetsAk8CHSJets"),
                                         subjet_source=cms.string("SoftDropCHS"),
@@ -1297,13 +1279,12 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
                                             "ECFNbeta2Ak8SoftDropCHS")
                                     ),
                                     cms.PSet(
-                                        # Here we store as the "main" pt/et/phi
-                                        # the ungroomed CA15 pt/eta/phi so one can do JEC etc.
-                                        # To recover the fat jets that HepTopTag produces
-                                        # (ie Top jet candidates), one should sum the subjets.
+                                        # The fat jets that HepTopTag produces are the Top jet candidates,
+                                        # i.e. the sum of its subjets. Therefore they will NOT have
+                                        # the same pt/eta/phi as normal ca15 jets.
                                         topjet_source = cms.string(
-                                            "packedPatJetsCa15CHSJets"),
-                                        subjet_source = cms.string("HepTopTag"),
+                                            "patJetsHepTopTagCHSPacked"),
+                                        subjet_source = cms.string("daughters"),
                                         do_subjet_taginfo = cms.bool(True),
                                         higgstag_source = cms.string(
                                             "patJetsCa15CHSJets"),

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -916,6 +916,20 @@ task.add(process.pfBoostedDoubleSVTagInfos)
 
 process.pfBoostedDoubleSVTagInfos.trackSelection.jetDeltaRMax = cms.double(0.8)
 
+# Add subjets from groomed fat jet to its corresponding ungroomed fatjet
+process.packedPatJetsAk8CHSJets = cms.EDProducer("JetSubstructurePacker",
+    jetSrc = cms.InputTag("patJetsAk8CHSJets"),
+    distMax = cms.double(0.8),
+    algoTags = cms.VInputTag(
+        cms.InputTag("patJetsAk8CHSJetsSoftDropPacked")
+    ),
+    algoLabels = cms.vstring(
+        'SoftDropCHS'
+    ),
+    fixDaughters = cms.bool(False)
+)
+task.add(process.packedPatJetsAk8CHSJets)
+
 # HOTVR & XCONE
 process.hotvrPuppi = cms.EDProducer("HOTVRProducer",
     src=cms.InputTag("puppi")
@@ -1215,8 +1229,8 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
                                     ),
                                     cms.PSet(
                                         topjet_source=cms.string(
-                                            "patJetsAk8CHSJetsSoftDropPacked"),
-                                        subjet_source=cms.string("daughters"),
+                                            "packedPatJetsAk8CHSJets"),
+                                        subjet_source=cms.string("SoftDropCHS"),
                                         do_subjet_taginfo=cms.bool(True),
                                         higgstag_source=cms.string(
                                             "patJetsAk8CHSJets"),

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -784,17 +784,17 @@ process.NjettinessAk8SoftDropPuppi = process.NjettinessAk8SoftDropCHS.clone(
 task.add(process.NjettinessAk8SoftDropPuppi)
 
 # AK8 GenJets
-process.NjettinessAk8Gen = Njettiness.clone(
-    src=cms.InputTag("ak8GenJets"),
-    cone=cms.double(0.8)
-)
-task.add(process.NjettinessAk8Gen)
+# process.NjettinessAk8Gen = Njettiness.clone(
+#     src=cms.InputTag("ak8GenJets"),
+#     cone=cms.double(0.8)
+# )
+# task.add(process.NjettinessAk8Gen)
 
-process.NjettinessAk8SoftDropGen = Njettiness.clone(
-    src=cms.InputTag("ak8GenJetsSoftDrop"),
-    cone=cms.double(0.8)
-)
-task.add(process.NjettinessAk8SoftDropGen)
+# process.NjettinessAk8SoftDropGen = Njettiness.clone(
+#     src=cms.InputTag("ak8GenJetsSoftDrop"),
+#     cone=cms.double(0.8)
+# )
+# task.add(process.NjettinessAk8SoftDropGen)
 
 """
 process.QJetsCa8CHS = QJetsAdder.clone(src = cms.InputTag("patJetsCa8CHSJets"), jetRad = cms.double(0.8))

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -444,18 +444,31 @@ process.packedGenParticlesForJetsNoNu = cms.EDFilter("CandPtrSelector",
 task.add(process.packedGenParticlesForJetsNoNu)
 
 
-def modify_patjetproducer_for_data(producer):
+def del_attr_safely(obj, name):
+    if hasattr(obj, name):
+        delattr(obj, name)
+
+
+def modify_patjetproducer_for_data(process, producer):
     """Modify a PATJetProducer for use with data i.e. turn off all gen-related parts
+
+    Also delete all the extra producers it adds in
 
     See PhysicsTools/PatAlgos/python/producersLayer1/jetProducer_cfi.py
     for all available options
     """
     producer.addGenPartonMatch = cms.bool(False)
     producer.embedGenPartonMatch = cms.bool(False)
+    del_attr_safely(process, producer.genPartonMatch.value().split(":")[0])
     producer.genPartonMatch = cms.InputTag("")
     producer.addGenJetMatch = cms.bool(False)
     producer.embedGenJetMatch = cms.bool(False)
+    del_attr_safely(process, producer.genJetMatch.value().split(":")[0])
     producer.genJetMatch = cms.InputTag("")
+    del_attr_safely(process, producer.JetPartonMapSource.value().split(":")[0])
+    producer.JetPartonMapSource = cms.InputTag("")
+    if (producer.addJetFlavourInfo):
+        del_attr_safely(process, producer.JetFlavourInfoSource.value().split(":")[0])
     producer.JetFlavourInfoSource = cms.InputTag("")
     producer.addPartonJetMatch = cms.bool(False)
     producer.partonJetSource = cms.InputTag("NOT_IMPLEMENTED")
@@ -562,6 +575,7 @@ def add_fatjets_subjets(process, fatjets_name, groomed_jets_name, jetcorr_label=
                          rParam=rParam,
                          jetCorrections=jetcorr_arg,
                          genJetCollection=cms.InputTag(ungroomed_genjets_name),
+                         getJetMCFlavour=not useData,
                          **common_btag_parameters
                          )
         getattr(process, ungroomed_patname).addTagInfos = True
@@ -582,6 +596,7 @@ def add_fatjets_subjets(process, fatjets_name, groomed_jets_name, jetcorr_label=
                      # subjets are BasicJets, so PAT cannot be used for this
                      # matching ...
                      genJetCollection=cms.InputTag("slimmedGenJets"),
+                     getJetMCFlavour=not useData,
                      **common_btag_parameters
                      )
     getattr(process, groomed_patname).addTagInfos = True
@@ -609,6 +624,7 @@ def add_fatjets_subjets(process, fatjets_name, groomed_jets_name, jetcorr_label=
                      groomedFatJets=cms.InputTag(groomed_jets_name),
                      genJetCollection=cms.InputTag(
                          groomed_genjets_name, 'SubJets'),
+                     getJetMCFlavour=not useData,
                      **common_btag_parameters
                      )
     # Always add taginfos to subjets, but possible not to store them,
@@ -652,7 +668,7 @@ def add_fatjets_subjets(process, fatjets_name, groomed_jets_name, jetcorr_label=
         # For data, turn off every gen-related part - can't do this via
         # addJetCollection annoyingly
         if useData:
-            modify_patjetproducer_for_data(producer)
+            modify_patjetproducer_for_data(process, producer)
 
 
 #add_fatjets_subjets(process, 'ca8CHSJets', 'ca8CHSJetsPruned', genjets_name = lambda s: s.replace('CHS', 'Gen'))
@@ -834,14 +850,15 @@ addJetCollection(process,
                  pvSource=cms.InputTag('offlineSlimmedPrimaryVertices'),
                  svSource=cms.InputTag('slimmedSecondaryVertices'),
                  muSource=cms.InputTag('slimmedMuons'),
-                 elSource=cms.InputTag('slimmedElectrons')
+                 elSource=cms.InputTag('slimmedElectrons'),
+                 getJetMCFlavour=not useData
                  )
 delattr(process, "selectedPatJets"+cap(ak8_label))
 # For data, turn off every gen-related part - can't do this via
 # addJetCollection annoyingly
 if useData:
     producer = getattr(process, ak8puppi_patname)
-    modify_patjetproducer_for_data(producer)
+    modify_patjetproducer_for_data(process, producer)
 
 ak8_label = "AK8PFCHS"
 ak8chs_patname = 'patJets' + ak8_label
@@ -858,14 +875,15 @@ addJetCollection(process,
                  pvSource=cms.InputTag('offlineSlimmedPrimaryVertices'),
                  svSource=cms.InputTag('slimmedSecondaryVertices'),
                  muSource=cms.InputTag('slimmedMuons'),
-                 elSource=cms.InputTag('slimmedElectrons')
+                 elSource=cms.InputTag('slimmedElectrons'),
+                 getJetMCFlavour=not useData
                  )
 delattr(process, "selectedPatJets"+cap(ak8_label))
 # For data, turn off every gen-related part - can't do this via
 # addJetCollection annoyingly
 if useData:
     producer = getattr(process, ak8chs_patname)
-    modify_patjetproducer_for_data(producer)
+    modify_patjetproducer_for_data(process, producer)
 
 # Add puppi multiplicity producers
 # For each, we have to add a PATPuppiJetSpecificProducer,


### PR DESCRIPTION
The important changes here:

- remove L1FastJet level from PUPPI JEC (I know we correct afterwards, but makes debugging comparisons easier)
- the AK8 CHS collection now stores the **ungroomed** pt/eta/phi etc. To recover the groomed 4-vector, one should add the 4-vecs of the subjets. In order to map the groomed subjets to the ungroomed jet, I used a `JetSubstructurePacker` which basically does the same deltaR matching we do inside NTupleWriter for matching jets. Note that I also had to turn off the feature that passing "*CHS" to subjet_source stored the corresponding CHS values from the userFloats - guessing it's a feature that won't be used, since we recluster ourselves

I also took the opportunity to add some comments and rearrange things a bit to make life easier in future. It also removes some surplus `selectedPatJets*` modules which we don't use but make debugging life harder.