### PR TITLE
[80Xv5] Fix issue with duplicate datasets from DasQuery, update tests

### DIFF
--- a/scripts/crab/DasQuery.py
+++ b/scripts/crab/DasQuery.py
@@ -25,5 +25,8 @@ def autocomplete_Datasets(data):
     if len(result_array) == 0: 
         print "No samples found going to exit"
         sys.exit(0)
-    return result_array
+    # Do this to remove duplicates but maintain order of insertion
+    # We get duplicates because it queries ALL databases not just the main one
+    # https://github.com/dmwm/DAS/issues/4287#issuecomment-390278822
+    return sorted(set(result_array), key=result_array.index)
 

--- a/scripts/crab/test_DasQuery.py
+++ b/scripts/crab/test_DasQuery.py
@@ -7,5 +7,10 @@ from DasQuery import autocomplete_Datasets
 inputDatasets = ['/DYJetsToLL_M-50_HT-*to*_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_*/MINIAODSIM']
 result = autocomplete_Datasets(inputDatasets)
 print result
-assert(len(result) == 22)
+assert(len(result) == 11)
+
+inputDatasets = ['/QCD_Pt-15to20_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-*/MINIAODSIM']
+result = autocomplete_Datasets(inputDatasets)
+print result
+assert(len(result) == 1)
 


### PR DESCRIPTION
DasQuery returns duplicate dataset entries due to how das_client works. This removes duplicate entries.

Also updated the tests accordingly.

Details in https://github.com/dmwm/DAS/issues/4287#issuecomment-390278822
