### PR TITLE
[80Xv5] Move to ungroomed AK8PUPPI TopJets

### DIFF
--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -12,6 +12,10 @@ else:
 # minimum pt for the large-R jets (applies for all: vanilla CA8/CA15, cmstoptag, heptoptag). Also applied for the corresponding genjets.
 fatjet_ptmin = 150.0
 #fatjet_ptmin = 10.0 #TEST
+# Ensures e.g. groomed jet producers always produce a matching jet for our main
+# jet collection that has cut fatjet_ptmin
+safety_factor  = 0.9
+
 
 bTagDiscriminators = [
     'pfJetProbabilityBJetTags',
@@ -269,10 +273,10 @@ process.puppi.clonePackedCands   = cms.bool(True)
 
 process.ca15PuppiJetsSoftDrop = ak8PFJetsCHSSoftDrop.clone(src = cms.InputTag('puppi'), jetPtMin = fatjet_ptmin, jetAlgorithm = cms.string("CambridgeAachen"), rParam = 1.5, R0 = 1.5, zcut = cms.double(0.2), beta = cms.double(1.0))
 
-process.ak8PuppiJetsSoftDrop = ak8PFJetsCHSSoftDrop.clone(src = cms.InputTag('puppi'), jetPtMin = fatjet_ptmin)
+process.ak8PuppiJetsSoftDrop = ak8PFJetsCHSSoftDrop.clone(src = cms.InputTag('puppi'), jetPtMin = fatjet_ptmin*safety_factor)
 
 process.ca15PuppiJetsSoftDropforsub = process.ca8CHSJets.clone (rParam = 1.5, jetPtMin = fatjet_ptmin, zcut = cms.double(0.2), beta = cms.double(1.0), useSoftDrop = cms.bool(True), useExplicitGhosts = cms.bool(True), R0 = cms.double(1.5), src = cms.InputTag('puppi'))
-process.ak8PuppiJetsSoftDropforsub = process.ak8CHSJetsFat.clone (rParam = 0.8, jetPtMin = fatjet_ptmin, zcut = cms.double(0.1), beta = cms.double(0.0), useSoftDrop = cms.bool(True), useExplicitGhosts = cms.bool(True), R0 = cms.double(0.8), src = cms.InputTag('puppi'))
+process.ak8PuppiJetsSoftDropforsub = process.ak8CHSJetsFat.clone (rParam = 0.8, jetPtMin = fatjet_ptmin*safety_factor, zcut = cms.double(0.1), beta = cms.double(0.0), useSoftDrop = cms.bool(True), useExplicitGhosts = cms.bool(True), R0 = cms.double(0.8), src = cms.InputTag('puppi'))
 
 process.ca15PuppiJets = process.ca8CHSJets.clone (rParam = 1.5, src='puppi')
 
@@ -520,6 +524,18 @@ addJetCollection(process,labelName = 'AK8PFCHS', jetSource = cms.InputTag('ak8CH
     elSource = cms.InputTag('slimmedElectrons')
 )
 
+process.packedPatJetsAk8PuppiJets = cms.EDProducer("JetSubstructurePacker",
+    jetSrc = cms.InputTag("patJetsAk8PuppiJetsFat"),
+    distMax = cms.double(0.8),
+    algoTags = cms.VInputTag(
+        cms.InputTag("patJetsAk8PuppiJetsSoftDropPacked")
+    ),
+    algoLabels = cms.vstring(
+        'SoftDropPuppi'
+    ),
+    fixDaughters = cms.bool(False)
+)
+
 
 ### MET
 
@@ -765,12 +781,14 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
         #doTopJets = cms.bool(False),
         doTopJets = cms.bool(True),
         topjet_ptmin = cms.double(150.0),
-        topjet_etamax = cms.double(5.0),                                                                               
-        topjet_sources = cms.vstring("slimmedJetsAK8","patJetsAk8CHSJetsSoftDropPacked","patJetsHepTopTagCHSPacked","patJetsHepTopTagPuppiPacked","patJetsAk8PuppiJetsSoftDropPacked"),
-      #  topjet_sources = cms.vstring("slimmedJetsAK8","patJetsAk8CHSJetsSoftDropPacked","patJetsAk8PuppiJetsSoftDropPacked"),
+        topjet_etamax = cms.double(5.0),
+        # The collection here determines the pt, eta, energy fractions, daughters etc for a TopJet collection
+        # Thus you should be careful if you are using groomed or ungroomed collections
+        # Use a JetSubstructurePacker if you want ungroomed, along with the correct subjet name in subjet_sources
+        topjet_sources = cms.vstring("slimmedJetsAK8","patJetsAk8CHSJetsSoftDropPacked","patJetsHepTopTagCHSPacked","patJetsHepTopTagPuppiPacked","packedPatJetsAk8PuppiJets"),
         #Note: use label "daughters" for  subjet_sources if you want to store as subjets the linked daughters of the topjets (NOT for slimmedJetsAK8 in miniAOD!)
         #to store a subjet collection present in miniAOD indicate the proper label of the subjets method in pat::Jet: SoftDrop or CMSTopTag
-        subjet_sources = cms.vstring("SoftDrop","daughters","daughters","daughters","daughters"),
+        subjet_sources = cms.vstring("SoftDrop","daughters","daughters","daughters","SoftDropPuppi"),
         #Specify "store" if you want to store b-tagging taginfos for subjet collection, make sure to have included them with .addTagInfos = True
         #addTagInfos = True is currently true by default, however, only for collections produced and not read directly from miniAOD
         #If you don't want to store stubjet taginfos leave string empy ""
@@ -789,7 +807,7 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
         #Alternatively it is possible to specify another pruned jet collection (to be produced here), from which to get it by jet-matching.
         #Finally, it is also possible to leave the pruned mass empty with ""
         topjet_prunedmass_sources = cms.vstring("ak8PFJetsCHSPrunedMass","patJetsAk8CHSJetsPrunedPacked","patJetsCa15CHSJetsPrunedPacked","patJetsCa15CHSJetsPrunedPacked","patJetsAk8CHSJetsPrunedPacked"),
-        topjet_softdropmass_sources = cms.vstring("ak8PFJetsCHSSoftDropMass", "", "", "", ""),
+        topjet_softdropmass_sources = cms.vstring("ak8PFJetsCHSSoftDropMass", "", "", "", "patJetsAk8PuppiJetsSoftDropPacked"),
         #topjet_sources = cms.vstring("patJetsHepTopTagCHSPacked", "patJetsCmsTopTagCHSPacked", "patJetsCa8CHSJetsPrunedPacked", "patJetsCa15CHSJetsFilteredPacked",
         #        "patJetsHepTopTagPuppiPacked", "patJetsCmsTopTagPuppiPacked", "patJetsCa8PuppiJetsPrunedPacked", "patJetsCa15PuppiJetsFilteredPacked",
         #        'patJetsCa8CHSJetsSoftDropPacked', 'patJetsCa8PuppiJetsSoftDropPacked'


### PR DESCRIPTION
As requested, move from `patJetsAk8PuppiJetsSoftDropPacked_daughters` with groomed pt to `packedPatJetsAk8PuppiJets_SoftDropPuppi` with ungroomed pt.

**This is only for AK8 PUPPI, not CHS, etc!** - if requested can also be done for CHS etc.

SoftDrop mass now available via `TopJet::softdropmass()` whilst ungroomed mass available via `TopJet::v4().M()`.
Upside of this is that all the energy fractions, # daughters etc work properly now.
Subjets are there as before.

Also not, I had to add in a "safety factor" to the pt cut on the FastjetJetProducers that ran with SoftDrop to ensure there is always a matching groomed jet for each ungroomed jet.

(Technical note, the use of `JetSubstructurePacker` allows one to store subjet info which can then be accessed using `pat::Jet::subjets("...")`.)

