### PR TITLE
More generic XConeProducer

### DIFF
--- a/core/plugins/XConeProducer.cc
+++ b/core/plugins/XConeProducer.cc
@@ -69,12 +69,12 @@ class XConeProducer : public edm::stream::EDProducer<> {
     edm::EDGetToken src_token_;
     const std::string subjetCollName_;
     const bool usePseudoXCone_;
-    unsigned int NJets_;
-    double RJets_;
-    double BetaJets_;
-    unsigned int NSubJets_;
-    double RSubJets_;
-    double BetaSubJets_;
+    unsigned int NJets_ = 2;
+    double RJets_ = 1.2;
+    double BetaJets_ = 2.0;
+    unsigned int NSubJets_ = 3;
+    double RSubJets_ = 0.4;
+    double BetaSubJets_ = 2.0;
 };
 
 //

--- a/core/plugins/XConeProducer.cc
+++ b/core/plugins/XConeProducer.cc
@@ -225,12 +225,6 @@ XConeProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
     // check if there are more particles then required subjets
     bool enoughParticles = (particle_in_fatjet.size() > NSubJets_);
-    if (!enoughParticles) {
-      edm::LogWarning("InsufficientParticles")
-        << "Not enough particles in fatjet 1 to run second XCone step: "
-        << std::to_string(particle_in_fatjet.size())
-        << std::endl;
-    }
 
     // Run second clustering step (subjets) for each fat jet
     vector<PseudoJet> subjets;

--- a/core/plugins/XConeProducer.cc
+++ b/core/plugins/XConeProducer.cc
@@ -69,6 +69,12 @@ class XConeProducer : public edm::stream::EDProducer<> {
     edm::EDGetToken src_token_;
     const std::string subjetCollName_;
     const bool usePseudoXCone_;
+    unsigned int NJets_;
+    double RJets_;
+    double BetaJets_;
+    unsigned int NSubJets_;
+    double RSubJets_;
+    double BetaSubJets_;
 };
 
 //
@@ -86,7 +92,13 @@ class XConeProducer : public edm::stream::EDProducer<> {
 XConeProducer::XConeProducer(const edm::ParameterSet& iConfig):
   src_token_(consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("src"))),
   subjetCollName_("SubJets"),
-  usePseudoXCone_(iConfig.getParameter<bool>("usePseudoXCone"))
+  usePseudoXCone_(iConfig.getParameter<bool>("usePseudoXCone")),
+  NJets_(iConfig.getParameter<unsigned int>("NJets")),
+  RJets_(iConfig.getParameter<double>("RJets")),
+  BetaJets_(iConfig.getParameter<double>("BetaJets")),
+  NSubJets_(iConfig.getParameter<unsigned int>("NSubJets")),
+  RSubJets_(iConfig.getParameter<double>("RSubJets")),
+  BetaSubJets_(iConfig.getParameter<double>("BetaSubJets"))
 {
   // We make both the fat jets and subjets, and we must store them as separate collections
   produces<pat::JetCollection>();
@@ -157,7 +169,9 @@ XConeProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     _psj.push_back(PseudoJet(cand.px(), cand.py(), cand.pz(), cand.energy()));
   }
 
-  if (_psj.size() < 15) {
+  // make sure to have enough particles with non-zero momentum in event
+  unsigned int minParticleCount = NJets_ * 3;
+  if (_psj.size() < minParticleCount) {
     auto jetCollection = std::make_unique<pat::JetCollection>();
     iEvent.put(std::move(jetCollection));
     auto subjetCollection = std::make_unique<pat::JetCollection>();
@@ -165,114 +179,89 @@ XConeProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     return;
   }
 
+  // declare jet collections
+  auto jetCollection = std::make_unique<pat::JetCollection>();
+  auto subjetCollection = std::make_unique<pat::JetCollection>();
+  std::vector< std::vector<int> > indices;
 
-  // Run first clustering step (N=2, R=1.2)
+  // Run clustering of fatjets
   vector<PseudoJet> fatjets;
   std::unique_ptr<NjettinessPlugin> plugin_xcone;
-  initPlugin(plugin_xcone, 2, 1.2, 2.0, usePseudoXCone_);
+  initPlugin(plugin_xcone, NJets_, RJets_, BetaJets_, usePseudoXCone_);
   double ghost_maxrap = 4.0;      // maxiumum y of ghost particles
   AreaDefinition area_def(active_area, GhostedAreaSpec(ghost_maxrap));
   JetDefinition jet_def_xcone(plugin_xcone.get());
   ClusterSequence clust_seq_xcone(_psj, jet_def_xcone);
   fatjets = sorted_by_pt(clust_seq_xcone.inclusive_jets(0));
 
-  // get SoftDrop Mass
+  // get SoftDrop Mass for every fat jet
   SoftDrop sd(0.0, 0.1, 1.2);
-  PseudoJet sdjet1 = sd(fatjets[0]);
-  PseudoJet sdjet2 = sd(fatjets[1]);
-  float sd_mass1 = sdjet1.m();
-  float sd_mass2 = sdjet2.m();
+  vector<float> sd_mass;
+  for(unsigned int i=0; i<fatjets.size(); i++){
+    PseudoJet sdjet = sd(fatjets[i]);
+    sd_mass.push_back(sdjet.m());
+  }
 
-  // get and wirte list: if particle i is clustered in jet j, the i-th entry of the list == j
+  // check if subjets should be clustered
+  bool doSubjets = true;
+  if(NSubJets_ == 0) doSubjets = false;
+
+  // first get and wirte list of particles in fatjets:
+  // if particle i is clustered in jet j, the i-th entry of the list == j
   vector<int> list_fat;
   list_fat.clear();
   list_fat = clust_seq_xcone.particle_jet_indices(fatjets);
-  vector<PseudoJet> particle_in_fat1, particle_in_fat2;
 
-  // get one set of particles for each jet
-  for (unsigned int ipart=0; ipart < _psj.size(); ++ipart) {
-    if (list_fat[ipart]==0) {
-      particle_in_fat1.push_back(_psj.at(ipart)); // get vector as PseudoJet for fatjet 1
+  // loop over all fatjets and cluster subjets
+  for(unsigned int i=0; i<fatjets.size(); i++){
+    // get set of particles in fatjet i
+    vector<PseudoJet> particle_in_fatjet;
+    for (unsigned int ipart=0; ipart < _psj.size(); ++ipart) {
+      if (list_fat[ipart] < 0) continue;
+      else if (abs(list_fat[ipart])==i) {
+        particle_in_fatjet.push_back(_psj.at(ipart));
+      }
     }
-    if (list_fat[ipart]==1) {
-      particle_in_fat2.push_back(_psj.at(ipart)); // get vector as PseudoJet for fatjet 2
+
+    // check if there are more particles then required subjets
+    bool enoughParticles = (particle_in_fatjet.size() > NSubJets_);
+    if (!enoughParticles) {
+      edm::LogWarning("InsufficientParticles")
+        << "Not enough particles in fatjet 1 to run second XCone step: "
+        << std::to_string(particle_in_fatjet.size())
+        << std::endl;
     }
-  }
 
-  uint minParticlesPerJet = 3;
-  bool doJet1Subjets = (particle_in_fat1.size() > minParticlesPerJet);
-  if (!doJet1Subjets) {
-    edm::LogWarning("InsufficientParticles")
-      << "Not enough particles in fatjet 1 to run second XCone step: "
-      << std::to_string(particle_in_fat1.size())
-      << std::endl;
-  }
+    // Run second clustering step (subjets) for each fat jet
+    vector<PseudoJet> subjets;
+    vector<double> subjet_area;
+    if (enoughParticles && doSubjets) {
+      std::unique_ptr<NjettinessPlugin> plugin_xcone_sub;
+      initPlugin(plugin_xcone_sub, NSubJets_, RSubJets_, BetaSubJets_, usePseudoXCone_);
+      JetDefinition jet_def_sub(plugin_xcone_sub.get());
+      ClusterSequenceArea clust_seq_sub(particle_in_fatjet, jet_def_sub, area_def);
+      subjets = sorted_by_pt(clust_seq_sub.inclusive_jets(0));
+      for (unsigned int j = 0; j < subjets.size(); ++j) subjet_area.push_back(subjets[j].area());
+    }
 
-  bool doJet2Subjets = (particle_in_fat2.size() > minParticlesPerJet);
-  if (!doJet2Subjets) {
-    edm::LogWarning("InsufficientParticles")
-      << "Not enough particles in fatjet 2 to run second XCone step: "
-      << std::to_string(particle_in_fat2.size())
-      << std::endl;
-  }
+    // jet area for fat jet
+    double jet_area = 0;
+    // double jet_area = fatjets[i].area();
 
-  // Run second clustering step (N=3, R=0.4) for each fat jet
-  vector<PseudoJet> subjets_1, subjets_2;
+    // pat-ify fatjets
+    auto patJet = createPatJet(fatjets[i]);
+    patJet.setJetArea(jet_area);
+    patJet.addUserFloat("softdropmass", sd_mass[i]);
+    jetCollection->push_back(patJet);
 
-  // subjets from fat jet 1
-  vector<double> subjet1_area;
-  if (doJet1Subjets) {
-    std::unique_ptr<NjettinessPlugin> plugin_xcone_sub1;
-    initPlugin(plugin_xcone_sub1, 3, 0.4, 2.0, usePseudoXCone_);
-    JetDefinition jet_def_sub1(plugin_xcone_sub1.get());
-    ClusterSequenceArea clust_seq_sub1(particle_in_fat1, jet_def_sub1, area_def);
-    subjets_1 = sorted_by_pt(clust_seq_sub1.inclusive_jets(0));
-    for (unsigned int j = 0; j < subjets_1.size(); ++j) subjet1_area.push_back(subjets_1[j].area());
-  }
+    indices.resize(jetCollection->size());
+    for (uint s=0; s<subjets.size(); s++) {
+      indices[i].push_back(subjetCollection->size());
+      auto subjet = createPatJet(subjets[s]);
+      subjet.setJetArea(subjet_area[s]);
+      subjetCollection->push_back(subjet);
+    }
 
-  //subjets from fat jet 2
-  vector<double> subjet2_area;
-  if (doJet2Subjets) {
-    std::unique_ptr<NjettinessPlugin> plugin_xcone_sub2;
-    initPlugin(plugin_xcone_sub2, 3, 0.4, 2.0, usePseudoXCone_);
-    JetDefinition jet_def_sub2(plugin_xcone_sub2.get());
-    ClusterSequenceArea clust_seq_sub2(particle_in_fat2, jet_def_sub2, area_def);
-    subjets_2 = sorted_by_pt(clust_seq_sub2.inclusive_jets(0));
-    for (unsigned int k = 0; k < subjets_2.size(); ++k) subjet2_area.push_back(subjets_2[k].area());
-  }
-
-  double jet1_area = 0;
-  double jet2_area = 0;
-  //double jet1_area = fatjets[0].area();
-  //double jet2_area = fatjets[1].area();
-
-  // pat-ify jets and subjets
-  auto jetCollection = std::make_unique<pat::JetCollection>();
-
-  auto patJet1 = createPatJet(fatjets[0]);
-  patJet1.setJetArea(jet1_area);
-  patJet1.addUserFloat("softdropmass", sd_mass1);
-  jetCollection->push_back(patJet1);
-
-  auto patJet2 = createPatJet(fatjets[1]);
-  patJet2.setJetArea(jet2_area);
-  patJet2.addUserFloat("softdropmass", sd_mass2);
-  jetCollection->push_back(patJet2);
-
-  auto subjetCollection = std::make_unique<pat::JetCollection>();
-  std::vector< std::vector<int> > indices;
-  indices.resize(jetCollection->size());
-  for (uint s=0; s<subjets_1.size(); s++) {
-    indices[0].push_back(subjetCollection->size());
-    auto subjet = createPatJet(subjets_1[s]);
-    subjet.setJetArea(subjet1_area[s]);
-    subjetCollection->push_back(subjet);
-  }
-  for (uint s=0; s<subjets_2.size(); s++) {
-    indices[1].push_back(subjetCollection->size());
-    auto subjet = createPatJet(subjets_2[s]);
-    subjet.setJetArea(subjet2_area[s]);
-    subjetCollection->push_back(subjet);
   }
 
   edm::OrphanHandle<pat::JetCollection> subjetHandleAfterPut = iEvent.put(std::move(subjetCollection), subjetCollName_);

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -2,8 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 #isDebug = True
 isDebug = False
-#useData = False
-useData = True
+useData = False
+#useData = True
 if useData:
     met_sources_GL =  cms.vstring("slimmedMETs","slimmedMETsPuppi","slMETsCHS","slimmedMETsMuEGClean","slimmedMETsEGClean","slimmedMETsUncorrected")
 else:
@@ -53,7 +53,7 @@ if isDebug:
     )
 
     process.SimpleMemoryCheck = cms.Service("SimpleMemoryCheck",
-    ignoreTotal = cms.untracked.int32(2),                                            
+    ignoreTotal = cms.untracked.int32(2),
     moduleMemorySummary = cms.untracked.bool(True)
     )
 
@@ -61,10 +61,12 @@ if isDebug:
 
 process.source = cms.Source("PoolSource",
   fileNames  = cms.untracked.vstring([
-            '/store/data/Run2016B/SingleElectron/MINIAOD/03Feb2017_ver2-v2/110000/028CD245-EFEA-E611-8A2B-90B11C2801E1.root'
-  ]),
+            #'/store/data/Run2016B/SingleElectron/MINIAOD/03Feb2017_ver2-v2/110000/028CD245-EFEA-E611-8A2B-90B11C2801E1.root'
+             '/store/mc/RunIISummer16MiniAODv2/TT_TuneCUETP8M2T4_13TeV-powheg-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/80000/6ADE8687-9DBE-E611-AB0F-001E677924C6.root'
+ ]),
   skipEvents = cms.untracked.uint32(0)
 )
+#process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(10))
 #process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(300))
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1000))
 #process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(10000))
