### PR TITLE
[94X] Fix bug using product of all weights

### DIFF
--- a/core/src/AnalysisModuleRunner.cxx
+++ b/core/src/AnalysisModuleRunner.cxx
@@ -734,9 +734,9 @@ void AnalysisModuleRunner::ExecuteEvent(const SInputData&, Double_t w) throw (SE
     }
 
     if(event.genInfo){
-          for (unsigned int i=0; i<event.genInfo->weights().size(); i++){
-	      event.weight *= event.genInfo->weights().at(i);
-	  }
+        // Use first weight as the central weight, all others are actually
+        // variations e.g. scale, parton shower
+        event.weight = event.genInfo->weights().at(0);
     }
 
     bool keep = pimpl->analysis->process(event);


### PR DESCRIPTION
In new Fall17 PSweights samples (e.g. the ttbar ones) the nominal event weight is **not** the product of all weights in the GenInfo, but only the first entry. (if you multiply them all you get 10^34)
This fixes it so that the `event.weight` is only the first entry.

Was there a prior reason to use the product? Should that still be an option?

Ref links (with varying ages, none seem to be The Definite Uptodate Answer):

https://twiki.cern.ch/twiki/bin/viewauth/CMS/LHEReaderCMSSW
https://twiki.cern.ch/twiki/bin/view/CMS/ScaleAndPDFUncertaintiesFromEventWeights
https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideDataFormatGeneratorInterface