### PR TITLE
Checking size of input particles

### DIFF
--- a/core/plugins/XConeProducer.cc
+++ b/core/plugins/XConeProducer.cc
@@ -142,14 +142,6 @@ XConeProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   edm::Handle<edm::View<reco::Candidate>> particles;
   iEvent.getByToken(src_token_, particles);
 
-  if (particles->size() < 15) {
-    auto jetCollection = std::make_unique<pat::JetCollection>();
-    iEvent.put(std::move(jetCollection));
-    auto subjetCollection = std::make_unique<pat::JetCollection>();
-    iEvent.put(std::move(subjetCollection), subjetCollName_);
-    return;
-  }
-
   // Convert particles to PseudoJets
   std::vector<PseudoJet> _psj;
   for (const auto & cand: *particles) {
@@ -164,6 +156,15 @@ XConeProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
     _psj.push_back(PseudoJet(cand.px(), cand.py(), cand.pz(), cand.energy()));
   }
+
+  if (_psj.size() < 15) {
+    auto jetCollection = std::make_unique<pat::JetCollection>();
+    iEvent.put(std::move(jetCollection));
+    auto subjetCollection = std::make_unique<pat::JetCollection>();
+    iEvent.put(std::move(subjetCollection), subjetCollName_);
+    return;
+  }
+
 
   // Run first clustering step (N=2, R=1.2)
   vector<PseudoJet> fatjets;


### PR DESCRIPTION
XCone crashes if there are too few input particles. Before we checked the size of the particle collection. With PUPPI, we have to check the number of particles with a non-zero puppy weight. This is now changed in the XConeProducer