@@ -124,9 +126,9 @@ process.load("Configuration.StandardSequences.MagneticField_cff")
 #see https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideFrontierConditions for latest global tags
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
 if useData:
-    process.GlobalTag.globaltag = '80X_dataRun2_2016SeptRepro_v5' 
+    process.GlobalTag.globaltag = '80X_dataRun2_2016SeptRepro_v5'
 else:
-    process.GlobalTag.globaltag = '80X_mcRun2_asymptotic_2016_TrancheIV_v6' 
+    process.GlobalTag.globaltag = '80X_mcRun2_asymptotic_2016_TrancheIV_v6'
 
 
 from RecoJets.Configuration.RecoPFJets_cff import *
@@ -160,7 +162,7 @@ process.prunedPrunedGenParticles = cms.EDProducer("GenParticlePruner",
     src = cms.InputTag("prunedTmp"),
     select = cms.vstring(
         'keep *',
-        'drop 11 <= abs(pdgId) <= 16 && numberOfMothers() == 1 && abs(mother().pdgId())==6',  
+        'drop 11 <= abs(pdgId) <= 16 && numberOfMothers() == 1 && abs(mother().pdgId())==6',
         'keep 11 <= abs(pdgId) <= 16 && numberOfMothers() == 1 && abs(mother().pdgId())==6 && mother().numberOfDaughters() > 2 && abs(mother().daughter(0).pdgId()) != 24 && abs(mother().daughter(1).pdgId()) != 24 && abs(mother().daughter(2).pdgId()) != 24',
     )
 )
