### PR TITLE
Remove loose JetID

### DIFF
--- a/common/include/JetIds.h
+++ b/common/include/JetIds.h
@@ -45,12 +45,11 @@ private:
  */
 class JetPFID {
  public:
-  enum wp {WP_LOOSE, WP_TIGHT, WP_TIGHT_LEPVETO};
+  enum wp {WP_TIGHT, WP_TIGHT_LEPVETO};
   explicit JetPFID(wp working_point);
   bool operator()(const Jet&, const uhh2::Event&) const;
  private:
   wp m_working_point;
-  bool looseID(const Jet & jet) const;
   bool tightID(const Jet & jet) const;
   bool tightLepVetoID(const Jet & jet) const;
 };

--- a/common/include/JetIds.h
+++ b/common/include/JetIds.h
@@ -40,27 +40,9 @@ private:
 
 
 /**
- * Jet Id following recomandations for 13 TeV:
- * https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetID
- *
- * For |eta|<=2.7 Apply
- * looseJetID = (NHF<0.99 && NEMF<0.99 && NumConst>1) && ((abs(eta)<=2.4 && CHF>0 && CHM>0 && CEMF<0.99) || abs(eta)>2.4) && abs(eta)<=3.0
- * tightJetID = (NHF<0.90 && NEMF<0.90 && NumConst>1) && ((abs(eta)<=2.4 && CHF>0 && CHM>0 && CEMF<0.99) || abs(eta)>2.4) && abs(eta)<=3.0
- * tightLepVetoJetID = (NHF<0.90 && NEMF<0.90 && NumConst>1 && MUF<0.8) && ((abs(eta)<=2.4 && CHF>0 && CHM>0 && CEMF<0.90) || abs(eta)>2.4) && abs(eta)<=3.0
- *
- * For |eta|>2.7 && |eta|<=3.0 Apply
- * looseJetID = (NEMF<0.90 && NumNeutralParticle>2 && abs(eta)>2.7 && abs(eta)<=3.0)
- * tightJetID = (NEMF<0.90 && NumNeutralParticle>2 && abs(eta)>2.7 && abs(eta)<=3.0)
- *
- * For |eta|> 3.0 Apply
- * looseJetID = (NEMF<0.90 && NumNeutralParticle>10 && abs(eta)>3.0 )
- * tightJetID = (NEMF<0.90 && NumNeutralParticle>10 && abs(eta)>3.0 ) 
- *
- *
- * once hf is understood may need to be changed!
+ * Jet Id following recomandations for 2017 13 TeV:
+ * https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetID13TeVRun2017
  */
-
-
 class JetPFID {
  public:
   enum wp {WP_LOOSE, WP_TIGHT, WP_TIGHT_LEPVETO};

--- a/common/src/CommonModules.cxx
+++ b/common/src/CommonModules.cxx
@@ -19,7 +19,7 @@ void CommonModules::fail_if_init() const{
 
 
 CommonModules::CommonModules(){
-  working_point = JetPFID::WP_LOOSE;
+  working_point = JetPFID::WP_TIGHT;
 }
 
 

--- a/common/src/JetIds.cxx
+++ b/common/src/JetIds.cxx
@@ -48,51 +48,22 @@ DeepCSVBTag::DeepCSVBTag(float float_point):deepcsv_threshold(float_point) {}
 bool DeepCSVBTag::operator()(const Jet & jet, const Event &) const{
     return jet.btag_DeepCSV() > deepcsv_threshold;
 }
+
+
 ///
 JetPFID::JetPFID(wp working_point):m_working_point(working_point){}
 
 bool JetPFID::operator()(const Jet & jet, const Event &) const{
   switch(m_working_point){
-  case WP_LOOSE:
-    return looseID(jet);
   case WP_TIGHT:
     return tightID(jet);
   case  WP_TIGHT_LEPVETO:
     return tightLepVetoID(jet);
   default:
-    throw invalid_argument("invalid working point passed to CSVBTag");
+    throw invalid_argument("invalid working point passed to JetPFID");
   }
   return false;
 }
-
-//not updated since 2016 recomandation
-bool JetPFID::looseID(const Jet & jet) const{
-  if(fabs(jet.eta())<=2.7
-     && jet.numberOfDaughters()>1 
-     && jet.neutralHadronEnergyFraction()<0.99
-     && jet.neutralEmEnergyFraction()<0.99){
-    
-    if(fabs(jet.eta())>=2.4)
-      return true;
-      
-    if(jet.chargedEmEnergyFraction()<0.99
-       && jet.chargedHadronEnergyFraction()>0
-       && jet.chargedMultiplicity()>0)
-      return true;   
-  }
-  else if(fabs(jet.eta())>2.7 && fabs(jet.eta())<=3
-	  &&jet.neutralEmEnergyFraction()<0.90
-	  &&jet.neutralMultiplicity()>2){
-    return true;
-  }
-  else if(fabs(jet.eta())>3
-	  && jet.neutralMultiplicity()>10
-	  && jet.neutralEmEnergyFraction()<0.90){
-    return true;
-  }
-  return false;
-}
-
 
 //according to https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetID13TeVRun2017
 bool JetPFID::tightID(const Jet & jet) const{

--- a/common/test/test_JER.cpp
+++ b/common/test/test_JER.cpp
@@ -47,7 +47,7 @@ test_JER::test_JER(uhh2::Context& ctx){
   ////
 
   //// OBJ CLEANING
-  const JetId jetID(JetPFID(JetPFID::WP_LOOSE));
+  const JetId jetID(JetPFID(JetPFID::WP_TIGHT));
 
   std::vector<std::string> JEC_AK4, JEC_AK8;
   if(isMC){

--- a/common/test/test_JLCkey.cpp
+++ b/common/test/test_JLCkey.cpp
@@ -51,7 +51,7 @@ test_JLCkey::test_JLCkey(uhh2::Context& ctx){
   ele_cleaner.reset(new ElectronCleaner(ele));
   //
 
-  const JetId jetID(JetPFID(JetPFID::WP_LOOSE));
+  const JetId jetID(JetPFID(JetPFID::WP_TIGHT));
 
   std::vector<std::string> JEC_AK4, JEC_AK8;
   if(isMC){


### PR DESCRIPTION
This removes the loose jet ID from the code as no longer recommended/supported, and replaces any occurrences with the Tight ID. Most importantly, this happens in `CommonModules`.

Also updated comments