### PR TITLE
[80Xv5] Update XCone/HOTVR

### DIFF
--- a/core/include/GenTopJet.h
+++ b/core/include/GenTopJet.h
@@ -11,19 +11,19 @@ public:
 
   const std::vector<Particle> & subjets() const{return m_subjets;}
   void add_subjet(const Particle & p){m_subjets.push_back(p);}
-  const float tau1() const{return m_tau1;}
+  float tau1() const{return m_tau1;}
   void  set_tau1(float tau1){m_tau1=tau1;}
-  const float tau2() const{return m_tau2;}
+  float tau2() const{return m_tau2;}
   void  set_tau2(float tau2){m_tau2=tau2;}
-  const float tau3() const{return m_tau3;}
+  float tau3() const{return m_tau3;}
   void  set_tau3(float tau3){m_tau3=tau3;}
-  const double chf() const{return m_chf;}
+  double chf() const{return m_chf;}
   void  set_chf(double chf){m_chf=chf;}
-  const double cef() const{return m_cef;}
+  double cef() const{return m_cef;}
   void  set_cef(double cef){m_cef=cef;}
-  const double nhf() const{return m_nhf;}
+  double nhf() const{return m_nhf;}
   void  set_nhf(double nhf){m_nhf=nhf;}
-  const double nef() const{return m_nef;}
+  double nef() const{return m_nef;}
   void  set_nef(double nef){m_nef=nef;}
   
 private:

--- a/core/include/GenTopJet.h
+++ b/core/include/GenTopJet.h
@@ -5,6 +5,10 @@
 class GenTopJet : public Particle {
 public:
 
+  GenTopJet() {
+    m_tau1 = m_tau2 = m_tau3 = m_chf = m_cef = m_nhf = m_nef = -1.0;
+  }
+
   const std::vector<Particle> & subjets() const{return m_subjets;}
   void add_subjet(const Particle & p){m_subjets.push_back(p);}
   const float tau1() const{return m_tau1;}

--- a/core/plugins/HOTVRProducer.cc
+++ b/core/plugins/HOTVRProducer.cc
@@ -30,7 +30,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 
-#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"
 #include "DataFormats/Math/interface/LorentzVector.h"
 
@@ -74,7 +74,7 @@ class HOTVRProducer : public edm::stream::EDProducer<> {
 // constructors and destructor
 //
 HOTVRProducer::HOTVRProducer(const edm::ParameterSet& iConfig):
-  src_token_(consumes<edm::View<pat::PackedCandidate>>(iConfig.getParameter<edm::InputTag>("src"))),
+  src_token_(consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("src"))),
   subjetCollName_("SubJets")
 {
   // We make both the fat jets and subjets, and we must store them as separate collections
@@ -115,7 +115,7 @@ HOTVRProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   seeds[1] = std::max(runNum_uint, minSeed_ + 5) + 5 * evNum_uint;
   gas.set_random_status(seeds);
 
-  edm::Handle<edm::View<pat::PackedCandidate>> particles;
+  edm::Handle<edm::View<reco::Candidate>> particles;
   iEvent.getByToken(src_token_, particles);
 
   // Convert particles to PseudoJets

--- a/core/plugins/HOTVRProducer.cc
+++ b/core/plugins/HOTVRProducer.cc
@@ -104,15 +104,15 @@ HOTVRProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   // Convert particles to PseudoJets
   std::vector<PseudoJet> _psj;
   for (const auto & cand: *particles) {
-    if (std::isnan(cand.p4().Px()) || 
-        std::isnan(cand.p4().Py()) || 
-        std::isnan(cand.p4().Pz()) || 
-        std::isinf(cand.p4().Px()) || 
-        std::isinf(cand.p4().Py()) ||
-        std::isinf(cand.p4().Pz()))
+    if (std::isnan(cand.px()) ||
+        std::isnan(cand.py()) ||
+        std::isnan(cand.pz()) ||
+        std::isinf(cand.px()) ||
+        std::isinf(cand.py()) ||
+        std::isinf(cand.pz()))
       continue;
 
-    _psj.push_back(PseudoJet(cand.p4().X(), cand.p4().Y(), cand.p4().Z(), cand.p4().T()));
+    _psj.push_back(PseudoJet(cand.px(), cand.py(), cand.pz(), cand.energy()));
   }
 
   // Do the clustering, make jets, nsub, store

--- a/core/plugins/HOTVRProducer.cc
+++ b/core/plugins/HOTVRProducer.cc
@@ -273,7 +273,7 @@ HOTVRProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 pat::Jet HOTVRProducer::createPatJet(const PseudoJet & psj)
 {
   pat::Jet newJet;
-  newJet.setP4(math::XYZTLorentzVector(psj.pt(), psj.eta(), psj.phi(), psj.E()));
+  newJet.setP4(math::XYZTLorentzVector(psj.px(), psj.py(), psj.pz(), psj.E()));
   return newJet;
 }
 

--- a/core/plugins/HOTVRProducer.cc
+++ b/core/plugins/HOTVRProducer.cc
@@ -1,0 +1,277 @@
+// -*- C++ -*-
+//
+// Package:    UHH2/HOTVRProducer
+// Class:      HOTVRProducer
+//
+/**\class HOTVRProducer HOTVRProducer.cc UHH2/HOTVRProducer/plugins/HOTVRProducer.cc
+
+ Description: [one line class summary]
+
+ Implementation:
+    [Notes on implementation]
+*/
+//
+// Original Author:  Robin Aggleton
+//         Created:  Tue, 23 Jan 2018 13:27:50 GMT
+//
+//
+
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "DataFormats/PatCandidates/interface/Jet.h"
+#include "DataFormats/Math/interface/LorentzVector.h"
+
+#include "fastjet/ClusterSequence.hh"
+#include "fastjet/ClusterSequenceArea.hh"
+#include "fastjet/contrib/HOTVR.hh"
+#include "fastjet/contrib/HOTVRinfo.hh"
+#include "fastjet/contrib/Nsubjettiness.hh"
+#include "fastjet/contrib/XConePlugin.hh"
+#include "fastjet/contrib/SoftDrop.hh"
+
+#include "vector"
+
+using namespace fastjet;
+using namespace contrib;
+
+//
+// class declaration
+//
+
+class HOTVRProducer : public edm::stream::EDProducer<> {
+  public:
+    explicit HOTVRProducer(const edm::ParameterSet&);
+    ~HOTVRProducer();
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  private:
+    virtual void beginStream(edm::StreamID) override;
+    virtual void produce(edm::Event&, const edm::EventSetup&) override;
+    virtual void endStream() override;
+
+    virtual pat::Jet createPatJet(const PseudoJet &);
+    virtual pat::Jet createPatJet(const PseudoJet &, const std::vector<PseudoJet> &, double, double, double, double, std::vector<double>);
+
+    // ----------member data ---------------------------
+    edm::EDGetToken src_token_;
+};
+
+//
+// constructors and destructor
+//
+HOTVRProducer::HOTVRProducer(const edm::ParameterSet& iConfig):
+  src_token_(consumes<edm::View<pat::PackedCandidate>>(iConfig.getParameter<edm::InputTag>("src")))
+{
+  produces<pat::JetCollection>();
+}
+
+
+HOTVRProducer::~HOTVRProducer()
+{
+
+  // do anything here that needs to be done at destruction time
+  // (e.g. close files, deallocate resources etc.)
+
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+void
+HOTVRProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+
+  edm::Handle<edm::View<pat::PackedCandidate>> particles;
+  iEvent.getByToken(src_token_, particles);
+
+  // Convert particles to PseudoJets
+  std::vector<PseudoJet> _psj;
+  for (const auto & cand: *particles) {
+    if (std::isnan(cand.p4().Px()) || 
+        std::isnan(cand.p4().Py()) || 
+        std::isnan(cand.p4().Pz()) || 
+        std::isinf(cand.p4().Px()) || 
+        std::isinf(cand.p4().Py()) ||
+        std::isinf(cand.p4().Pz()))
+      continue;
+
+    _psj.push_back(PseudoJet(cand.p4().X(), cand.p4().Y(), cand.p4().Z(), cand.p4().T()));
+  }
+
+  // Do the clustering, make jets, nsub, store
+  double mu(30.),                      // massjump threshold
+         theta(0.7),                   // massjump parameter
+         max_r(1.5),                   // maximum allowed distance R
+         min_r(0.1),                   // minimum allowed distance R
+         rho(600.),                    // cone shrinking parameter
+         hotvr_pt_min(30.);            // minimum pT of subjet
+
+  // jet definition with HOTVR plugin
+  HOTVR hotvr_plugin(mu, theta, min_r, max_r, rho, hotvr_pt_min, HOTVR::CALIKE);
+  JetDefinition jet_def(&hotvr_plugin);
+
+   // Setup cluster sequence
+  ClusterSequence cs(_psj, jet_def);
+  vector<PseudoJet> hotvr_jets = hotvr_plugin.get_jets();
+
+  // NOTE: There is a problem when getting Nsubjettiness directly
+  // from HOTVR jets, because the link to the cluster sequence got lost
+  // somehow. Thus the approach here will be to identify the Jets from
+  // the cluster sequence with the hotvr_jets by comparing their
+  // four-vectors.
+
+  // area definition
+  double ghost_maxrap = 4.0;      // maxiumum y of ghost particles
+  AreaDefinition area_def(active_area_explicit_ghosts, GhostedAreaSpec(ghost_maxrap, 1, 0.02));
+
+  // setup cluster sequence with area
+  HOTVR hotvr_plugin_area(mu, theta, min_r, max_r, rho, hotvr_pt_min, HOTVR::CALIKE);
+  JetDefinition jet_def_area(&hotvr_plugin_area);
+  ClusterSequenceArea cs_area(_psj, jet_def_area, area_def);
+  vector<PseudoJet> hotvr_jets_area = hotvr_plugin_area.get_jets();
+
+  //in a few cases, there are jets in the original clustering without a corresponding jet in the area clustering
+  //->add a dummy jet into the area collection and throw a warning because we cannot determine the area for these jets
+  if (hotvr_jets_area.size() != hotvr_jets.size()) {
+
+    for (unsigned int i = 0; i < hotvr_jets.size(); ++i) {
+        bool matched = false;
+        for (unsigned int j = 0; j < hotvr_jets_area.size(); ++j) {
+            if( fabs(hotvr_jets[i].pt() - hotvr_jets_area[j].pt())<0.0001 &&
+                fabs(hotvr_jets[i].eta() - hotvr_jets_area[j].eta())<0.0001) {
+              matched = true;
+              break;
+            }
+        }
+
+        if(!matched) {
+          PseudoJet dummy_jet(0, 0, 0, 0);
+          hotvr_jets_area.insert(hotvr_jets_area.begin()+i, dummy_jet);
+        }
+      }
+
+    //sometimes, there are more jets in the area clustering
+    //->filter out jets from the area collection which are not matched to any jet in the original clustering
+    for (unsigned int i = 0; i < hotvr_jets_area.size(); ++i) {
+        //skip dummy jets from previous iteration
+        if (hotvr_jets_area[i].pt() == 0) continue;
+
+        bool matched=false;
+        for (unsigned int j = 0; j < hotvr_jets.size(); ++j) {
+            if( fabs(hotvr_jets[j].pt() - hotvr_jets_area[i].pt())<0.0001 &&
+                fabs(hotvr_jets[j].eta() - hotvr_jets_area[i].eta())<0.0001) {
+              matched = true;
+              break;
+            }
+        }
+        if(!matched) {
+          hotvr_jets_area.erase(hotvr_jets_area.begin()+i);
+          i--;
+        }
+    }
+  }
+
+  if (hotvr_jets_area.size() != hotvr_jets.size()) {
+    throw cms::Exception("MismatchedSizes", "Number of HOTVR jets found with ClusterSequence does not match number of jets with ClusterSequenceArea.");
+  }
+
+  auto outputJets = std::make_unique<pat::JetCollection>();
+
+  for (unsigned int i = 0; i < hotvr_jets.size(); ++i) {
+    double beta = 1.0;
+    HOTVRinfo hi = hotvr_jets[i].user_info<HOTVRinfo>();
+    Nsubjettiness nSub1(1, OnePass_WTA_KT_Axes(), NormalizedMeasure(beta, hi.max_distance()));
+    Nsubjettiness nSub2(2, OnePass_WTA_KT_Axes(), NormalizedMeasure(beta, hi.max_distance()));
+    Nsubjettiness nSub3(3, OnePass_WTA_KT_Axes(), NormalizedMeasure(beta, hi.max_distance()));
+    double tau1 = nSub1(hotvr_jets[i]);
+    double tau2 = nSub2(hotvr_jets[i]);
+    double tau3 = nSub3(hotvr_jets[i]);
+
+    // getting jet and subjet area
+    double jet_area = 0;
+    std::vector<double> subjet_area;
+    std::vector<PseudoJet> subjets;
+    if (hotvr_jets_area[i].pt()>0) {
+      jet_area = hotvr_jets_area[i].area();
+      HOTVRinfo hi_area = hotvr_jets_area[i].user_info<HOTVRinfo>();
+      subjets = hi_area.subjets();
+      for (unsigned int j = 0; j < subjets.size(); ++j) {
+        subjet_area.push_back(subjets[j].area());
+      }
+    } else {
+      subjets = hi.subjets();
+      for (unsigned int j = 0; j < subjets.size(); ++j) {
+        subjet_area.push_back(0);
+      }
+      edm::LogWarning("NoJetArea") << "HOTVRProducer: could not find area jet for a HOTVR jet; set area and subjet areas to 0.";
+    }
+    outputJets->push_back(createPatJet(hotvr_jets[i], subjets, tau1, tau2, tau3, jet_area, subjet_area));
+  }
+
+  iEvent.put(std::move(outputJets));
+}
+
+pat::Jet HOTVRProducer::createPatJet(const PseudoJet & psj)
+{
+  pat::Jet newJet;
+  newJet.setP4(math::XYZTLorentzVector(psj.pt(), psj.eta(), psj.phi(), psj.E()));
+  return newJet;
+}
+
+pat::Jet HOTVRProducer::createPatJet(const PseudoJet & psj, const std::vector<PseudoJet> &subpsj, double tau1, double tau2, double tau3, double jet_area, std::vector<double> subjet_area)
+{
+  pat::Jet newJet = createPatJet(psj);
+  newJet.setJetArea(jet_area);
+  newJet.addUserFloat("tau1", tau1);
+  newJet.addUserFloat("tau2", tau2);
+  newJet.addUserFloat("tau3", tau3);
+
+  for (uint i=0; i<subpsj.size(); i++) {
+    pat::Jet subjet = createPatJet(subpsj[i]);
+    subjet.setJetArea(subjet_area[i]);
+  }
+
+  return newJet;
+}
+
+
+// ------------ method called once each stream before processing any runs, lumis or events  ------------
+void
+HOTVRProducer::beginStream(edm::StreamID)
+{
+}
+
+// ------------ method called once each stream after processing all runs, lumis and events  ------------
+void
+HOTVRProducer::endStream() {
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+HOTVRProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(HOTVRProducer);

--- a/core/plugins/HOTVRProducer.cc
+++ b/core/plugins/HOTVRProducer.cc
@@ -100,6 +100,20 @@ HOTVRProducer::~HOTVRProducer()
 void
 HOTVRProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
+  // Set the fastjet random seed to a deterministic function
+  // of the run/lumi/event.
+  // NOTE!!! The fastjet random number sequence is a global singleton.
+  // Thus, we have to create an object and get access to the global singleton
+  // in order to change it.
+  // Taken from VirtualJetProducer
+  fastjet::GhostedAreaSpec gas;
+  std::vector<int> seeds(2);
+  unsigned int runNum_uint = static_cast <unsigned int> (iEvent.id().run());
+  unsigned int evNum_uint = static_cast <unsigned int> (iEvent.id().event());
+  uint minSeed_ = 14327;
+  seeds[0] = std::max(runNum_uint, minSeed_ + 3) + 3 * evNum_uint;
+  seeds[1] = std::max(runNum_uint, minSeed_ + 5) + 5 * evNum_uint;
+  gas.set_random_status(seeds);
 
   edm::Handle<edm::View<pat::PackedCandidate>> particles;
   iEvent.getByToken(src_token_, particles);

--- a/core/plugins/HOTVRProducer.cc
+++ b/core/plugins/HOTVRProducer.cc
@@ -112,7 +112,8 @@ HOTVRProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
         std::isnan(cand.pz()) ||
         std::isinf(cand.px()) ||
         std::isinf(cand.py()) ||
-        std::isinf(cand.pz()))
+        std::isinf(cand.pz()) ||
+        (cand.pt() == 0))
       continue;
 
     _psj.push_back(PseudoJet(cand.px(), cand.py(), cand.pz(), cand.energy()));

--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -552,7 +552,7 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
   }
   if(doGenInfo){
     genparticle_token = consumes<reco::GenParticleCollection>(iConfig.getParameter<edm::InputTag>("genparticle_source"));
-    if(doAllGenParticles) stablegenparticle_token = consumes<edm::View<pat::PackedGenParticle> >(iConfig.getParameter<edm::InputTag>("stablegenparticle_source"));
+    if(doAllGenParticles) stablegenparticle_token = consumes<edm::View<reco::Candidate> >(iConfig.getParameter<edm::InputTag>("stablegenparticle_source"));
     event->genInfo = new GenInfo();
     event->genparticles = new vector<GenParticle>();
     branch(tr, "genInfo","GenInfo", event->genInfo);
@@ -606,7 +606,7 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
   // GenJets
   if(doGenHOTVR || doGenXCone)
     {
-      stablegenparticle_token = consumes<edm::View<pat::PackedGenParticle> >(iConfig.getParameter<edm::InputTag>("stablegenparticle_source"));
+      stablegenparticle_token = consumes<edm::View<reco::Candidate> >(iConfig.getParameter<edm::InputTag>("stablegenparticle_source"));
      if(doGenHOTVR)
 	{      
 	  branch(tr, "genHOTVRTopJets", "std::vector<GenTopJet>", &genhotvrJets);
@@ -831,13 +831,14 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
      
      //store stable gen particles from packed collection
      if(doAllGenParticles){
-       edm::Handle<edm::View<pat::PackedGenParticle> > packed;
+       edm::Handle<edm::View<reco::Candidate> > packed;
        // use packed particle collection for all STABLE (status 1) particles
        iEvent.getByToken(stablegenparticle_token,packed);
 
        for(size_t j=0; j<packed->size();j++){
 	 bool skip_particle = false;
-	 const pat::PackedGenParticle* iter = &(*packed)[j];
+	 const pat::PackedGenParticle* iter = dynamic_cast<const pat::PackedGenParticle*>(&(packed->at(j)));
+
 	 //	 if(iter->status()!=1) cout<<"iter->status() = "<<iter->status()<<endl;
 	 if(doAllGenParticlesPythia8){//for pythia8: store particles with status code, see http://home.thep.lu.se/~torbjorn/pythia81html/ParticleProperties.html
 	   if(iter->status()<2)
@@ -1390,13 +1391,12 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
   if(doGenHOTVR || doGenXCone)
      {
-       edm::Handle<edm::View<pat::PackedGenParticle> > packed;
+       edm::Handle<edm::View<reco::Candidate> > packed;
        // use packed particle collection for all STABLE (status 1) particles
        iEvent.getByToken(stablegenparticle_token,packed);
        vector<GenParticle> genparticles;
        for(size_t j=0; j<packed->size();j++){
-
-	 const pat::PackedGenParticle* iter = &(*packed)[j];
+  const pat::PackedGenParticle* iter = dynamic_cast<const pat::PackedGenParticle*>(&(packed->at(j)));
 	 if(iter->status()!=1) continue;
 
 	 GenParticle genp;

--- a/core/plugins/NtupleWriter.h
+++ b/core/plugins/NtupleWriter.h
@@ -18,8 +18,7 @@
 
 #include <memory>
 
-// Jet Cluster for HOTVR & XCone by Alex and Dennis
-#include "UHH2/core/include/UniversalJetCluster.h"
+// GenJet Cluster for HOTVR & XCone by Alex and Dennis
 #include "UHH2/core/include/UniversalGenJetCluster.h"
 
 namespace uhh2 {
@@ -140,14 +139,12 @@ class NtupleWriter : public edm::EDFilter {
 
       std::vector<edm::EDGetToken> hotvr_tokens;
       std::vector<edm::EDGetToken> hotvr_subjet_tokens;
-      std::vector<std::vector<TopJet>> newHotvrJets;
+      std::vector<std::vector<TopJet>> hotvrJets;
 
       std::vector<edm::EDGetToken> xcone_tokens;
       std::vector<edm::EDGetToken> xcone_subjet_tokens;
-      std::vector<std::vector<TopJet>> newXConeJets;
+      std::vector<std::vector<TopJet>> xconeJets;
 
-      std::vector<TopJet> hotvrJets;
-      std::vector<TopJet> xconeJets;
       std::vector<GenTopJet> genhotvrJets;
       std::vector<GenTopJet> genxcone33Jets;
       std::vector<GenTopJet> genxcone33Jets_softdrop;

--- a/core/plugins/NtupleWriter.h
+++ b/core/plugins/NtupleWriter.h
@@ -138,6 +138,14 @@ class NtupleWriter : public edm::EDFilter {
 
       std::vector<bool> puppi;
 
+      std::vector<edm::EDGetToken> hotvr_tokens;
+      std::vector<edm::EDGetToken> hotvr_subjet_tokens;
+      std::vector<std::vector<TopJet>> newHotvrJets;
+
+      std::vector<edm::EDGetToken> xcone_tokens;
+      std::vector<edm::EDGetToken> xcone_subjet_tokens;
+      std::vector<std::vector<TopJet>> newXConeJets;
+
       std::vector<TopJet> hotvrJets;
       std::vector<TopJet> xconeJets;
       std::vector<GenTopJet> genhotvrJets;

--- a/core/plugins/XConeProducer.cc
+++ b/core/plugins/XConeProducer.cc
@@ -1,0 +1,252 @@
+// -*- C++ -*-
+//
+// Package:    UHH2/XConeProducer
+// Class:      XConeProducer
+//
+/**\class XConeProducer XConeProducer.cc UHH2/XConeProducer/plugins/XConeProducer.cc
+
+ Description: [one line class summary]
+
+ Implementation:
+    [Notes on implementation]
+*/
+//
+// Original Author:  Robin Aggleton
+//         Created:  Tue, 23 Jan 2018 13:27:56 GMT
+//
+//
+
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "DataFormats/PatCandidates/interface/Jet.h"
+
+#include "fastjet/ClusterSequence.hh"
+#include "fastjet/ClusterSequenceArea.hh"
+#include "fastjet/contrib/HOTVR.hh"
+#include "fastjet/contrib/HOTVRinfo.hh"
+#include "fastjet/contrib/Nsubjettiness.hh"
+#include "fastjet/contrib/XConePlugin.hh"
+#include "fastjet/contrib/SoftDrop.hh"
+
+#include "vector"
+
+using namespace fastjet;
+using namespace contrib;
+
+//
+// class declaration
+//
+
+class XConeProducer : public edm::stream::EDProducer<> {
+  public:
+    explicit XConeProducer(const edm::ParameterSet&);
+    ~XConeProducer();
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  private:
+    virtual void beginStream(edm::StreamID) override;
+    virtual void produce(edm::Event&, const edm::EventSetup&) override;
+    virtual void endStream() override;
+    
+    virtual pat::Jet createPatJet(const fastjet::PseudoJet &);
+    virtual pat::Jet createPatJet(const fastjet::PseudoJet & , const std::vector<fastjet::PseudoJet> &, double , std::vector<double>, float);
+
+    // ----------member data ---------------------------
+    edm::EDGetToken src_token_;
+
+    // ----------member data ---------------------------
+};
+
+//
+// constants, enums and typedefs
+//
+
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+XConeProducer::XConeProducer(const edm::ParameterSet& iConfig):
+  src_token_(consumes<edm::View<pat::PackedCandidate>>(iConfig.getParameter<edm::InputTag>("src")))
+{
+  produces<pat::JetCollection>();
+}
+
+
+XConeProducer::~XConeProducer()
+{
+
+  // do anything here that needs to be done at destruction time
+  // (e.g. close files, deallocate resources etc.)
+
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+void
+XConeProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+  edm::Handle<std::vector<pat::PackedCandidate>> particles;
+  iEvent.getByToken(src_token_, particles);
+
+
+  if (particles->size() < 15) {
+    auto outputJets = std::make_unique<pat::JetCollection>();
+    iEvent.put(std::move(outputJets));
+    return;
+  }
+
+  // Convert particles to PseudoJets
+  std::vector<PseudoJet> _psj;
+  for (const auto & cand: *particles) {
+    if (std::isnan(cand.p4().Px()) ||
+        std::isnan(cand.p4().Py()) ||
+        std::isnan(cand.p4().Pz()) ||
+        std::isinf(cand.p4().Px()) ||
+        std::isinf(cand.p4().Py()) ||
+        std::isinf(cand.p4().Pz()))
+      continue;
+
+    _psj.push_back(PseudoJet(cand.p4().X(), cand.p4().Y(), cand.p4().Z(), cand.p4().T()));
+  }
+
+  // Run first clustering step (N=2, R=1.2)
+  vector<PseudoJet> fatjets;
+  XConePlugin plugin_xcone(2, 1.2, 2.0);
+  double ghost_maxrap = 4.0;      // maxiumum y of ghost particles
+  AreaDefinition area_def(active_area, GhostedAreaSpec(ghost_maxrap));
+  JetDefinition jet_def_xcone(&plugin_xcone);
+  ClusterSequence clust_seq_xcone(_psj, jet_def_xcone);
+  fatjets = sorted_by_pt(clust_seq_xcone.inclusive_jets(0));
+
+  // get SoftDrop Mass
+  SoftDrop sd(0.0, 0.1, 1.2);
+  PseudoJet sdjet1 = sd(fatjets[0]);
+  PseudoJet sdjet2 = sd(fatjets[1]);
+  float sd_mass1 = sdjet1.m();
+  float sd_mass2 = sdjet2.m();
+
+  // get and wirte list: if particle i is clustered in jet j, the i-th entry of the list == j
+  vector<int> list_fat;
+  list_fat.clear();
+  list_fat = clust_seq_xcone.particle_jet_indices(fatjets);
+  vector<PseudoJet> particle_in_fat1, particle_in_fat2;
+
+  // get one set of particles for each jet
+  for (unsigned int ipart=0; ipart < _psj.size(); ++ipart) {
+    if (list_fat[ipart]==0) {
+      particle_in_fat1.push_back(_psj.at(ipart)); // get vector as PseudoJet for fatjet 1
+    }
+    if (list_fat[ipart]==1) {
+      particle_in_fat2.push_back(_psj.at(ipart)); // get vector as PseudoJet for fatjet 2
+    }
+  }
+
+  if(particle_in_fat1.size() < 3 || particle_in_fat2.size()<3) {
+    cms::Exception("InsufficientParticles", 
+                   "Not enough particles to run second XCone step");
+  }
+
+  // Run second clustering step (N=3, R=0.4) for each fat jet
+  vector<PseudoJet> subjets_1, subjets_2;
+
+  // subjets from fat jet 1
+  XConePlugin plugin_xcone_sub1(3, 0.4, 2.0);
+  JetDefinition jet_def_sub1(&plugin_xcone_sub1);
+  ClusterSequenceArea clust_seq_sub1(particle_in_fat1, jet_def_sub1, area_def);
+  subjets_1 = sorted_by_pt(clust_seq_sub1.inclusive_jets(0));
+
+  //subjets from fat jet 2
+  XConePlugin plugin_xcone_sub2(3, 0.4, 2.0);
+  JetDefinition jet_def_sub2(&plugin_xcone_sub2);
+  ClusterSequenceArea clust_seq_sub2(particle_in_fat2, jet_def_sub2, area_def);
+  subjets_2 = sorted_by_pt(clust_seq_sub2.inclusive_jets(0));
+
+  // set TopJets with subjets and JetArea
+
+  //double jet1_area = fatjets[0].area();
+  //double jet2_area = fatjets[1].area();
+  vector<double> subjet1_area;
+  vector<double> subjet2_area;
+  for (unsigned int j = 0; j < subjets_1.size(); ++j) subjet1_area.push_back(subjets_1[j].area());
+  for (unsigned int k = 0; k < subjets_2.size(); ++k) subjet2_area.push_back(subjets_2[k].area());
+
+  double jet1_area = 0;
+  double jet2_area = 0;
+  /*
+  vector<double> subjet1_area;
+  vector<double> subjet2_area;
+  for (unsigned int j = 0; j < subjets_1.size(); ++j) subjet1_area.push_back(0.);
+  for (unsigned int k = 0; k < subjets_2.size(); ++k) subjet2_area.push_back(0.);
+  */
+  auto outputJets = std::make_unique<pat::JetCollection>();
+  outputJets->push_back(createPatJet(fatjets[0], subjets_1, jet1_area, subjet1_area, sd_mass1));
+  outputJets->push_back(createPatJet(fatjets[1], subjets_2, jet2_area, subjet2_area, sd_mass2));
+  iEvent.put(std::move(outputJets));
+}
+
+pat::Jet XConeProducer::createPatJet(const PseudoJet & psj)
+{
+  pat::Jet newJet;
+  newJet.setP4(math::XYZTLorentzVector(psj.pt(), psj.eta(), psj.phi(), psj.E()));
+  return newJet;
+}
+
+pat::Jet XConeProducer::createPatJet(const PseudoJet & psj, const vector<PseudoJet> &subpsj, double jet_area, vector<double> subjet_area, float sd_mass)
+{
+  pat::Jet newJet = createPatJet(psj);
+  newJet.setJetArea(jet_area);
+  newJet.addUserFloat("softdropmass", sd_mass);
+  for (uint i=0; i<subpsj.size(); i++) {
+    pat::Jet subjet = createPatJet(subpsj[i]);
+    subjet.setJetArea(subjet_area[i]);
+  }
+
+  return newJet;
+}
+
+// ------------ method called once each stream before processing any runs, lumis or events  ------------
+void
+XConeProducer::beginStream(edm::StreamID)
+{
+}
+
+// ------------ method called once each stream after processing all runs, lumis and events  ------------
+void
+XConeProducer::endStream() {
+}
+
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+XConeProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(XConeProducer);

--- a/core/plugins/XConeProducer.cc
+++ b/core/plugins/XConeProducer.cc
@@ -108,6 +108,21 @@ XConeProducer::~XConeProducer()
 void
 XConeProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
+  // Set the fastjet random seed to a deterministic function
+  // of the run/lumi/event.
+  // NOTE!!! The fastjet random number sequence is a global singleton.
+  // Thus, we have to create an object and get access to the global singleton
+  // in order to change it.
+  // Taken from VirtualJetProducer
+  fastjet::GhostedAreaSpec gas;
+  std::vector<int> seeds(2);
+  unsigned int runNum_uint = static_cast <unsigned int> (iEvent.id().run());
+  unsigned int evNum_uint = static_cast <unsigned int> (iEvent.id().event());
+  uint minSeed_ = 14327;
+  seeds[0] = std::max(runNum_uint, minSeed_ + 3) + 3 * evNum_uint;
+  seeds[1] = std::max(runNum_uint, minSeed_ + 5) + 5 * evNum_uint;
+  gas.set_random_status(seeds);
+
   edm::Handle<edm::View<pat::PackedCandidate>> particles;
   iEvent.getByToken(src_token_, particles);
 

--- a/core/plugins/XConeProducer.cc
+++ b/core/plugins/XConeProducer.cc
@@ -127,7 +127,8 @@ XConeProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
         std::isnan(cand.pz()) ||
         std::isinf(cand.px()) ||
         std::isinf(cand.py()) ||
-        std::isinf(cand.pz()))
+        std::isinf(cand.pz()) ||
+        (cand.pt() == 0))
       continue;
 
     _psj.push_back(PseudoJet(cand.px(), cand.py(), cand.pz(), cand.energy()));

--- a/core/plugins/XConeProducer.cc
+++ b/core/plugins/XConeProducer.cc
@@ -63,10 +63,12 @@ class XConeProducer : public edm::stream::EDProducer<> {
     virtual void endStream() override;
 
     virtual pat::Jet createPatJet(const fastjet::PseudoJet &);
+    virtual void initPlugin(std::unique_ptr<NjettinessPlugin> & ptr, int N, double R0, double beta, bool usePseudoXCone);
 
     // ----------member data ---------------------------
     edm::EDGetToken src_token_;
     const std::string subjetCollName_;
+    const bool usePseudoXCone_;
 };
 
 //
@@ -83,7 +85,8 @@ class XConeProducer : public edm::stream::EDProducer<> {
 //
 XConeProducer::XConeProducer(const edm::ParameterSet& iConfig):
   src_token_(consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("src"))),
-  subjetCollName_("SubJets")
+  subjetCollName_("SubJets"),
+  usePseudoXCone_(iConfig.getParameter<bool>("usePseudoXCone"))
 {
   // We make both the fat jets and subjets, and we must store them as separate collections
   produces<pat::JetCollection>();
@@ -103,6 +106,19 @@ XConeProducer::~XConeProducer()
 //
 // member functions
 //
+
+// Setup either XConePlugin or PseudoXConePlugin and assign to ptr
+// Use NjettinessPlugin as it is the base class of both XConePlugin and PseudoXConePlugin
+void
+XConeProducer::initPlugin(std::unique_ptr<NjettinessPlugin> & ptr, int N, double R0, double beta, bool usePseudoXCone)
+{
+  if (usePseudoXCone) {
+    ptr.reset(new PseudoXConePlugin(N, R0, beta));
+  } else {
+    ptr.reset(new XConePlugin(N, R0, beta));
+  }
+}
+
 
 // ------------ method called to produce the data  ------------
 void
@@ -151,10 +167,11 @@ XConeProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
   // Run first clustering step (N=2, R=1.2)
   vector<PseudoJet> fatjets;
-  PseudoXConePlugin plugin_xcone(2, 1.2, 2.0);
+  std::unique_ptr<NjettinessPlugin> plugin_xcone;
+  initPlugin(plugin_xcone, 2, 1.2, 2.0, usePseudoXCone_);
   double ghost_maxrap = 4.0;      // maxiumum y of ghost particles
   AreaDefinition area_def(active_area, GhostedAreaSpec(ghost_maxrap));
-  JetDefinition jet_def_xcone(&plugin_xcone);
+  JetDefinition jet_def_xcone(plugin_xcone.get());
   ClusterSequence clust_seq_xcone(_psj, jet_def_xcone);
   fatjets = sorted_by_pt(clust_seq_xcone.inclusive_jets(0));
 
@@ -189,14 +206,16 @@ XConeProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   vector<PseudoJet> subjets_1, subjets_2;
 
   // subjets from fat jet 1
-  PseudoXConePlugin plugin_xcone_sub1(3, 0.4, 2.0);
-  JetDefinition jet_def_sub1(&plugin_xcone_sub1);
+  std::unique_ptr<NjettinessPlugin> plugin_xcone_sub1;
+  initPlugin(plugin_xcone_sub1, 3, 0.4, 2.0, usePseudoXCone_);
+  JetDefinition jet_def_sub1(plugin_xcone_sub1.get());
   ClusterSequenceArea clust_seq_sub1(particle_in_fat1, jet_def_sub1, area_def);
   subjets_1 = sorted_by_pt(clust_seq_sub1.inclusive_jets(0));
 
   //subjets from fat jet 2
-  PseudoXConePlugin plugin_xcone_sub2(3, 0.4, 2.0);
-  JetDefinition jet_def_sub2(&plugin_xcone_sub2);
+  std::unique_ptr<NjettinessPlugin> plugin_xcone_sub2;
+  initPlugin(plugin_xcone_sub2, 3, 0.4, 2.0, usePseudoXCone_);
+  JetDefinition jet_def_sub2(plugin_xcone_sub2.get());
   ClusterSequenceArea clust_seq_sub2(particle_in_fat2, jet_def_sub2, area_def);
   subjets_2 = sorted_by_pt(clust_seq_sub2.inclusive_jets(0));
 

--- a/core/plugins/XConeProducer.cc
+++ b/core/plugins/XConeProducer.cc
@@ -110,25 +110,26 @@ XConeProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   edm::Handle<std::vector<pat::PackedCandidate>> particles;
   iEvent.getByToken(src_token_, particles);
 
-
   if (particles->size() < 15) {
-    auto outputJets = std::make_unique<pat::JetCollection>();
-    iEvent.put(std::move(outputJets));
+    auto jetCollection = std::make_unique<pat::JetCollection>();
+    iEvent.put(std::move(jetCollection));
+    auto subjetCollection = std::make_unique<pat::JetCollection>();
+    iEvent.put(std::move(subjetCollection), subjetCollName_);
     return;
   }
 
   // Convert particles to PseudoJets
   std::vector<PseudoJet> _psj;
   for (const auto & cand: *particles) {
-    if (std::isnan(cand.p4().Px()) ||
-        std::isnan(cand.p4().Py()) ||
-        std::isnan(cand.p4().Pz()) ||
-        std::isinf(cand.p4().Px()) ||
-        std::isinf(cand.p4().Py()) ||
-        std::isinf(cand.p4().Pz()))
+    if (std::isnan(cand.px()) ||
+        std::isnan(cand.py()) ||
+        std::isnan(cand.pz()) ||
+        std::isinf(cand.px()) ||
+        std::isinf(cand.py()) ||
+        std::isinf(cand.pz()))
       continue;
 
-    _psj.push_back(PseudoJet(cand.p4().X(), cand.p4().Y(), cand.p4().Z(), cand.p4().T()));
+    _psj.push_back(PseudoJet(cand.px(), cand.py(), cand.pz(), cand.energy()));
   }
 
   // Run first clustering step (N=2, R=1.2)

--- a/core/plugins/XConeProducer.cc
+++ b/core/plugins/XConeProducer.cc
@@ -30,7 +30,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 
-#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"
 
 #include "fastjet/ClusterSequence.hh"
@@ -82,7 +82,7 @@ class XConeProducer : public edm::stream::EDProducer<> {
 // constructors and destructor
 //
 XConeProducer::XConeProducer(const edm::ParameterSet& iConfig):
-  src_token_(consumes<edm::View<pat::PackedCandidate>>(iConfig.getParameter<edm::InputTag>("src"))),
+  src_token_(consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("src"))),
   subjetCollName_("SubJets")
 {
   // We make both the fat jets and subjets, and we must store them as separate collections
@@ -123,7 +123,7 @@ XConeProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   seeds[1] = std::max(runNum_uint, minSeed_ + 5) + 5 * evNum_uint;
   gas.set_random_status(seeds);
 
-  edm::Handle<edm::View<pat::PackedCandidate>> particles;
+  edm::Handle<edm::View<reco::Candidate>> particles;
   iEvent.getByToken(src_token_, particles);
 
   if (particles->size() < 15) {

--- a/core/plugins/XConeProducer.cc
+++ b/core/plugins/XConeProducer.cc
@@ -151,7 +151,7 @@ XConeProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
   // Run first clustering step (N=2, R=1.2)
   vector<PseudoJet> fatjets;
-  XConePlugin plugin_xcone(2, 1.2, 2.0);
+  PseudoXConePlugin plugin_xcone(2, 1.2, 2.0);
   double ghost_maxrap = 4.0;      // maxiumum y of ghost particles
   AreaDefinition area_def(active_area, GhostedAreaSpec(ghost_maxrap));
   JetDefinition jet_def_xcone(&plugin_xcone);
@@ -189,13 +189,13 @@ XConeProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   vector<PseudoJet> subjets_1, subjets_2;
 
   // subjets from fat jet 1
-  XConePlugin plugin_xcone_sub1(3, 0.4, 2.0);
+  PseudoXConePlugin plugin_xcone_sub1(3, 0.4, 2.0);
   JetDefinition jet_def_sub1(&plugin_xcone_sub1);
   ClusterSequenceArea clust_seq_sub1(particle_in_fat1, jet_def_sub1, area_def);
   subjets_1 = sorted_by_pt(clust_seq_sub1.inclusive_jets(0));
 
   //subjets from fat jet 2
-  XConePlugin plugin_xcone_sub2(3, 0.4, 2.0);
+  PseudoXConePlugin plugin_xcone_sub2(3, 0.4, 2.0);
   JetDefinition jet_def_sub2(&plugin_xcone_sub2);
   ClusterSequenceArea clust_seq_sub2(particle_in_fat2, jet_def_sub2, area_def);
   subjets_2 = sorted_by_pt(clust_seq_sub2.inclusive_jets(0));

--- a/core/plugins/XConeProducer.cc
+++ b/core/plugins/XConeProducer.cc
@@ -108,7 +108,7 @@ XConeProducer::~XConeProducer()
 void
 XConeProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
-  edm::Handle<std::vector<pat::PackedCandidate>> particles;
+  edm::Handle<edm::View<pat::PackedCandidate>> particles;
   iEvent.getByToken(src_token_, particles);
 
   if (particles->size() < 15) {

--- a/core/plugins/XConeProducer.cc
+++ b/core/plugins/XConeProducer.cc
@@ -242,7 +242,7 @@ XConeProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 pat::Jet XConeProducer::createPatJet(const PseudoJet & psj)
 {
   pat::Jet newJet;
-  newJet.setP4(math::XYZTLorentzVector(psj.pt(), psj.eta(), psj.phi(), psj.E()));
+  newJet.setP4(math::XYZTLorentzVector(psj.px(), psj.py(), psj.pz(), psj.E()));
   return newJet;
 }
 

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -505,7 +505,6 @@ process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService
 )
 """
 
-
 # for JEC cluster AK8 jets with lower pt (compare to miniAOD)
 addJetCollection(process,labelName = 'AK8PFPUPPI', jetSource = cms.InputTag('ak8PuppiJets'), algo = 'AK', rParam=0.8, genJetCollection=cms.InputTag('slimmedGenJetsAK8'), jetCorrections = ('AK8PFchs', ['L1FastJet', 'L2Relative', 'L3Absolute'], 'None'),pfCandidates = cms.InputTag('packedPFCandidates'),
     pvSource = cms.InputTag('offlineSlimmedPrimaryVertices'),
@@ -520,6 +519,18 @@ addJetCollection(process,labelName = 'AK8PFCHS', jetSource = cms.InputTag('ak8CH
     elSource = cms.InputTag('slimmedElectrons')
 )
 
+# HOTVR & XCONE
+process.hotvrPuppi = cms.EDProducer("HOTVRProducer",
+    src=cms.InputTag("puppi")
+)
+
+process.hotvrPfCand = cms.EDProducer("HOTVRProducer",
+    src=cms.InputTag("packedPFCandidates")
+)
+
+process.xconePfCand = cms.EDProducer("XConeProducer",
+    src=cms.InputTag("packedPFCandidates")
+)
 
 ### MET
 
@@ -859,16 +870,18 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
         doAllPFParticles = cms.bool(False),
         pf_collection_source = cms.InputTag("packedPFCandidates"),
 
-        # # *** HOTVR & XCone stuff
+        # *** HOTVR & XCone stuff
         doHOTVR = cms.bool(True),
         doXCone = cms.bool(True),
         doGenHOTVR = cms.bool(not useData),
         doGenXCone = cms.bool(not useData),    
-         # doHOTVR = cms.bool(False),
-         # doXCone = cms.bool(False),
-         # doGenHOTVR = cms.bool(False),
-         # doGenXCone =  cms.bool(False),
-
+        HOTVR_sources=cms.VInputTag(
+            cms.InputTag("hotvrPfCand"),
+            cms.InputTag("hotvrPuppi")
+        ),
+        XCone_sources=cms.VInputTag(
+            cms.InputTag("xconePfCand")
+        )
 )
 
 #process.content = cms.EDAnalyzer("EventContentAnalyzer")

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -856,7 +856,7 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
         # *** gen stuff:
         doGenInfo = cms.bool(not useData),
         genparticle_source = cms.InputTag("prunedPrunedGenParticles"),
-        stablegenparticle_source = cms.InputTag("packedGenParticles"),
+        stablegenparticle_source = cms.InputTag("packedGenParticlesForJetsNoNu"),
         doAllGenParticles = cms.bool(False), #set to true if you want to store all gen particles, otherwise, only prunedPrunedGenParticles are stored (see above)
         doAllGenParticlesPythia8 =  cms.bool(False), #set to true if you want to store all gen particles with pythia8 (see status codes in http://home.thep.lu.se/~torbjorn/pythia81html/ParticleProperties.html
         doGenJets = cms.bool(not useData),

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -524,12 +524,16 @@ process.hotvrPuppi = cms.EDProducer("HOTVRProducer",
     src=cms.InputTag("puppi")
 )
 
-process.hotvrPfCand = cms.EDProducer("HOTVRProducer",
-    src=cms.InputTag("packedPFCandidates")
+process.hotvrCHS = cms.EDProducer("HOTVRProducer",
+    src=cms.InputTag("chs")
 )
 
-process.xconePfCand = cms.EDProducer("XConeProducer",
-    src=cms.InputTag("packedPFCandidates")
+process.xconePuppi = cms.EDProducer("XConeProducer",
+    src=cms.InputTag("puppi")
+)
+
+process.xconeCHS = cms.EDProducer("XConeProducer",
+    src=cms.InputTag("chs")
 )
 
 ### MET
@@ -876,11 +880,12 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
         doGenHOTVR = cms.bool(not useData),
         doGenXCone = cms.bool(not useData),    
         HOTVR_sources=cms.VInputTag(
-            cms.InputTag("hotvrPfCand"),
+            cms.InputTag("hotvrCHS"),
             cms.InputTag("hotvrPuppi")
         ),
         XCone_sources=cms.VInputTag(
-            cms.InputTag("xconePfCand")
+            cms.InputTag("xconeCHS"),
+            cms.InputTag("xconePuppi")
         )
 )
 

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -266,6 +266,7 @@ process.load('CommonTools/PileupAlgos/Puppi_cff')
 process.puppi.candName = cms.InputTag('packedPFCandidates')
 process.puppi.vertexName = cms.InputTag('offlineSlimmedPrimaryVertices')
 process.puppi.clonePackedCands   = cms.bool(True)
+process.puppi.useExistingWeights   = cms.bool(True)
 
 process.ca15PuppiJetsSoftDrop = ak8PFJetsCHSSoftDrop.clone(src = cms.InputTag('puppi'), jetPtMin = fatjet_ptmin, jetAlgorithm = cms.string("CambridgeAachen"), rParam = 1.5, R0 = 1.5, zcut = cms.double(0.2), beta = cms.double(1.0))
 

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -521,20 +521,25 @@ addJetCollection(process,labelName = 'AK8PFCHS', jetSource = cms.InputTag('ak8CH
 )
 
 # HOTVR & XCONE
+usePseudoXCone = cms.bool(True)
 process.hotvrPuppi = cms.EDProducer("HOTVRProducer",
-    src=cms.InputTag("puppi")
+    src=cms.InputTag("puppi"),
+    usePseudoXCone=usePseudoXCone
 )
 
 process.hotvrCHS = cms.EDProducer("HOTVRProducer",
-    src=cms.InputTag("chs")
+    src=cms.InputTag("chs"),
+    usePseudoXCone=usePseudoXCone
 )
 
 process.xconePuppi = cms.EDProducer("XConeProducer",
-    src=cms.InputTag("puppi")
+    src=cms.InputTag("puppi"),
+    usePseudoXCone=usePseudoXCone
 )
 
 process.xconeCHS = cms.EDProducer("XConeProducer",
-    src=cms.InputTag("chs")
+    src=cms.InputTag("chs"),
+    usePseudoXCone=usePseudoXCone
 )
 
 ### MET

--- a/core/src/UniversalGenJetCluster.cxx
+++ b/core/src/UniversalGenJetCluster.cxx
@@ -69,7 +69,7 @@ void UniversalGenJetCluster::ClusterXCone23()
 {
   // Run first clustering step (N=2, R=1.2) 
   std::vector<PseudoJet> fatjets;
-  XConePlugin plugin_xcone(2, 1.2, 2.0);
+  PseudoXConePlugin plugin_xcone(2, 1.2, 2.0);
   JetDefinition jet_def_xcone(&plugin_xcone);
   ClusterSequence clust_seq_xcone(_psj, jet_def_xcone);
   fatjets = sorted_by_pt(clust_seq_xcone.inclusive_jets(0));
@@ -112,13 +112,13 @@ void UniversalGenJetCluster::ClusterXCone23()
 
   if(jet1_is_had){
     // subjets from fat jet 1 (hadronic)
-    XConePlugin plugin_xcone_sub1(3, 0.4, 2.0);
+    PseudoXConePlugin plugin_xcone_sub1(3, 0.4, 2.0);
     JetDefinition jet_def_sub1(&plugin_xcone_sub1);
     ClusterSequence clust_seq_sub1(particle_in_fat1, jet_def_sub1);
     subjets_1 = sorted_by_pt(clust_seq_sub1.inclusive_jets(0));
 
     // subjets from fat jet 2 (leptonic)
-    XConePlugin plugin_xcone_sub2(2, 0.4, 2.0);
+    PseudoXConePlugin plugin_xcone_sub2(2, 0.4, 2.0);
     JetDefinition jet_def_sub2(&plugin_xcone_sub2);
     ClusterSequence clust_seq_sub2(particle_in_fat2, jet_def_sub2);
     subjets_2 = sorted_by_pt(clust_seq_sub2.inclusive_jets(0));
@@ -126,13 +126,13 @@ void UniversalGenJetCluster::ClusterXCone23()
   }
   if(!jet1_is_had){
     // subjets from fat jet 1 (leptonic)
-    XConePlugin plugin_xcone_sub1(2, 0.4, 2.0);
+    PseudoXConePlugin plugin_xcone_sub1(2, 0.4, 2.0);
     JetDefinition jet_def_sub1(&plugin_xcone_sub1);
     ClusterSequence clust_seq_sub1(particle_in_fat1, jet_def_sub1);
     subjets_1 = sorted_by_pt(clust_seq_sub1.inclusive_jets(0));
 
     // subjets from fat jet 2 (hadronic)
-    XConePlugin plugin_xcone_sub2(3, 0.4, 2.0);
+    PseudoXConePlugin plugin_xcone_sub2(3, 0.4, 2.0);
     JetDefinition jet_def_sub2(&plugin_xcone_sub2);
     ClusterSequence clust_seq_sub2(particle_in_fat2, jet_def_sub2);
     subjets_2 = sorted_by_pt(clust_seq_sub2.inclusive_jets(0));
@@ -161,7 +161,7 @@ void UniversalGenJetCluster::ClusterXCone33()
 {
   // Run first clustering step (N=2, R=1.2) 
   vector<PseudoJet> fatjets;
-  XConePlugin plugin_xcone(2, 1.2, 2.0);
+  PseudoXConePlugin plugin_xcone(2, 1.2, 2.0);
   JetDefinition jet_def_xcone(&plugin_xcone);
   ClusterSequence clust_seq_xcone(_psj, jet_def_xcone);
   fatjets = sorted_by_pt(clust_seq_xcone.inclusive_jets(0));
@@ -193,13 +193,13 @@ void UniversalGenJetCluster::ClusterXCone33()
   vector<PseudoJet> subjets_1, subjets_2;
 
   // subjets from fat jet 1 
-  XConePlugin plugin_xcone_sub1(3, 0.4, 2.0);
+  PseudoXConePlugin plugin_xcone_sub1(3, 0.4, 2.0);
   JetDefinition jet_def_sub1(&plugin_xcone_sub1);
   ClusterSequence clust_seq_sub1(particle_in_fat1, jet_def_sub1);
   subjets_1 = sorted_by_pt(clust_seq_sub1.inclusive_jets(0));
 
   // subjets from fat jet 2 
-  XConePlugin plugin_xcone_sub2(3, 0.4, 2.0);
+  PseudoXConePlugin plugin_xcone_sub2(3, 0.4, 2.0);
   JetDefinition jet_def_sub2(&plugin_xcone_sub2);
   ClusterSequence clust_seq_sub2(particle_in_fat2, jet_def_sub2);
   subjets_2 = sorted_by_pt(clust_seq_sub2.inclusive_jets(0));


### PR DESCRIPTION
Updates for HOTVR/XCone:

**Physics changes**:

- Ntuple now has XCone & HOTVR with both CHS & PUPPI, dropping the pfCandidates ones (i.e. what we used to have)
- Move to `PseudoXConePlugin` instead of normal `XConePlugin` for speed gains (both reco & gen level). This saves us ~0.3s/evt/producer, so about 0.6s/evt overall. For reco XConeProducer this is configured by a bool to allow easy testing/changing. For gen level its hard-coded.
- Both producers now filter out input particles with pT= 0.
- Gen level XCone & HOTVR now use genParticles **without neutrinos** - previously had included them. (NB this doesn't affect runtime)


**Code changes**:

- Move clusterers  into own producers and out of UnivesalClusterer
- NtupleWriter can now store any number of XCone/HOTVR collections (reco only)
- Made use of `puppi.useExistingWeights` to shave off time (about 0.2s/evt)
- Had to do some internal changing to allow modules to consume output from `CandPtrSelector` (i.e. take `reco::Candidate`)
- Some other niceties like fixing the const warnings in `GenTopJet` when compiling, init instance vars, deterministic RNG seed for clusterers

For comparison, here are the runtimes with full XCone, recalculating puppi weights:

```
TimeReport      event loop Real/event = 2.931695

TimeReport   0.072718     0.072718     0.072718  MyNtuple (includes gen level XCone, HOTVR)
TimeReport   0.161843     0.161843     0.161843  hotvrCHS
TimeReport   0.075718     0.075718     0.075718  hotvrPuppi
TimeReport   0.204478     0.204478     0.204478  puppi
TimeReport   0.437445     0.437445     0.437445  xconeCHS
TimeReport   0.360391     0.360391     0.360391  xconePuppi
```

and after all changes above:

```
TimeReport      event loop Real/event = 2.012205

TimeReport   0.021691     0.021691     0.021691  MyNtuple
TimeReport   0.005801     0.005801     0.005801  puppi
TimeReport   0.102966     0.102966     0.102966  xconeCHS
TimeReport   0.091758     0.091758     0.091758  xconePuppi
```
so all the changes shave off 1s/evt.

TBH I don't see how we can get under 2s/evt without dropping more producers/collections.

One thing that is needed is a mem check to make sure none of the new modules introduced are creating havoc.

For reference, here was the timings with 80Xv4:

```
TimeReport      event loop Real/event = 2.303859

TimeReport   0.587225     0.587225     0.587225  MyNtuple (has all the XCone, HOTVR stuff inside it)
TimeReport   0.201786     0.201786     0.201786  puppi
```

so overall we gain a little speedup and have more useful collections 😄 