### PR TITLE
[94X] Update EventHists & add MC pileup hist maker analysis

### DIFF
--- a/common/src/EventHists.cxx
+++ b/common/src/EventHists.cxx
@@ -7,8 +7,8 @@
 using namespace uhh2;
 
 EventHists::EventHists(uhh2::Context & ctx, const std::string & dirname): Hists(ctx, dirname){
-    N_PrimVertices = book<TH1F>("N_PrimVertices", "number of primary vertices", 56, -0.5, 55.5);
-    N_TrueInteractions = book<TH1F>("N_TrueInteractions", "number of true interactions", 50, 0, 50);
+    N_PrimVertices = book<TH1F>("N_PrimVertices", "number of primary vertices", 102, -0.5, 101.5);
+    N_TrueInteractions = book<TH1F>("N_TrueInteractions", "number of true interactions", 100, 0, 100);
     Weights = book<TH1F>("Weights", "weights", 100,0,2);
     MET = book<TH1F>("MET", "missing E_{T}", 200,0,1000);
     HT = book<TH1F>("HT", "H_{T} Jets", 100, 0, 3500);

--- a/examples/config/MakePileupHistMC.xml
+++ b/examples/config/MakePileupHistMC.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE JobConfiguration PUBLIC "" "JobConfig.dtd">
+
+<!-- OutputLevel controls which messages are printed; set to VERBOSE or DEBUG for more verbosity, to WARNING or ERROR for less -->
+<JobConfiguration JobName="ExampleCycleJob" OutputLevel="INFO">
+    <Library Name="libSUHH2examples"/>
+    <Package Name="SUHH2examples.par" />
+
+   <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="./" PostFix="" TargetLumi="1" >
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="MyMC" Cacheable="False">
+            <In FileName="/nfs/dust/cms/user/aggleton/UHH_Dev/94X_3/CMSSW_9_4_1/src/UHH2/core/python/Ntuple.root" Lumi="0.0"/> 
+            <InputTree Name="AnalysisTree" /> 
+        </InputData>
+            
+        <UserConfig>
+            <!-- define which collections to read from the input. Only specify what you need to save I/O time -->
+            <Item Name="PrimaryVertexCollection" Value="offlineSlimmedPrimaryVertices" /> 
+            <Item Name="ElectronCollection" Value="slimmedElectronsUSER" />
+            <Item Name="MuonCollection" Value="slimmedMuonsUSER" /> 
+            <Item Name="TauCollection" Value="slimmedTaus" />
+            <Item Name="JetCollection" Value="slimmedJets" />
+            <Item Name="GenJetCollection" Value="slimmedGenJets" />
+            <Item Name="METName" Value="slimmedMETs" />
+            
+            <!-- the class name of the AnalysisModule subclasses to run: -->
+            <Item Name="AnalysisModule" Value="MakePileupHistModule" /> 
+            
+            <!-- tell AnalysisModuleRunner NOT to use the MC event weight from SFrame; rather let
+                 MCLumiWeight (called via CommonModules) calculate the MC event weight. The MC
+                 event weight assigned by MCLumiWeight is InputData.Lumi / Cycle.TargetLumi. -->
+            <Item Name="use_sframe_weight" Value="false" />
+            
+        </UserConfig>
+    </Cycle>
+</JobConfiguration>

--- a/examples/src/MakePileupHistMC.cc
+++ b/examples/src/MakePileupHistMC.cc
@@ -1,0 +1,44 @@
+#include <iostream>
+#include <memory>
+
+#include "UHH2/core/include/AnalysisModule.h"
+#include "UHH2/core/include/Event.h"
+#include "UHH2/common/include/EventHists.h"
+
+using namespace std;
+using namespace uhh2;
+
+namespace uhh2examples {
+
+/** \brief Simple analysis to dump pileup hists to ROOT file, for use in MCPileupReweight
+ *
+ */
+class MakePileupHistModule: public AnalysisModule {
+public:
+    
+    explicit MakePileupHistModule(Context & ctx);
+    virtual bool process(Event & event) override;
+
+private:
+    std::unique_ptr<Hists> h_pu;
+};
+
+
+MakePileupHistModule::MakePileupHistModule(Context & ctx){
+    
+    h_pu.reset(new EventHists(ctx, "input_Event"));
+
+}
+
+
+bool MakePileupHistModule::process(Event & event) {
+    h_pu->fill(event);
+    
+    return true;
+}
+
+// as we want to run the ExampleCycleNew directly with AnalysisModuleRunner,
+// make sure the MakePileupHistModule is found by class name. This is ensured by this macro:
+UHH2_REGISTER_ANALYSIS_MODULE(MakePileupHistModule)
+
+}


### PR DESCRIPTION
Add in simple analysis to dump pileup info. Also updated binning to match that in the data ROOT file.