### PR TITLE
[94X] Move to fastjet 3.2.1 and fastjet-contrib 1.032

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -95,8 +95,8 @@ git cms-merge-topic guitargeek:ElectronID_MVA2017_940pre3
 # Necessary for using our FastJet
 git cms-addpkg RecoJets/JetProducers
 # Necessary for using Fastjet 3.2.1 to pickup new JetDefinition default arg order
-rm RecoJets/JetProducers/test/Buildfile.xml
-rm RecoJets/JetProducers/test/test-voronoi-area.cc
+rm RecoJets/JetProducers/test/BuildFile.xml
+rm RecoJets/JetProducers/test/test-large-voronoi-area.cc  # old test, not used?
 git cms-addpkg RecoBTag/SecondaryVertex
 git cms-addpkg RecoJets/JetAlgorithms
 git cms-addpkg PhysicsTools/JetMCAlgos

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -79,8 +79,8 @@ eval `scramv1 runtime -sh`
 
 # Install FastJet & contribs for HOTVR & XCONE
 cd ../..
-FJVER="3.1.0"
-FJCONTRIBVER="1.026"
+FJVER="3.2.1"
+FJCONTRIBVER="1.032"
 time setupFastjet $FJVER $FJCONTRIBVER
 
 cd $CMSSW_BASE/src
@@ -94,6 +94,12 @@ git cms-merge-topic guitargeek:ElectronID_MVA2017_940pre3
 
 # Necessary for using our FastJet
 git cms-addpkg RecoJets/JetProducers
+# Necessary for using Fastjet 3.2.1 to pickup new JetDefinition default arg order
+rm RecoJets/JetProducers/test/Buildfile.xml
+rm RecoJets/JetProducers/test/test-voronoi-area.cc
+git cms-addpkg RecoBTag/SecondaryVertex
+git cms-addpkg RecoJets/JetAlgorithms
+git cms-addpkg PhysicsTools/JetMCAlgos
 
 # For adding in Puppi multiplicities, until they get merged into a 94X release
 # Do a manual cherry-pick of the PR commits otherwise merge-topic will get loads of extra fluff


### PR DESCRIPTION
The fastjet changes from 3.1.0 to 3.2.1 speed up HOTVR significantly.
The contrib changes from 1.026 to 1.032 speed up the ECFs significantly.

NB this should probably be merged **after** #852 to avoid messing up install instructions
To ensure thread-safety, our versions of fastjet & fastjet-contrib has the thread-safety commits that were applied to fastjet 3.1.0 and fastjet-contrib 1.026 from the cms-externals repos.

With multithreading, can get down to < 1s/event.

e.g. 100 TTbar MC, comparing the individual & combined changes

**with 3.2.1 + 1.032 (update both, this PR)**

```
TimeReport   0.016263     0.016263     0.016263  ECFNbeta1Ak8SoftDropCHS <<< !
TimeReport   0.015910     0.015910     0.015910  ECFNbeta2Ak8SoftDropCHS <<< !
TimeReport   0.142428     0.142428     0.142428  hepTopTagCHS
TimeReport   0.307057     0.307057     0.307057  hotvrPfCand
TimeReport   0.088100     0.088100     0.088100  hotvrPuppi
TimeReport   0.549734     0.549734     0.549734  xconePfCand

TimeReport ---------- Event  Summary ---[sec]----
TimeReport       event loop CPU/event = 2.462897
TimeReport      event loop Real/event = 2.478959
TimeReport     sum Streams Real/event = 2.473125
TimeReport efficiency CPU/Real/thread = 0.993521
```

**with 3.2.1 + 1.032  + 4 threads (update both, this PR + multithreading)**

```
TimeReport ---------- Event  Summary ---[sec]----
TimeReport       event loop CPU/event = 2.870499
TimeReport      event loop Real/event = 0.816563 <<< !
TimeReport     sum Streams Real/event = 3.222661
TimeReport efficiency CPU/Real/thread = 0.878835
```


**with 3.2.1 + 1.031 (update fastjet only)**

```
TimeReport   0.154988     0.154988     0.154988  ECFNbeta1Ak8SoftDropCHS
TimeReport   0.154827     0.154827     0.154827  ECFNbeta2Ak8SoftDropCHS
TimeReport   0.142491     0.142491     0.142491  hepTopTagCHS
TimeReport   0.304335     0.304335     0.304335  hotvrPfCand  <<< !
TimeReport   0.088101     0.088101     0.088101  hotvrPuppi  <<< !
TimeReport   0.566282     0.566282     0.566282  xconePfCand

TimeReport ---------- Event  Summary ---[sec]----
TimeReport       event loop CPU/event = 2.762006
TimeReport      event loop Real/event = 3.082765
TimeReport     sum Streams Real/event = 2.768504
TimeReport efficiency CPU/Real/thread = 0.895951
```

**with 3.1.0 + 1.026 (current setup)**

```
TimeReport   0.158753     0.158753     0.158753  ECFNbeta1Ak8SoftDropCHS
TimeReport   0.158180     0.158180     0.158180  ECFNbeta2Ak8SoftDropCHS
TimeReport   0.142369     0.142369     0.142369  hepTopTagCHS
TimeReport   1.207417     1.207417     1.207417  hotvrPfCand
TimeReport   0.356312     0.356312     0.356312  hotvrPuppi
TimeReport   0.564076     0.564076     0.564076  xconePfCand

TimeReport ---------- Event  Summary ---[sec]----
TimeReport       event loop CPU/event = 3.934991
TimeReport      event loop Real/event = 3.945705
TimeReport     sum Streams Real/event = 3.939587
TimeReport efficiency CPU/Real/thread = 0.997285
```

**Summary:**

- HOTVR speed up by factor ~ x4
- ECF speed up by factor ~ x10
- Total event speedup by ~ x1.6 (similar factor for data)
- Memory requirement same
- No change for XCone & HepTopTagger (the other main slowdowns)
- With 4 cores, speed up by factor ~ x3