### PR TITLE
[80Xv5] Fix typo where -ve ele/mu not considered in GenXCone23

### DIFF
--- a/core/src/UniversalGenJetCluster.cxx
+++ b/core/src/UniversalGenJetCluster.cxx
@@ -14,7 +14,8 @@ UniversalGenJetCluster::UniversalGenJetCluster(vector<GenParticle> *genparticles
     {
       //      _psj.push_back(ConvertGenToPsj(&(genparticles->at(i))));
       _psj.push_back(ConvertGenToPsj(genparticles->at(i))); //TEST
-      if(abs(genparticles->at(i).pdgId()==11) || abs(genparticles->at(i).pdgId()==13)){
+      uint pdgid = abs(genparticles->at(i).pdgId());
+      if(pdgid==11 || pdgid==13){
 	if(genparticles->at(i).v4().Pt() > pt_max){
 	  pt_max = genparticles->at(i).v4().Pt();
 	  lepton = genparticles->at(i);


### PR DESCRIPTION
The closing `)` was in the wrong place.

NB this has some physics consequences - it means that sometimes the highest pT e/mu gets ignored, and another one found, so that the "leptonic" jet is incorrectly identified and thus # subjets is wrong.