@@ -190,8 +192,8 @@ process.ca15CHSJetsFiltered = ak5PFJetsFiltered.clone(
         jetPtMin = cms.double(fatjet_ptmin)
 )
 
-from RecoJets.JetProducers.AnomalousCellParameters_cfi import *  
-from RecoJets.JetProducers.PFJetParameters_cfi import *          
+from RecoJets.JetProducers.AnomalousCellParameters_cfi import *
+from RecoJets.JetProducers.PFJetParameters_cfi import *
 from RecoJets.JetProducers.CATopJetParameters_cfi import CATopJetParameters
 process.cmsTopTagCHS = cms.EDProducer(
     "CATopJetProducer",
@@ -207,7 +209,7 @@ process.cmsTopTagCHS = cms.EDProducer(
     writeCompound = cms.bool(True)
 )
 
-#process.hepTopTagCHS = process.cmsTopTagCHS.clone(  
+#process.hepTopTagCHS = process.cmsTopTagCHS.clone(
 #    rParam = cms.double(1.5),
 #    tagAlgo = cms.int32(2), #2=fastjet heptt
 #    muCut = cms.double(0.8),
@@ -215,13 +217,13 @@ process.cmsTopTagCHS = cms.EDProducer(
 #    useSubjetMass = cms.bool(False),
 #)
 
-process.hepTopTagCHS = cms.EDProducer(     
+process.hepTopTagCHS = cms.EDProducer(
         "HTTTopJetProducer",
          PFJetParameters.clone( src = cms.InputTag('chs'),
                                doAreaFastjet = cms.bool(True),
                                doRhoFastjet = cms.bool(False),
                                jetPtMin = cms.double(fatjet_ptmin)
-                               ),   
+                               ),
         AnomalousCellParameters,
         optimalR = cms.bool(True),
         algorithm = cms.int32(1),
@@ -348,13 +350,13 @@ def add_fatjets_subjets(process, fatjets_name, groomed_jets_name, jetcorr_label 
         assert getattr(process, fatjets_name).jetAlgorithm.value() == 'AntiKt'
     else:
         raise RuntimeError, "cannot guess jet algo (ca/ak) from fatjets name %s" % fatjets_name
-    
+
     subjets_name = groomed_jets_name + 'Subjets' # e.g. CA8CHSPruned + Subjets
-    
+
     # add genjet producers, if requested:
     groomed_genjets_name = 'INVALID'
     ungroomed_genjets_name = 'INVALID'
-    
+
     if genjets_name is not None:
         groomed_jetproducer = getattr(process, groomed_jets_name)
         assert groomed_jetproducer.type_() in ('FastjetJetProducer', 'CATopJetProducer'), "do not know how to construct genjet collection for %s" % repr(groomed_jetproducer)
@@ -367,7 +369,7 @@ def add_fatjets_subjets(process, fatjets_name, groomed_jets_name, jetcorr_label 
         ungroomed_genjets_name = genjets_name(fatjets_name)
         if verbose: print "Adding ungroomed genjets ", ungroomed_genjets_name
         setattr(process, ungroomed_genjets_name, ungroomed_jetproducer.clone(src = cms.InputTag('packedGenParticlesForJetsNoNu'), jetType = 'GenJet'))
-        
+
 
     # patify ungroomed jets, if not already done:
     add_ungroomed = not hasattr(process, 'patJets' + cap(fatjets_name))
@@ -382,7 +384,7 @@ def add_fatjets_subjets(process, fatjets_name, groomed_jets_name, jetcorr_label 
             **common_btag_parameters
         )
         getattr(process,"patJets" + cap(fatjets_name)).addTagInfos = True
-    
+
     # patify groomed fat jets, with b-tagging:
     if verbose: print "adding grommed jets patJets" + cap(groomed_jets_name)
     addJetCollection(process, labelName = groomed_jets_name, jetSource = cms.InputTag(groomed_jets_name), algo = algo, rParam = rParam,
@@ -411,7 +413,7 @@ def add_fatjets_subjets(process, fatjets_name, groomed_jets_name, jetcorr_label 
     setattr(process, 'patJets' + cap(groomed_jets_name) + 'Packed',cms.EDProducer("BoostedJetMerger",
         jetSrc=cms.InputTag("patJets" + cap(groomed_jets_name)),
         subjetSrc=cms.InputTag("patJets" + cap(subjets_name))))
-        
+
     # adapt all for b-tagging, and switch off some PAT features not supported in miniAOD:
     module_names = [subjets_name, groomed_jets_name]
     if add_ungroomed: module_names += [fatjets_name]
@@ -465,7 +467,7 @@ process.NjettinessCa15CHS = Njettiness.clone(src = cms.InputTag("ca15CHSJets"), 
 process.NjettinessCa15SoftDropCHS = Njettiness.clone(
                                                  src = cms.InputTag("ca15CHSJetsSoftDropforsub"),
                                                  Njets=cms.vuint32(1,2,3),          # compute 1-, 2-, 3- subjettiness
-                                                 # variables for measure definition : 
+                                                 # variables for measure definition :
                                                  measureDefinition = cms.uint32( 0 ), # CMS default is normalized measure
                                                  beta = cms.double(1.0),              # CMS default is 1
                                                  R0 = cms.double(1.5),                  # CMS default is jet cone size
@@ -479,7 +481,7 @@ process.NjettinessCa15SoftDropPuppi = process.NjettinessCa15SoftDropCHS.clone(sr
 process.NjettinessAk8SoftDropCHS = Njettiness.clone(
                                                  src = cms.InputTag("ak8CHSJetsSoftDropforsub"),
                                                  Njets=cms.vuint32(1,2,3),          # compute 1-, 2-, 3- subjettiness
-                                                 # variables for measure definition : 
+                                                 # variables for measure definition :
                                                  measureDefinition = cms.uint32( 0 ), # CMS default is normalized measure
                                                  beta = cms.double(1.0),              # CMS default is 1
                                                  R0 = cms.double(0.8),                  # CMS default is jet cone size
@@ -537,25 +539,34 @@ process.packedPatJetsAk8PuppiJets = cms.EDProducer("JetSubstructurePacker",
 )
 
 # HOTVR & XCONE
-usePseudoXCone = cms.bool(True)
 process.hotvrPuppi = cms.EDProducer("HOTVRProducer",
-    src=cms.InputTag("puppi"),
-    usePseudoXCone=usePseudoXCone
+    src=cms.InputTag("puppi")
 )
 
 process.hotvrCHS = cms.EDProducer("HOTVRProducer",
-    src=cms.InputTag("chs"),
-    usePseudoXCone=usePseudoXCone
+    src=cms.InputTag("chs")
 )
 
+usePseudoXCone = cms.bool(True)
 process.xconePuppi = cms.EDProducer("XConeProducer",
     src=cms.InputTag("puppi"),
-    usePseudoXCone=usePseudoXCone
+    usePseudoXCone=usePseudoXCone,  # use PseudoXCone (faster) or XCone
+    NJets = cms.uint32(2),          # number of fatjets
+    RJets = cms.double(1.2),        # cone radius of fatjets
+    BetaJets = cms.double(2.0),     # conical mesure (beta = 2.0 is XCone default)
+    NSubJets = cms.uint32(3),       # number of subjets in each fatjet
+    RSubJets = cms.double(0.4),     # cone radius of subjetSrc
+    BetaSubJets = cms.double(2.0)   # conical mesure for subjets
 )
 
 process.xconeCHS = cms.EDProducer("XConeProducer",
-    src=cms.InputTag("chs"),
-    usePseudoXCone=usePseudoXCone
+    usePseudoXCone=usePseudoXCone,  # use PseudoXCone (faster) or XCone
+    NJets = cms.uint32(2),          # number of fatjets
+    RJets = cms.double(1.2),        # cone radius of fatjets
+    BetaJets = cms.double(2.0),     # conical mesure (beta = 2.0 is XCone default)
+    NSubJets = cms.uint32(3),       # number of subjets in each fatjet
+    RSubJets = cms.double(0.4),     # cone radius of subjetSrc
+    BetaSubJets = cms.double(2.0)   # conical mesure for subjets
 )
 
 ### MET
@@ -605,7 +616,7 @@ else:
     process.patPFMetCHS.addGenMET = False
     process.slimmedMETsCHS.src = cms.InputTag("patPFMetCHS")
     del process.slimmedMETsCHS.rawUncertainties # not available
-    
+
 clean_met_(process.slimmedMETsCHS)
 addMETCollection(process, labelName="slMETsCHS", metSource="slimmedMETsCHS")
 process.slMETsCHS.addGenMET = False
@@ -747,7 +758,7 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
         #    # Note: all other settings of type string are passed to the module, e.g.:
         #    TestKey = cms.string("TestValue")
         #),
-        fileName = cms.string("Ntuple.root"), 
+        fileName = cms.string("Ntuple.root"),
         doPV = cms.bool(True),
         pv_sources = cms.vstring("offlineSlimmedPrimaryVertices"),
         doRho = cms.untracked.bool(True),
@@ -770,7 +781,7 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
           'cutBasedElectronHLTPreselection_Summer16_V1',
           'heepElectronID_HEEPV60',
         ),
-        #Add variables to trace possible issues with the ECAL slew rate mitigation 
+        #Add variables to trace possible issues with the ECAL slew rate mitigation
         #https://twiki.cern.ch/twiki/bin/view/CMSPublic/ReMiniAOD03Feb2017Notes#EGM
         doEleAddVars = cms.bool(useData),
         dupECALClusters_source = cms.InputTag('particleFlowEGammaGSFixed:dupECALClusters'),
@@ -784,14 +795,14 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
         tau_etamax = cms.double(999.0),
         doPhotons = cms.bool(False),
         #photon_sources = cms.vstring("selectedPatPhotons"),
-        
+
         doJets = cms.bool(True),
         #jet_sources = cms.vstring("patJetsAk4PFCHS", "patJetsAk8PFCHS", "patJetsCa15CHSJets", "patJetsCa8CHSJets", "patJetsCa15PuppiJets", "patJetsCa8PuppiJets"),
    #     jet_sources = cms.vstring("slimmedJets","slimmedJetsPuppi"),
         jet_sources = cms.vstring("slimmedJets","slimmedJetsPuppi","patJetsAK8PFPUPPI","patJetsAK8PFCHS"),
         jet_ptmin = cms.double(10.0),
         jet_etamax = cms.double(999.0),
-        
+
         doMET = cms.bool(True),
         #met_sources =  cms.vstring("slimmedMETs","slimmedMETsPuppi","slMETsCHS","slimmedMETsMuEGClean"),
         met_sources =  met_sources_GL,
@@ -844,8 +855,8 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
 
         # switch off qjets for now, as it takes a long time:
         #topjet_qjets_sources = cms.vstring("QJetsCa15CHS", "QJetsCa8CHS", "QJetsCa8CHS", "QJetsCa15CHS"),
-        
-        doTrigger = cms.bool(True), 
+
+        doTrigger = cms.bool(True),
         trigger_bits = cms.InputTag("TriggerResults","",triggerpath),
         # MET filters (HBHE noise, CSC, etc.) are stored as trigger Bits in MINIAOD produced in path "PAT"/"RECO" with prefix "Flag_"
         metfilter_bits = cms.InputTag("TriggerResults","",metfilterpath),
@@ -855,7 +866,7 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
         # Give the names of filters for that you want to store the trigger objects that have fired the respecitve trigger
         # filter paths for a given trigger can be found in https://cmsweb.cern.ch/confdb/
         # Example: for HLT_Mu45_eta2p1 the last trigger filter is hltL3fL1sMu16orMu25L1f0L2f10QL3Filtered45e2p1Q
-        #          for HLT_Ele35_CaloIdVT_GsfTrkIdT_PFJet150_PFJet50: relevant filters are hltEle35CaloIdVTGsfTrkIdTGsfDphiFilter (last electron filter), hltEle35CaloIdVTGsfTrkIdTDiCentralPFJet50EleCleaned and hltEle35CaloIdVTGsfTrkIdTCentralPFJet150EleCleaned (for the two jets). 
+        #          for HLT_Ele35_CaloIdVT_GsfTrkIdT_PFJet150_PFJet50: relevant filters are hltEle35CaloIdVTGsfTrkIdTGsfDphiFilter (last electron filter), hltEle35CaloIdVTGsfTrkIdTDiCentralPFJet50EleCleaned and hltEle35CaloIdVTGsfTrkIdTCentralPFJet150EleCleaned (for the two jets).
         #          The  filter hltEle35CaloIdVTGsfTrkIdTCentralPFJet150EleCleaned only included redundant objects that are already included in hltEle35CaloIdVTGsfTrkIdTCentralPFJet50EleCleaned.
         #          for HLT_Ele45_CaloIdVT_GsfTrkIdT_PFJet200_PFJet50: relevant filters are hltEle45CaloIdVTGsfTrkIdTGsfDphiFilter (last electron filter), hltEle45CaloIdVTGsfTrkIdTDiCentralPFJet50EleCleaned
         triggerObjects_sources = cms.vstring(""),
@@ -870,7 +881,7 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
         trigger_objects = cms.InputTag("selectedPatTrigger"),
 
 
-        
+
         # *** gen stuff:
         doGenInfo = cms.bool(not useData),
         genparticle_source = cms.InputTag("prunedPrunedGenParticles"),
@@ -881,11 +892,11 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
         genjet_sources = cms.vstring("slimmedGenJets","slimmedGenJetsAK8","ca15GenJets"),
         genjet_ptmin = cms.double(10.0),
         genjet_etamax = cms.double(5.0),
-                            
+
         doGenTopJets = cms.bool(not useData),
         gentopjet_sources = cms.VInputTag(cms.InputTag("ak8GenJetsSoftDrop")),
         #gentopjet_sources = cms.VInputTag(cms.InputTag("ak8GenJets"),cms.InputTag("ak8GenJetsSoftDrop")), #this can be used to save N-subjettiness for ungroomed GenJets
-        gentopjet_ptmin = cms.double(150.0), 
+        gentopjet_ptmin = cms.double(150.0),
         gentopjet_etamax = cms.double(5.0),
         gentopjet_tau1 = cms.VInputTag(),
         gentopjet_tau2 = cms.VInputTag(),
@@ -893,7 +904,7 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
         #gentopjet_tau1 = cms.VInputTag(cms.InputTag("NjettinessAk8Gen","tau1"),cms.InputTag("NjettinessAk8SoftDropGen","tau1")), #this can be used to save N-subjettiness for GenJets
         #gentopjet_tau2 = cms.VInputTag(cms.InputTag("NjettinessAk8Gen","tau2"),cms.InputTag("NjettinessAk8SoftDropGen","tau2")), #this can be used to save N-subjettiness for GenJets
         #gentopjet_tau3 = cms.VInputTag(cms.InputTag("NjettinessAk8Gen","tau3"),cms.InputTag("NjettinessAk8SoftDropGen","tau3")), #this can be used to save N-subjettiness for GenJets
-        
+
         doGenJetsWithParts = cms.bool(False),
         doAllPFParticles = cms.bool(False),
         pf_collection_source = cms.InputTag("packedPFCandidates"),
@@ -902,7 +913,7 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
         doHOTVR = cms.bool(True),
         doXCone = cms.bool(True),
         doGenHOTVR = cms.bool(not useData),
-        doGenXCone = cms.bool(not useData),    
+        doGenXCone = cms.bool(not useData),
         HOTVR_sources=cms.VInputTag(
             cms.InputTag("hotvrCHS"),
             cms.InputTag("hotvrPuppi")

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -560,6 +560,7 @@ process.xconePuppi = cms.EDProducer("XConeProducer",
 )
 
 process.xconeCHS = cms.EDProducer("XConeProducer",
+    src=cms.InputTag("chs"),
     usePseudoXCone=usePseudoXCone,  # use PseudoXCone (faster) or XCone
     NJets = cms.uint32(2),          # number of fatjets
     RJets = cms.double(1.2),        # cone radius of fatjets


### PR DESCRIPTION
Now you can define the XCone setup (for RECO jets) in the Ntuplewriter.py.
One can set number of jets, cone radius and beta as well as number, radius and beta for subjets. 
If number of subjets are set to 0, no clustering of subjet is performed and empty subjet collections are added to the fatjets. The requirement of sufficient particles is now related to the number of required jets and subjets. 

I also removed a line from the HOTVR in the ntuplewriter where a bool was set which was not used.

I tested this with chs and puppi in 1000 events for both SingleElectron and ttbar.