### PR TITLE
[94X] Fix input for MET filters in MC

### DIFF
--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -1140,7 +1140,7 @@ task.add(process.slimmedElectronsUSER)
 if useData:
     metfilterpath = "RECO"
 else:
-    metfilterpath = "HLT"
+    metfilterpath = "PAT"
 
 process.MyNtuple = cms.EDFilter('NtupleWriter',
                                 # AnalysisModule = cms.PSet(


### PR DESCRIPTION
Wasn't storing them before in MC, now does.

Don't know how it worked before in 80X, Twiki instructions haven't changed...?