### PR TITLE
[94X] Don't throw exception if 2nd occurrence of trigger found in MC

### DIFF
--- a/core/include/Event.h
+++ b/core/include/Event.h
@@ -44,6 +44,7 @@ public:
   std::vector< Particle>* genjets;
   std::vector< PFParticle>* pfparticles;
 
+
   /** \brief Access to trigger results.
    * 
    * Access to trigger results is treated differently from the other
@@ -156,6 +157,8 @@ private:
 
     std::vector<std::string> triggerNames_currentrun;
     int triggerNames_currentrun_runid;
+    // generic flag to alert the user to something the first time, and not on subsequent occurrences.
+    mutable bool doOnce;
 };
 
 }


### PR DESCRIPTION
This is a hack specifically for MC that stored the HLT twice, so it doesn't throw, and only outputs a warning the first event.

For real data we still throw an exception since it is stored correctly.
