### PR TITLE
Make HOTVR/XCONE producers look for reco::Candidate input

### DIFF
--- a/core/plugins/HOTVRProducer.cc
+++ b/core/plugins/HOTVRProducer.cc
@@ -30,7 +30,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 
-#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"
 #include "DataFormats/Math/interface/LorentzVector.h"
 
@@ -72,7 +72,7 @@ class HOTVRProducer : public edm::global::EDProducer<> {
 // constructors and destructor
 //
 HOTVRProducer::HOTVRProducer(const edm::ParameterSet& iConfig):
-  src_token_(consumes<edm::View<pat::PackedCandidate>>(iConfig.getParameter<edm::InputTag>("src"))),
+  src_token_(consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("src"))),
   subjetCollName_("SubJets")
 {
   // We make both the fat jets and subjets, and we must store them as separate collections
@@ -113,7 +113,7 @@ HOTVRProducer::produce(edm::StreamID id, edm::Event& iEvent, const edm::EventSet
   seeds[1] = std::max(runNum_uint, minSeed_ + 5) + 5 * evNum_uint;
   gas.set_random_status(seeds);
 
-  edm::Handle<edm::View<pat::PackedCandidate>> particles;
+  edm::Handle<edm::View<reco::Candidate>> particles;
   iEvent.getByToken(src_token_, particles);
 
   // Convert particles to PseudoJets

--- a/core/plugins/XConeProducer.cc
+++ b/core/plugins/XConeProducer.cc
@@ -30,7 +30,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 
-#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"
 
 #include "fastjet/ClusterSequence.hh"
@@ -80,7 +80,7 @@ class XConeProducer : public edm::global::EDProducer<> {
 // constructors and destructor
 //
 XConeProducer::XConeProducer(const edm::ParameterSet& iConfig):
-  src_token_(consumes<edm::View<pat::PackedCandidate>>(iConfig.getParameter<edm::InputTag>("src"))),
+  src_token_(consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("src"))),
   subjetCollName_("SubJets")
 {
   // We make both the fat jets and subjets, and we must store them as separate collections
@@ -121,7 +121,7 @@ XConeProducer::produce(edm::StreamID id, edm::Event& iEvent, const edm::EventSet
   seeds[1] = std::max(runNum_uint, minSeed_ + 5) + 5 * evNum_uint;
   gas.set_random_status(seeds);
 
-  edm::Handle<edm::View<pat::PackedCandidate>> particles;
+  edm::Handle<edm::View<reco::Candidate>> particles;
   iEvent.getByToken(src_token_, particles);
 
   if (particles->size() < 15) {


### PR DESCRIPTION
This allows them to be used with CHS input as well as PUPPI, PF.

(More technically: previously we only cared about `pat::PackedCandidate` inputs as that was the class for `packedPFCandidates` and `puppi`. But `chs` is produced by a `CandPtrSelector` (https://github.com/cms-sw/cmssw/blob/CMSSW_9_4_1/CommonTools/CandAlgos/plugins/CandPtrSelector.cc) as a `reco::Candidate` collection. Since `PackedCandidate` inherit from this, we'll just move to using `reco::Candidate` instead with no loss of information because we only care about px/py/px/e.)

