### PR TITLE
[94X] Ntuplewriter with multithreading

### DIFF
--- a/core/include/GenTopJet.h
+++ b/core/include/GenTopJet.h
@@ -5,6 +5,10 @@
 class GenTopJet : public Particle {
 public:
 
+  GenTopJet() {
+    m_tau1 = m_tau2 = m_tau3 = m_chf = m_cef = m_nhf = m_nef = -1.0;
+  }
+
   const std::vector<Particle> & subjets() const{return m_subjets;}
   void add_subjet(const Particle & p){m_subjets.push_back(p);}
   float tau1() const{return m_tau1;}

--- a/core/include/JetBTagInfo.h
+++ b/core/include/JetBTagInfo.h
@@ -38,11 +38,17 @@ public:
     m_FlightDistance3dVal.clear();
     m_FlightDistance3dSig.clear();
     m_VertexJetDeltaR.clear();
+    m_JetNSecondaryVertices = 0;
     m_VertexNTracks.clear();
     m_SecondaryVertex.clear();
     m_VertexChi2.clear();                                
     m_VertexNdof.clear();                    
     m_VertexNormalizedChi2.clear();
+
+    m_VertexCategoryJTC = 0;
+    m_VertexMassJTC = 0;
+    m_VertexEnergyRatioJTC = 0;
+    m_TrackSip3dSigAboveCharmJTC = 0;
   }
 
   //track impact parameter tag info getters

--- a/core/plugins/CandIsolatorFromDepositsMINIISO.h
+++ b/core/plugins/CandIsolatorFromDepositsMINIISO.h
@@ -30,7 +30,7 @@ public:
 
   virtual ~CandIsolatorFromDepositsMINIISO();
 
