### PR TITLE
Add doAllGenParticlesPythia8 to ntuplewriter py config [80X_v3]

### DIFF
--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -837,6 +837,7 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
         genparticle_source = cms.InputTag("prunedPrunedGenParticles"),
         stablegenparticle_source = cms.InputTag("packedGenParticles"),
         doAllGenParticles = cms.bool(False), #set to true if you want to store all gen particles, otherwise, only prunedPrunedGenParticles are stored (see above)
+        doAllGenParticlesPythia8 =  cms.bool(False), #set to true if you want to store all gen particles with pythia8 (see status codes in http://home.thep.lu.se/~torbjorn/pythia81html/ParticleProperties.html
         doGenJets = cms.bool(not useData),
         genjet_sources = cms.vstring("slimmedGenJets","slimmedGenJetsAK8","ca15GenJets"),
         genjet_ptmin = cms.double(10.0),


### PR DESCRIPTION
In 0f83af71cadabd93c56ef8af55a6066b2793f06b the `doAllGenParticlesPythia8` config param was added to NtupleWriter but not the `ntuplewriter.py` config. The config will fail to run; this fixes it.

This also needs to go into 80X_v4 and master branches.