-  virtual void produce(edm::Event&, const edm::EventSetup&);
+  virtual void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
   class SingleDeposit {

--- a/core/plugins/HOTVRProducer.cc
+++ b/core/plugins/HOTVRProducer.cc
@@ -22,7 +22,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -51,7 +51,7 @@ using namespace contrib;
 // class declaration
 //
 
-class HOTVRProducer : public edm::stream::EDProducer<> {
+class HOTVRProducer : public edm::global::EDProducer<> {
   public:
     explicit HOTVRProducer(const edm::ParameterSet&);
     ~HOTVRProducer();
@@ -59,11 +59,9 @@ class HOTVRProducer : public edm::stream::EDProducer<> {
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
   private:
-    virtual void beginStream(edm::StreamID) override;
-    virtual void produce(edm::Event&, const edm::EventSetup&) override;
-    virtual void endStream() override;
+    virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
-    virtual pat::Jet createPatJet(const PseudoJet &);
+    virtual pat::Jet createPatJet(const PseudoJet &) const;
 
     // ----------member data ---------------------------
     edm::EDGetToken src_token_;
@@ -98,7 +96,7 @@ HOTVRProducer::~HOTVRProducer()
 
 // ------------ method called to produce the data  ------------
 void
-HOTVRProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+HOTVRProducer::produce(edm::StreamID id, edm::Event& iEvent, const edm::EventSetup& iSetup) const
 {
   // Set the fastjet random seed to a deterministic function
   // of the run/lumi/event.
@@ -285,24 +283,13 @@ HOTVRProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 }
 
 
-pat::Jet HOTVRProducer::createPatJet(const PseudoJet & psj)
+pat::Jet HOTVRProducer::createPatJet(const PseudoJet & psj) const
 {
   pat::Jet newJet;
   newJet.setP4(math::XYZTLorentzVector(psj.px(), psj.py(), psj.pz(), psj.E()));
   return newJet;
 }
 
-
-// ------------ method called once each stream before processing any runs, lumis or events  ------------
-void
-HOTVRProducer::beginStream(edm::StreamID)
-{
-}
-
-// ------------ method called once each stream after processing all runs, lumis and events  ------------
-void
-HOTVRProducer::endStream() {
-}
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void

--- a/core/plugins/HOTVRProducer.cc
+++ b/core/plugins/HOTVRProducer.cc
@@ -100,6 +100,20 @@ HOTVRProducer::~HOTVRProducer()
 void
 HOTVRProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
+  // Set the fastjet random seed to a deterministic function
+  // of the run/lumi/event.
+  // NOTE!!! The fastjet random number sequence is a global singleton.
+  // Thus, we have to create an object and get access to the global singleton
+  // in order to change it.
+  // Taken from VirtualJetProducer
+  fastjet::GhostedAreaSpec gas;
+  std::vector<int> seeds(2);
+  unsigned int runNum_uint = static_cast <unsigned int> (iEvent.id().run());
+  unsigned int evNum_uint = static_cast <unsigned int> (iEvent.id().event());
+  uint minSeed_ = 14327;
+  seeds[0] = std::max(runNum_uint, minSeed_ + 3) + 3 * evNum_uint;
+  seeds[1] = std::max(runNum_uint, minSeed_ + 5) + 5 * evNum_uint;
+  gas.set_random_status(seeds);
 
   edm::Handle<edm::View<pat::PackedCandidate>> particles;
   iEvent.getByToken(src_token_, particles);

--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -1459,6 +1459,8 @@ void NtupleWriter::beginRun(edm::Run const& iRun, edm::EventSetup const&  iSetup
   */
 }
 
+void NtupleWriter::endRun(edm::Run const& iRun, edm::EventSetup const&  iSetup){}
+
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void NtupleWriter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   //The following says we do not know what parameters are allowed so do no validation

--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -106,7 +106,7 @@ public:
             dir = outfile->GetDirectory(path.c_str());
         }
         if(!dir){
-            throw runtime_error("Could not create directory '" + path + "' in outfile!");
+            throw cms::Exception("FailedMkDir", "Could not create directory '" + path + "' in outfile!");
         }
         h->SetDirectory(dir);
     }
@@ -120,7 +120,7 @@ public:
 
 private:
     virtual void do_declare_event_input(const std::type_info & ti, const std::string & bname, const std::string & mname) override {
-        throw runtime_error("declare_event_input not implemented in CMSSW!");
+        throw cms::Exception("NotImplementedError" "declare_event_input not implemented in CMSSW!");
     }
 
     virtual void do_declare_event_output(const std::type_info & ti, const std::string & bname, const std::string & mname) override {
@@ -129,11 +129,11 @@ private:
     }
 
     virtual void do_undeclare_event_output(const std::string & bname) override {
-        throw runtime_error("undeclare_event_output not implemented in CMSSW!");
+        throw cms::Exception("NotImplementedError", "undeclare_event_output not implemented in CMSSW!");
     }
 
     virtual void do_undeclare_all_event_output() override {
-        throw runtime_error("undeclare_all_event_output not implemented in CMSSW!");
+        throw cms::Exception("NotImplementedError", "undeclare_all_event_output not implemented in CMSSW!");
     }
 
     TFile * outfile;
@@ -164,7 +164,7 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
       edm::ParameterSet module_pset = iConfig.getParameter<edm::ParameterSet>("AnalysisModule");
       string modulename = module_pset.getParameter<std::string>("name");
       string libname = module_pset.getParameter<std::string>("library");
-      cout << "Trying to build AnalysisModule '" << modulename << "' from library '" << libname << "'" << endl;
+      edm::LogInfo("NtupleWriter") << "Trying to build AnalysisModule '" << modulename << "' from library '" << libname << "'";
       gSystem->Load(libname.c_str());
       context.reset(new uhh2::CMSSWContext(*ges, outfile, tr));
       auto names = module_pset.getParameterNamesForType<string>();
@@ -311,13 +311,11 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
 
       for(unsigned int j=0; j<topjets_list.size(); ++j){
         if(!topjets_list[j].exists("topjet_source")){
-          cerr << "Exception: it is necessary to specify the source of the topjet collection" << endl;
-          throw;
+          throw cms::Exception("MissingSourceName", "It is necessary to specify the source of the topjet collection");
         }
         std::string topjet_source = topjets_list[j].getParameter<std::string>("topjet_source");
         if(!topjets_list[j].exists("subjet_source")){
-          cerr << "Exception: it is necessary to specify the subjets for each topjet collection" << endl;
-          throw;
+          throw cms::Exception("MissingSourceName", "It is necessary to specify the subjets for each topjet collection");
         }
         std::string subjet_source = topjets_list[j].getParameter<std::string>("subjet_source");
 
@@ -345,8 +343,7 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
           cfg.higgs_name = topjets_list[j].getParameter<std::string>("higgstag_name");
         }
         if(cfg.higgs_src!="" && cfg.higgs_name==""){
-          cerr << "Exception: higgstag source specified, but no higgstag discriminator name" << endl;
-          throw;
+          throw cms::Exception("MissingSourceName", "higgstag source specified, but no higgstag discriminator name");
         }
         if(topjets_list[j].exists("higgstaginfo_source")){
           cfg.higgstaginfo_src = topjets_list[j].getParameter<std::string>("higgstaginfo_source");
@@ -368,8 +365,7 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
         }
         if(substructure_variables){
           if(!topjets_list[j].exists("substructure_variables_source")){
-            cerr << "Exception: njettiness or qjets sources defined without definition of substructure_variables_source" << endl;
-            throw;
+            throw cms::Exception("MissingSourceName", "njettiness or qjets sources defined without definition of substructure_variables_source");
           }
           cfg.substructure_variables_src = topjets_list[j].getParameter<std::string>("substructure_variables_source");
         }
@@ -1092,7 +1088,7 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
        iEvent.getByToken(met_tokens[j], met_handle);
        const std::vector<pat::MET>& pat_mets = *met_handle;
        if(pat_mets.size()!=1){
-         std::cout<< "WARNING: number of METs = " << pat_mets.size() <<", should be 1" << std::endl;
+         edm::LogWarning("NtupleWriter") << "WARNING: number of METs = " << pat_mets.size() <<", should be 1";
        }
        else{
          pat::MET pat_met = pat_mets[0];
@@ -1141,7 +1137,7 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
        iEvent.getByToken(genmet_tokens[j], genmet_handle);
        const std::vector<pat::MET>& pat_genmets = *genmet_handle;
        if(pat_genmets.size()!=1){
-         std::cout<< "WARNING: number of GenMETs = " << pat_genmets.size() <<", should be 1" << std::endl;
+         edm::LogWarning("NtupleWriter") << "WARNING: number of GenMETs = " << pat_genmets.size() <<", should be 1";
        }
        else{
          pat::MET pat_genmet = pat_genmets[0];

--- a/core/plugins/NtupleWriter.h
+++ b/core/plugins/NtupleWriter.h
@@ -4,7 +4,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/one/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -28,7 +28,7 @@ namespace uhh2 {
     class NtupleWriterTopJets;
 }
 
-class NtupleWriter : public edm::EDFilter {
+class NtupleWriter : public edm::one::EDFilter<edm::one::WatchRuns> {
    public:
       explicit NtupleWriter(const edm::ParameterSet&);
       ~NtupleWriter();
@@ -41,6 +41,7 @@ class NtupleWriter : public edm::EDFilter {
       virtual void endJob() override;
 
       virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
+      virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
       
       // fill gen particles from a gen topjet
       void fill_genparticles_jet(const reco::GenJet& reco_genjet, GenJetWithParts& genjet);

--- a/core/plugins/NtupleWriterJets.cxx
+++ b/core/plugins/NtupleWriterJets.cxx
@@ -309,12 +309,13 @@ void NtupleWriterJets::fill_jet_info(const pat::Jet & pat_jet, Jet & jet, bool d
 
     if(!csv || !csvmva || !doubleak8 || !doubleca15 || !deepcsv_b || !deepcsv_bb){
       if(btag_warning){
-	cout << "Warning in NtupleWriterJets: did not find all b-taggers! Available btaggers: ";
-	for(const auto & name_value : bdisc){
-	  cout << name_value.first << " ";
-	}
-	cout << endl;
-	btag_warning = false;
+        std::string btag_list = "";
+        for(const auto & name_value : bdisc){
+          btag_list += name_value.first;
+          btag_list += " ";
+        }
+        edm::LogWarning("NtupleWriterJets") << "Did not find all b-taggers! Available btaggers: " << btag_list;
+        btag_warning = false;
       }
       // throw runtime_error("did not find all b-taggers; see output for details");
     }

--- a/core/plugins/NtupleWriterLeptons.cxx
+++ b/core/plugins/NtupleWriterLeptons.cxx
@@ -27,7 +27,7 @@ void NtupleWriterElectrons::process(const edm::Event & event, uhh2::Event & ueve
     edm::Handle<std::vector<reco::Vertex>> pv_handle;
    event.getByToken(pv_token, pv_handle);
    if(pv_handle->empty()){
-       cout << "WARNING: no PVs found, not writing electrons!" << endl;
+       edm::LogWarning("NtupleWriterElectrons") << "No PVs found, not writing electrons!";
        return;
    }
    const auto & PV = pv_handle->front();
@@ -102,7 +102,7 @@ void NtupleWriterElectrons::process(const edm::Event & event, uhh2::Event & ueve
 
         for(const auto& tag_str : IDtag_keys){
 
-          if(!pat_ele.hasUserInt(tag_str)) throw std::runtime_error("NtupleWriterElectrons::process -- label for pat::Electron::userInt not found: "+tag_str);
+          if(!pat_ele.hasUserInt(tag_str)) throw cms::Exception("Missing userInt label", "Label for pat::Electron::userInt not found: "+tag_str);
           ele.set_tag(Electron::tagname2tag(tag_str), float(pat_ele.userInt(tag_str)));
         }
 
@@ -149,7 +149,7 @@ void NtupleWriterMuons::process(const edm::Event & event, uhh2::Event & uevent, 
    edm::Handle<std::vector<reco::Vertex>> pv_handle;
    event.getByToken(pv_token, pv_handle);
    if(pv_handle->empty()){
-       cout << "WARNING: no PVs found, not writing muons!" << endl;
+       edm::LogWarning("NtupleWriterMuons") << "No PVs found, not writing muons!";
        return;
    }
    const auto & PV = pv_handle->front();

--- a/core/plugins/PATElectronUserData.cc
+++ b/core/plugins/PATElectronUserData.cc
@@ -3,7 +3,7 @@
 #include <string>
 
 #include <FWCore/Framework/interface/Frameworkfwd.h>
-#include <FWCore/Framework/interface/EDProducer.h>
+#include <FWCore/Framework/interface/stream/EDProducer.h>
 #include <FWCore/Framework/interface/Event.h>
 #include <FWCore/Framework/interface/MakerMacros.h>
 #include <FWCore/ParameterSet/interface/ParameterSet.h>
@@ -12,13 +12,13 @@
 
 #include <RecoEgamma/EgammaTools/interface/EffectiveAreas.h>
 
-class PATElectronUserData : public edm::EDProducer {
+class PATElectronUserData : public edm::stream::EDProducer<> {
  public:
   explicit PATElectronUserData(const edm::ParameterSet&);
   virtual ~PATElectronUserData() {}
 
  private:
-  virtual void produce(edm::Event&, const edm::EventSetup&);
+  virtual void produce(edm::Event&, const edm::EventSetup&) override;
 
   edm::EDGetTokenT< edm::View<pat::Electron> > src_;
   edm::EDGetTokenT< edm::View<reco::Vertex> > vertices_;

--- a/core/plugins/PATMuonUserData.cc
+++ b/core/plugins/PATMuonUserData.cc
@@ -3,20 +3,20 @@
 #include <string>
 
 #include <FWCore/Framework/interface/Frameworkfwd.h>
-#include <FWCore/Framework/interface/EDProducer.h>
+#include <FWCore/Framework/interface/stream/EDProducer.h>
 #include <FWCore/Framework/interface/Event.h>
 #include <FWCore/Framework/interface/MakerMacros.h>
 #include <FWCore/ParameterSet/interface/ParameterSet.h>
 
 #include <DataFormats/PatCandidates/interface/Muon.h>
 
-class PATMuonUserData : public edm::EDProducer {
+class PATMuonUserData : public edm::stream::EDProducer<> {
  public:
   explicit PATMuonUserData(const edm::ParameterSet&);
   virtual ~PATMuonUserData() {}
 
  private:
-  virtual void produce(edm::Event&, const edm::EventSetup&);
+  virtual void produce(edm::Event&, const edm::EventSetup&) override;
 
   edm::EDGetTokenT< edm::View<pat::Muon> > src_;
   std::vector<std::string> vmaps_double_;

--- a/core/plugins/PFCandIsolatorFromDepositsMINIISO.h
+++ b/core/plugins/PFCandIsolatorFromDepositsMINIISO.h
@@ -30,7 +30,7 @@ public:
 
   virtual ~PFCandIsolatorFromDepositsMINIISO();
 
-  virtual void produce(edm::Event&, const edm::EventSetup&);
+  virtual void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
   class SingleDeposit {

--- a/core/plugins/XConeProducer.cc
+++ b/core/plugins/XConeProducer.cc
@@ -108,6 +108,21 @@ XConeProducer::~XConeProducer()
 void
 XConeProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
+  // Set the fastjet random seed to a deterministic function
+  // of the run/lumi/event.
+  // NOTE!!! The fastjet random number sequence is a global singleton.
+  // Thus, we have to create an object and get access to the global singleton
+  // in order to change it.
+  // Taken from VirtualJetProducer
+  fastjet::GhostedAreaSpec gas;
+  std::vector<int> seeds(2);
+  unsigned int runNum_uint = static_cast <unsigned int> (iEvent.id().run());
+  unsigned int evNum_uint = static_cast <unsigned int> (iEvent.id().event());
+  uint minSeed_ = 14327;
+  seeds[0] = std::max(runNum_uint, minSeed_ + 3) + 3 * evNum_uint;
+  seeds[1] = std::max(runNum_uint, minSeed_ + 5) + 5 * evNum_uint;
+  gas.set_random_status(seeds);
+
   edm::Handle<edm::View<pat::PackedCandidate>> particles;
   iEvent.getByToken(src_token_, particles);
 

--- a/core/plugins/XConeProducer.cc
+++ b/core/plugins/XConeProducer.cc
@@ -22,7 +22,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -50,7 +50,7 @@ using namespace contrib;
 // class declaration
 //
 
-class XConeProducer : public edm::stream::EDProducer<> {
+class XConeProducer : public edm::global::EDProducer<> {
   public:
     explicit XConeProducer(const edm::ParameterSet&);
     ~XConeProducer();
@@ -58,11 +58,9 @@ class XConeProducer : public edm::stream::EDProducer<> {
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
   private:
-    virtual void beginStream(edm::StreamID) override;
-    virtual void produce(edm::Event&, const edm::EventSetup&) override;
-    virtual void endStream() override;
+    virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
-    virtual pat::Jet createPatJet(const fastjet::PseudoJet &);
+    virtual pat::Jet createPatJet(const fastjet::PseudoJet &) const;
 
     // ----------member data ---------------------------
     edm::EDGetToken src_token_;
@@ -106,7 +104,7 @@ XConeProducer::~XConeProducer()
 
 // ------------ method called to produce the data  ------------
 void
-XConeProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+XConeProducer::produce(edm::StreamID id, edm::Event& iEvent, const edm::EventSetup& iSetup) const
 {
   // Set the fastjet random seed to a deterministic function
   // of the run/lumi/event.
@@ -255,22 +253,11 @@ XConeProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   iEvent.put(std::move(jetCollection));
 }
 
-pat::Jet XConeProducer::createPatJet(const PseudoJet & psj)
+pat::Jet XConeProducer::createPatJet(const PseudoJet & psj) const
 {
   pat::Jet newJet;
   newJet.setP4(math::XYZTLorentzVector(psj.px(), psj.py(), psj.pz(), psj.E()));
   return newJet;
-}
-
-// ------------ method called once each stream before processing any runs, lumis or events  ------------
-void
-XConeProducer::beginStream(edm::StreamID)
-{
-}
-
-// ------------ method called once each stream after processing all runs, lumis and events  ------------
-void
-XConeProducer::endStream() {
 }
 
 

--- a/core/plugins/convertPackedCandToPFCand.cc
+++ b/core/plugins/convertPackedCandToPFCand.cc
@@ -1,5 +1,5 @@
 #include <FWCore/Framework/interface/Frameworkfwd.h>
-#include <FWCore/Framework/interface/stream/EDProducer.h>
+#include <FWCore/Framework/interface/global/EDProducer.h>
 #include <FWCore/Framework/interface/Event.h>
 #include <FWCore/Framework/interface/MakerMacros.h>
 #include <FWCore/ParameterSet/interface/ParameterSet.h>
@@ -8,14 +8,14 @@
 #include <DataFormats/ParticleFlowCandidate/interface/PFCandidate.h>
 #include <memory>
 
-class convertPackedCandToPFCand : public edm::stream::EDProducer<> {
+class convertPackedCandToPFCand : public edm::global::EDProducer<> {
 
  public:
   convertPackedCandToPFCand(const edm::ParameterSet& iConfig);
   ~convertPackedCandToPFCand() {}
   
  private:
-  virtual void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+  virtual void produce(edm::StreamID id, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
   edm::EDGetTokenT< pat::PackedCandidateCollection > src_;
 };
 
@@ -25,7 +25,8 @@ convertPackedCandToPFCand::convertPackedCandToPFCand(const edm::ParameterSet& iC
   produces<reco::PFCandidateCollection>();
 }
 
-void convertPackedCandToPFCand::produce(edm::Event& iEvent,const edm::EventSetup& iSetup){
+void convertPackedCandToPFCand::produce(edm::StreamID id, edm::Event& iEvent,const edm::EventSetup& iSetup) const
+{
 
   edm::Handle< pat::PackedCandidateCollection > packedCands_;
   iEvent.getByToken(src_, packedCands_);
@@ -41,7 +42,6 @@ void convertPackedCandToPFCand::produce(edm::Event& iEvent,const edm::EventSetup
 
   iEvent.put(std::move(recoPFCands));
 
-  return;
 }
 
 DEFINE_FWK_MODULE(convertPackedCandToPFCand);

--- a/core/plugins/convertPackedCandToPFCand.cc
+++ b/core/plugins/convertPackedCandToPFCand.cc
@@ -1,5 +1,5 @@
 #include <FWCore/Framework/interface/Frameworkfwd.h>
-#include <FWCore/Framework/interface/EDProducer.h>
+#include <FWCore/Framework/interface/stream/EDProducer.h>
 #include <FWCore/Framework/interface/Event.h>
 #include <FWCore/Framework/interface/MakerMacros.h>
 #include <FWCore/ParameterSet/interface/ParameterSet.h>
@@ -8,14 +8,14 @@
 #include <DataFormats/ParticleFlowCandidate/interface/PFCandidate.h>
 #include <memory>
 
-class convertPackedCandToPFCand : public edm::EDProducer {
+class convertPackedCandToPFCand : public edm::stream::EDProducer<> {
 
  public:
   convertPackedCandToPFCand(const edm::ParameterSet& iConfig);
   ~convertPackedCandToPFCand() {}
   
  private:
-  void produce(edm::Event& iEvent, const edm::EventSetup& iSetup);
+  virtual void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
   edm::EDGetTokenT< pat::PackedCandidateCollection > src_;
 };
 

--- a/core/python/compareTrees.py
+++ b/core/python/compareTrees.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python
+
+"""
+Produce comparison plots for all variable in all branches on two ROOT files
+with same tree name. Each branch will be in its own subdirectory.
+Histograms with differing # entries or means will have "DIFF_" prepended to their filename.
+"""
+
+
+import os
+import ROOT
+import sys
+import argparse
+from collections import OrderedDict
+
+
+ROOT.PyConfig.IgnoreCommandLineOptions = True
+ROOT.gROOT.SetBatch(1)
+ROOT.TH1.SetDefaultSumw2()
+# ROOT.gErrorIgnoreLevel = ROOT.kError
+ROOT.gErrorIgnoreLevel = ROOT.kBreak  # to turn off all Error in <TCanvas::Range> etc
+
+
+def do_comparison_plot(T1, T2, name, output_name, print_warning=True):
+    c = ROOT.TCanvas("c"+name, "", 800, 600)
+
+    h1name = "h1_%s" % name
+    T1.Draw(name + ">>" + h1name)
+    h1 = ROOT.TH1F(ROOT.gROOT.FindObject(h1name))
+    h1_colour = ROOT.kBlack
+    h1.SetLineColor(h1_colour)
+    h1.SetLineWidth(2)
+    h1.Draw("HISTE")
+
+    h2name = "h2_%s" % name
+    T2.Draw(name + ">>" + h2name)
+    h2 = ROOT.TH1F(ROOT.gROOT.FindObject(h2name))
+    h2_colour = ROOT.kRed
+    h2.SetLineColor(h2_colour)
+    h2.SetLineStyle(2)
+    h2.SetLineWidth(2)
+    h2.Draw("HISTE")
+    c.Update()
+    # To get the 2nd stats box we MUST NOT draw with SAME
+    # Instead draw by itself, then plot them together afterwards
+    stats2 = h2.GetListOfFunctions().FindObject("stats").Clone("stats1")
+    stats2.SetY1NDC(0.52);
+    stats2.SetY2NDC(0.7);
+    stats2.SetTextColor(h2_colour);
+
+    if h1.GetEntries() == 0 and h2.GetEntries() == 0:
+        return
+
+    # Do a simple check to see if hists differ
+    is_diff = False
+    if print_warning and (h1.GetEntries() > 0 or h2.GetEntries() > 0):
+        if h1.GetEntries() != h2.GetEntries():
+            is_diff = True
+            print name, " has differing entries", h1.GetEntries(), "vs", h2.GetEntries()
+        if h1.GetMean() != h2.GetMean():
+            is_diff = True
+            print name, " has differing means", h1.GetMean(), "vs", h2.GetMean()
+
+    if is_diff:
+        basename = os.path.basename(output_name)
+        output_name = output_name.replace(basename, "DIFF_"+basename)
+
+    h1.Draw("HISTE")
+    h2.Draw("HISTE SAME")
+    stats2.Draw()
+    c.Modified()
+    c.SaveAs(output_name)
+
+    return is_diff
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("filename1", help="Reference ROOT filename")
+    parser.add_argument("filename2", help="Comparison ROOT filename")
+    default_dir = "ComparisonPlots"
+    parser.add_argument("--outputDir", help="Output directory for plots, defaults to %s" % default_dir, default=default_dir)
+    default_tree = "AnalysisTree"
+    parser.add_argument("--treeName", help="Name of TTree, defaults to %s" % default_tree, default=default_tree)
+    args = parser.parse_args()
+
+    f1 = ROOT.TFile.Open(args.filename1)
+    f2 = ROOT.TFile.Open(args.filename2)
+
+    T1 = f1.Get(args.treeName)
+    T2 = f2.Get(args.treeName)
+
+    br_list1 = T1.GetListOfBranches()
+    # br_list2 = T2.GetListOfBranches()
+
+    results = OrderedDict()
+
+    print "Plots produced in", args.outputDir
+    ROOT.gSystem.mkdir(args.outputDir)
+
+    for i in range(br_list1.GetEntries()):
+    # for i in range(0, 20):
+        branch1 = br_list1.At(i)
+        branch_name = branch1.GetName()
+        print "BRANCH", i, ":", branch_name
+        branch2 = T2.GetBranch(branch_name)
+        if branch2 is None:
+            print "WARNING Tree2 doesn't have branch ", branch_name
+
+        ROOT.gSystem.mkdir(os.path.join(args.outputDir, branch_name))
+
+        leaves1 = branch1.GetListOfBranches()
+        leaves2 = branch2.GetListOfBranches()
+
+        if leaves1.GetEntries() == 0:
+            # means its a leaf not a branch
+            output_name = os.path.join(args.outputDir, branch_name, branch_name+"_compare.pdf")
+            is_diff = do_comparison_plot(T1, T2, branch_name, output_name)
+            results[branch_name] = is_diff
+        else:
+            for j in range(leaves1.GetEntries()):
+                leaf1 = leaves1.At(j)
+                leaf2 = leaves2.At(j)
+
+                leaf_type = leaf1.GetTypeName()
+                if leaf_type.startswith("map"):
+                    # don't know how to print these yet
+                    continue
+
+                var_name = leaf1.GetName()
+                if var_name != leaf2.GetName():
+                    print "WARNING diff leaf names", var_name, "vs", leaf2.GetName()
+
+                print var_name
+                parts = var_name.replace(branch_name+".", "").replace(".", "_")
+                output_name = os.path.join(args.outputDir, branch_name, parts + "_compare.pdf")
+                is_diff = do_comparison_plot(T1, T2, var_name, output_name)
+                results[var_name] = is_diff
+
+    f1.Close()
+    f2.Close()
+
+    # Print results
+    if any(results.values()):
+        max_len = max([len(x) for x in results.keys()])
+        print "*" * max_len
+        print "Differing vars:"
+        print "*" * max_len
+        for name, result in results.iteritems():
+            if result:
+                print name
+        print "*" * max_len
+        sys.exit(1)
+    else:
+        print "All distributions same"
+        sys.exit(0)

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -39,6 +39,7 @@ process.MessageLogger.cerr.FwkReport.reportEvery = cms.untracked.int32(1000)
 process.options = cms.untracked.PSet(
     wantSummary=cms.untracked.bool(False),
     # wantSummary=cms.untracked.bool(True),
+    # numberOfThreads = cms.untracked.uint32(8), # if running crab jobs, you must set this to agree with numCores
     numberOfStreams = cms.untracked.uint32(0) # 0 = use number of threads; to set use -n
 )
 

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -37,8 +37,9 @@ process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.FwkReport.reportEvery = cms.untracked.int32(1000)
 #process.MessageLogger.cerr.FwkReport.reportEvery = cms.untracked.int32(1)
 process.options = cms.untracked.PSet(
-    wantSummary=cms.untracked.bool(False)
-    # wantSummary=cms.untracked.bool(True)
+    wantSummary=cms.untracked.bool(False),
+    # wantSummary=cms.untracked.bool(True),
+    numberOfStreams = cms.untracked.uint32(0) # 0 = use number of threads; to set use -n
 )
 
 # DEBUG ----------------

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -45,7 +45,7 @@ setupFastjet() {
 	# cd fastjet-${FJVER}
 
 	# Use the CMS version of fastjet as thread-safe
-	git clone -b cms/v3.1.0 https://github.com/UHH2/fastjet.git
+	git clone -b cms/v$FJVER https://github.com/UHH2/fastjet.git
 	cd fastjet
 	./configure --prefix="${FJINSTALLDIR}" --enable-allplugins --enable-allcxxplugins CXXFLAGS=-fPIC
 	make $MAKEFLAGS
@@ -62,7 +62,7 @@ setupFastjet() {
 	# cd fjcontrib-${FJCONTRIBVER}
 
 	# Use the CMS version of fastjet-contrib as thread-safe
-	git clone -b v1.026 https://github.com/UHH2/fastjet-contrib.git
+	git clone -b cms/v$FJCONTRIBVER https://github.com/UHH2/fastjet-contrib.git
 	cd fastjet-contrib
 	# add HOTVR from SVN - do it this way until it becomes a proper contrib
 	svn co http://fastjet.hepforge.org/svn/contrib/contribs/HOTVR/trunk HOTVR/

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -33,25 +33,37 @@ setupFastjet() {
 	FJCONTRIBVER="$2"
 	echo "Setting up fastjet $FJVER and fastjet-contrib $FJCONTRIBVER"
 
-	# Setup fastjet & fastjet-contrib
-	# NB use curl not wget as curl available by cvmfs, wget isnt
 	FJINSTALLDIR="$(pwd)/fastjet-install"
-	curl -O http://fastjet.fr/repo/fastjet-${FJVER}.tar.gz
-	tar xzf fastjet-${FJVER}.tar.gz
+
+	# Setup fastjet & fastjet-contrib
 	mkdir "${FJINSTALLDIR}"
-	cd fastjet-${FJVER}
+
+	# For normal fastjet
+	# NB use curl not wget as curl available by cvmfs, wget isnt
+	# curl -O http://fastjet.fr/repo/fastjet-${FJVER}.tar.gz
+	# tar xzf fastjet-${FJVER}.tar.gz
+	# cd fastjet-${FJVER}
+
+	# Use the CMS version of fastjet as thread-safe
+	git clone -b cms/v3.1.0 https://github.com/cms-externals/fastjet.git
+	cd fastjet
 	./configure --prefix="${FJINSTALLDIR}" --enable-allplugins --enable-allcxxplugins CXXFLAGS=-fPIC
 	make $MAKEFLAGS
-	make check
+	# make check  # fails for siscone
 	make install
 	cd ..
 
 	# Add fastjet-config to PATH
 	export PATH="${FJINSTALLDIR}/bin":$PATH
 
-	curl -O http://fastjet.hepforge.org/contrib/downloads/fjcontrib-${FJCONTRIBVER}.tar.gz
-	tar xzf fjcontrib-${FJCONTRIBVER}.tar.gz
-	cd fjcontrib-${FJCONTRIBVER}
+	# For normal fastjet-contrib
+	# curl -O http://fastjet.hepforge.org/contrib/downloads/fjcontrib-${FJCONTRIBVER}.tar.gz
+	# tar xzf fjcontrib-${FJCONTRIBVER}.tar.gz
+	# cd fjcontrib-${FJCONTRIBVER}
+
+	# Use the CMS version of fastjet-contrib as thread-safe
+	git clone -b v1.026 https://github.com/cms-externals/fastjet-contrib.git
+	cd fastjet-contrib
 	# add HOTVR from SVN - do it this way until it becomes a proper contrib
 	svn co http://fastjet.hepforge.org/svn/contrib/contribs/HOTVR/trunk HOTVR/
 	# although we add fastjet-config to path, due to a bug we need to

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -45,7 +45,7 @@ setupFastjet() {
 	# cd fastjet-${FJVER}
 
 	# Use the CMS version of fastjet as thread-safe
-	git clone -b cms/v3.1.0 https://github.com/cms-externals/fastjet.git
+	git clone -b cms/v3.1.0 https://github.com/UHH2/fastjet.git
 	cd fastjet
 	./configure --prefix="${FJINSTALLDIR}" --enable-allplugins --enable-allcxxplugins CXXFLAGS=-fPIC
 	make $MAKEFLAGS
@@ -62,7 +62,7 @@ setupFastjet() {
 	# cd fjcontrib-${FJCONTRIBVER}
 
 	# Use the CMS version of fastjet-contrib as thread-safe
-	git clone -b v1.026 https://github.com/cms-externals/fastjet-contrib.git
+	git clone -b v1.026 https://github.com/UHH2/fastjet-contrib.git
 	cd fastjet-contrib
 	# add HOTVR from SVN - do it this way until it becomes a proper contrib
 	svn co http://fastjet.hepforge.org/svn/contrib/contribs/HOTVR/trunk HOTVR/


### PR DESCRIPTION
This allows the ntuplewriter to run with multiple threads, significantly speeding up runtime. In local tests running over 500 MC events, I went from ~4s/evt (1 thread) to ~0.9s/evt (4 threads) and ~0.5s/evt (8 threads). I haven't checked memory usage yet though.

To run `cmsRun` in multithreaded mode, do e.g. `cmsRun -n 4 ntuplewriter.py` where 4 is the number of threads.
You can pick any number, but it shouldn't be more than the number of cores available, and as you use more you get diminishing returns.

**NB** To use multithreading, we now have to use the CMS versions of fastjet and fastjet-contrib, which have thread-safe additions. If you want to run multithreads, you will have to re-install them, see `install.sh`. (The easiest way is to delete the contents of your `fastjet-install` dir, follow the install instructions, and then redo the `scram setup fastjet && scram setup fastjet-contrib && scram setup fastjet-contrib-archive && scram b clean && scram b -j12`, and then re-compile UHH.

I updated all our ED modules to the new stream/global/one types, and replaced any `cout`s or `runtime_error` with `edm::LogInfo/Warning` and `cms::Exception`, respectively.

I also added in a script I use to compare all leaves in all branches of two TTrees, `compareTrees.py`. It prints plots of every variable, and tells you if two plots differ (not the most sophisticated way though).
Useful for testing 1 core vs multicore output. Noticeably, I found the HOTVR and XCONE jet areas would differ slightly. This is due to having a non-deterministic random number seed. I copied the method used in the CMSSW `VirtualJetProducer` to set the seed deterministically based on event and run numbers, and the jet area now agrees for 1-core and multi-core tests.

I also spotted a few uninitialised variables that needed setting.

**NB2** I tried a very small number of jobs on CRAB, and it seems to work. However, I don't know what will happen when it scales to > 10K jobs, you may get stuck in a queue for slots with >1 CPU. Or there may be some new race-condition I haven't seen yet.
To run on CRAB you have to set in `ntuplewriter.py`:
```
process.options.numberOfThreads = cms.untracked.uint32(4)
```
and in your crab script:
```
config.JobType.numCores = 4
```
CRAB only accepts 1, 4, or 8 cores, and the number in `ntuplewriter.py` must be the same.