### PR TITLE
[94X] Forward-port of HOTVR/XCone changes from 80Xv5

### DIFF
--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -527,7 +527,7 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
   }
   if(doGenInfo){
     genparticle_token = consumes<reco::GenParticleCollection>(iConfig.getParameter<edm::InputTag>("genparticle_source"));
-    if(doAllGenParticles) stablegenparticle_token = consumes<edm::View<pat::PackedGenParticle> >(iConfig.getParameter<edm::InputTag>("stablegenparticle_source"));
+    if(doAllGenParticles) stablegenparticle_token = consumes<edm::View<reco::Candidate> >(iConfig.getParameter<edm::InputTag>("stablegenparticle_source"));
     event->genInfo = new GenInfo();
     event->genparticles = new vector<GenParticle>();
     branch(tr, "genInfo","GenInfo", event->genInfo);
@@ -585,7 +585,7 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
   // GenJets
   if(doGenHOTVR || doGenXCone)
     {
-      stablegenparticle_token = consumes<edm::View<pat::PackedGenParticle> >(iConfig.getParameter<edm::InputTag>("stablegenparticle_source"));
+      stablegenparticle_token = consumes<edm::View<reco::Candidate> >(iConfig.getParameter<edm::InputTag>("stablegenparticle_source"));
      if(doGenHOTVR)
         {
           branch(tr, "genHOTVRTopJets", "std::vector<GenTopJet>", &genhotvrJets);
@@ -796,13 +796,13 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
      //store stable gen particles from packed collection
      if(doAllGenParticles){
-       edm::Handle<edm::View<pat::PackedGenParticle> > packed;
+       edm::Handle<edm::View<reco::Candidate> > packed;
        // use packed particle collection for all STABLE (status 1) particles
        iEvent.getByToken(stablegenparticle_token,packed);
 
        for(size_t j=0; j<packed->size();j++){
          bool skip_particle = false;
-         const pat::PackedGenParticle* iter = &(*packed)[j];
+         const pat::PackedGenParticle* iter = dynamic_cast<const pat::PackedGenParticle*>(&(packed->at(j)));
          //      if(iter->status()!=1) cout<<"iter->status() = "<<iter->status()<<endl;
          if(doAllGenParticlesPythia8){//for pythia8: store particles with status code, see http://home.thep.lu.se/~torbjorn/pythia81html/ParticleProperties.html
            if(iter->status()<2)
@@ -1369,13 +1369,13 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
   if(doGenHOTVR || doGenXCone)
      {
-       edm::Handle<edm::View<pat::PackedGenParticle> > packed;
+       edm::Handle<edm::View<reco::Candidate> > packed;
        // use packed particle collection for all STABLE (status 1) particles
        iEvent.getByToken(stablegenparticle_token,packed);
        vector<GenParticle> genparticles;
        for(size_t j=0; j<packed->size();j++){
 
-         const pat::PackedGenParticle* iter = &(*packed)[j];
+         const pat::PackedGenParticle* iter = dynamic_cast<const pat::PackedGenParticle*>(&(packed->at(j)));
          if(iter->status()!=1) continue;
 
          GenParticle genp;

--- a/core/plugins/XConeProducer.cc
+++ b/core/plugins/XConeProducer.cc
@@ -67,12 +67,12 @@ class XConeProducer : public edm::global::EDProducer<> {
     edm::EDGetToken src_token_;
     const std::string subjetCollName_;
     const bool usePseudoXCone_;
-    unsigned int NJets_;
-    double RJets_;
-    double BetaJets_;
-    unsigned int NSubJets_;
-    double RSubJets_;
-    double BetaSubJets_;
+    unsigned int NJets_ = 2;
+    double RJets_ = 1.2;
+    double BetaJets_ = 2.0;
+    unsigned int NSubJets_ = 3;
+    double RSubJets_ = 0.4;
+    double BetaSubJets_ = 2.0;
 };
 
 //

--- a/core/plugins/XConeProducer.cc
+++ b/core/plugins/XConeProducer.cc
@@ -67,6 +67,12 @@ class XConeProducer : public edm::global::EDProducer<> {
     edm::EDGetToken src_token_;
     const std::string subjetCollName_;
     const bool usePseudoXCone_;
+    unsigned int NJets_;
+    double RJets_;
+    double BetaJets_;
+    unsigned int NSubJets_;
+    double RSubJets_;
+    double BetaSubJets_;
 };
 
 //
@@ -84,7 +90,13 @@ class XConeProducer : public edm::global::EDProducer<> {
 XConeProducer::XConeProducer(const edm::ParameterSet& iConfig):
   src_token_(consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("src"))),
   subjetCollName_("SubJets"),
-  usePseudoXCone_(iConfig.getParameter<bool>("usePseudoXCone"))
+  usePseudoXCone_(iConfig.getParameter<bool>("usePseudoXCone")),
+  NJets_(iConfig.getParameter<unsigned int>("NJets")),
+  RJets_(iConfig.getParameter<double>("RJets")),
+  BetaJets_(iConfig.getParameter<double>("BetaJets")),
+  NSubJets_(iConfig.getParameter<unsigned int>("NSubJets")),
+  RSubJets_(iConfig.getParameter<double>("RSubJets")),
+  BetaSubJets_(iConfig.getParameter<double>("BetaSubJets"))
 {
   // We make both the fat jets and subjets, and we must store them as separate collections
   produces<pat::JetCollection>();
@@ -155,7 +167,9 @@ XConeProducer::produce(edm::StreamID id, edm::Event& iEvent, const edm::EventSet
     _psj.push_back(PseudoJet(cand.px(), cand.py(), cand.pz(), cand.energy()));
   }
 
-  if (_psj.size() < 15) {
+  // make sure to have enough particles with non-zero momentum in event
+  unsigned int minParticleCount = NJets_ * 3;
+  if (_psj.size() < minParticleCount) {
     auto jetCollection = std::make_unique<pat::JetCollection>();
     iEvent.put(std::move(jetCollection));
     auto subjetCollection = std::make_unique<pat::JetCollection>();
@@ -163,114 +177,89 @@ XConeProducer::produce(edm::StreamID id, edm::Event& iEvent, const edm::EventSet
     return;
   }
 
+  // declare jet collections
+  auto jetCollection = std::make_unique<pat::JetCollection>();
+  auto subjetCollection = std::make_unique<pat::JetCollection>();
+  std::vector< std::vector<int> > indices;
 
-  // Run first clustering step (N=2, R=1.2)
+  // Run clustering of fatjets
   vector<PseudoJet> fatjets;
   std::unique_ptr<NjettinessPlugin> plugin_xcone;
-  initPlugin(plugin_xcone, 2, 1.2, 2.0, usePseudoXCone_);
+  initPlugin(plugin_xcone, NJets_, RJets_, BetaJets_, usePseudoXCone_);
   double ghost_maxrap = 4.0;      // maxiumum y of ghost particles
   AreaDefinition area_def(active_area, GhostedAreaSpec(ghost_maxrap));
   JetDefinition jet_def_xcone(plugin_xcone.get());
   ClusterSequence clust_seq_xcone(_psj, jet_def_xcone);
   fatjets = sorted_by_pt(clust_seq_xcone.inclusive_jets(0));
 
-  // get SoftDrop Mass
+  // get SoftDrop Mass for every fat jet
   SoftDrop sd(0.0, 0.1, 1.2);
-  PseudoJet sdjet1 = sd(fatjets[0]);
-  PseudoJet sdjet2 = sd(fatjets[1]);
-  float sd_mass1 = sdjet1.m();
-  float sd_mass2 = sdjet2.m();
+  vector<float> sd_mass;
+  for(unsigned int i=0; i<fatjets.size(); i++){
+    PseudoJet sdjet = sd(fatjets[i]);
+    sd_mass.push_back(sdjet.m());
+  }
 
-  // get and wirte list: if particle i is clustered in jet j, the i-th entry of the list == j
+  // check if subjets should be clustered
+  bool doSubjets = true;
+  if(NSubJets_ == 0) doSubjets = false;
+
+  // first get and wirte list of particles in fatjets:
+  // if particle i is clustered in jet j, the i-th entry of the list == j
   vector<int> list_fat;
   list_fat.clear();
   list_fat = clust_seq_xcone.particle_jet_indices(fatjets);
-  vector<PseudoJet> particle_in_fat1, particle_in_fat2;
 
-  // get one set of particles for each jet
-  for (unsigned int ipart=0; ipart < _psj.size(); ++ipart) {
-    if (list_fat[ipart]==0) {
-      particle_in_fat1.push_back(_psj.at(ipart)); // get vector as PseudoJet for fatjet 1
+  // loop over all fatjets and cluster subjets
+  for(unsigned int i=0; i<fatjets.size(); i++){
+    // get set of particles in fatjet i
+    vector<PseudoJet> particle_in_fatjet;
+    for (unsigned int ipart=0; ipart < _psj.size(); ++ipart) {
+      if (list_fat[ipart] < 0) continue;
+      else if (abs(list_fat[ipart])==i) {
+        particle_in_fatjet.push_back(_psj.at(ipart));
+      }
     }
-    if (list_fat[ipart]==1) {
-      particle_in_fat2.push_back(_psj.at(ipart)); // get vector as PseudoJet for fatjet 2
+
+    // check if there are more particles then required subjets
+    bool enoughParticles = (particle_in_fatjet.size() > NSubJets_);
+    if (!enoughParticles) {
+      edm::LogWarning("InsufficientParticles")
+        << "Not enough particles in fatjet 1 to run second XCone step: "
+        << std::to_string(particle_in_fatjet.size())
+        << std::endl;
     }
-  }
 
-  uint minParticlesPerJet = 3;
-  bool doJet1Subjets = (particle_in_fat1.size() > minParticlesPerJet);
-  if (!doJet1Subjets) {
-    edm::LogWarning("InsufficientParticles")
-      << "Not enough particles in fatjet 1 to run second XCone step: "
-      << std::to_string(particle_in_fat1.size())
-      << std::endl;
-  }
+    // Run second clustering step (subjets) for each fat jet
+    vector<PseudoJet> subjets;
+    vector<double> subjet_area;
+    if (enoughParticles && doSubjets) {
+      std::unique_ptr<NjettinessPlugin> plugin_xcone_sub;
+      initPlugin(plugin_xcone_sub, NSubJets_, RSubJets_, BetaSubJets_, usePseudoXCone_);
+      JetDefinition jet_def_sub(plugin_xcone_sub.get());
+      ClusterSequenceArea clust_seq_sub(particle_in_fatjet, jet_def_sub, area_def);
+      subjets = sorted_by_pt(clust_seq_sub.inclusive_jets(0));
+      for (unsigned int j = 0; j < subjets.size(); ++j) subjet_area.push_back(subjets[j].area());
+    }
 
-  bool doJet2Subjets = (particle_in_fat2.size() > minParticlesPerJet);
-  if (!doJet2Subjets) {
-    edm::LogWarning("InsufficientParticles")
-      << "Not enough particles in fatjet 2 to run second XCone step: "
-      << std::to_string(particle_in_fat2.size())
-      << std::endl;
-  }
+    // jet area for fat jet
+    double jet_area = 0;
+    // double jet_area = fatjets[i].area();
 
-  // Run second clustering step (N=3, R=0.4) for each fat jet
-  vector<PseudoJet> subjets_1, subjets_2;
+    // pat-ify fatjets
+    auto patJet = createPatJet(fatjets[i]);
+    patJet.setJetArea(jet_area);
+    patJet.addUserFloat("softdropmass", sd_mass[i]);
+    jetCollection->push_back(patJet);
 
-  // subjets from fat jet 1
-  vector<double> subjet1_area;
-  if (doJet1Subjets) {
-    std::unique_ptr<NjettinessPlugin> plugin_xcone_sub1;
-    initPlugin(plugin_xcone_sub1, 3, 0.4, 2.0, usePseudoXCone_);
-    JetDefinition jet_def_sub1(plugin_xcone_sub1.get());
-    ClusterSequenceArea clust_seq_sub1(particle_in_fat1, jet_def_sub1, area_def);
-    subjets_1 = sorted_by_pt(clust_seq_sub1.inclusive_jets(0));
-    for (unsigned int j = 0; j < subjets_1.size(); ++j) subjet1_area.push_back(subjets_1[j].area());
-  }
+    indices.resize(jetCollection->size());
+    for (uint s=0; s<subjets.size(); s++) {
+      indices[i].push_back(subjetCollection->size());
+      auto subjet = createPatJet(subjets[s]);
+      subjet.setJetArea(subjet_area[s]);
+      subjetCollection->push_back(subjet);
+    }
 
-  //subjets from fat jet 2
-  vector<double> subjet2_area;
-  if (doJet2Subjets) {
-    std::unique_ptr<NjettinessPlugin> plugin_xcone_sub2;
-    initPlugin(plugin_xcone_sub2, 3, 0.4, 2.0, usePseudoXCone_);
-    JetDefinition jet_def_sub2(plugin_xcone_sub2.get());
-    ClusterSequenceArea clust_seq_sub2(particle_in_fat2, jet_def_sub2, area_def);
-    subjets_2 = sorted_by_pt(clust_seq_sub2.inclusive_jets(0));
-    for (unsigned int k = 0; k < subjets_2.size(); ++k) subjet2_area.push_back(subjets_2[k].area());
-  }
-
-  double jet1_area = 0;
-  double jet2_area = 0;
-  //double jet1_area = fatjets[0].area();
-  //double jet2_area = fatjets[1].area();
-
-  // pat-ify jets and subjets
-  auto jetCollection = std::make_unique<pat::JetCollection>();
-
-  auto patJet1 = createPatJet(fatjets[0]);
-  patJet1.setJetArea(jet1_area);
-  patJet1.addUserFloat("softdropmass", sd_mass1);
-  jetCollection->push_back(patJet1);
-
-  auto patJet2 = createPatJet(fatjets[1]);
-  patJet2.setJetArea(jet2_area);
-  patJet2.addUserFloat("softdropmass", sd_mass2);
-  jetCollection->push_back(patJet2);
-
-  auto subjetCollection = std::make_unique<pat::JetCollection>();
-  std::vector< std::vector<int> > indices;
-  indices.resize(jetCollection->size());
-  for (uint s=0; s<subjets_1.size(); s++) {
-    indices[0].push_back(subjetCollection->size());
-    auto subjet = createPatJet(subjets_1[s]);
-    subjet.setJetArea(subjet1_area[s]);
-    subjetCollection->push_back(subjet);
-  }
-  for (uint s=0; s<subjets_2.size(); s++) {
-    indices[1].push_back(subjetCollection->size());
-    auto subjet = createPatJet(subjets_2[s]);
-    subjet.setJetArea(subjet2_area[s]);
-    subjetCollection->push_back(subjet);
   }
 
   edm::OrphanHandle<pat::JetCollection> subjetHandleAfterPut = iEvent.put(std::move(subjetCollection), subjetCollName_);

--- a/core/plugins/XConeProducer.cc
+++ b/core/plugins/XConeProducer.cc
@@ -223,12 +223,6 @@ XConeProducer::produce(edm::StreamID id, edm::Event& iEvent, const edm::EventSet
 
     // check if there are more particles then required subjets
     bool enoughParticles = (particle_in_fatjet.size() > NSubJets_);
-    if (!enoughParticles) {
-      edm::LogWarning("InsufficientParticles")
-        << "Not enough particles in fatjet 1 to run second XCone step: "
-        << std::to_string(particle_in_fatjet.size())
-        << std::endl;
-    }
 
     // Run second clustering step (subjets) for each fat jet
     vector<PseudoJet> subjets;

--- a/core/plugins/XConeProducer.cc
+++ b/core/plugins/XConeProducer.cc
@@ -197,8 +197,20 @@ XConeProducer::produce(edm::StreamID id, edm::Event& iEvent, const edm::EventSet
     }
   }
 
-  if(particle_in_fat1.size() < 3 || particle_in_fat2.size()<3) {
-    cms::Exception("InsufficientParticles", "Not enough particles to run second XCone step");
+  uint minParticlesPerJet = 3;
+  if(particle_in_fat1.size() < minParticlesPerJet || particle_in_fat2.size() < minParticlesPerJet) {
+    edm::LogWarning("InsufficientParticles")
+      << "Not enough particles in fatjets to run second XCone step (# in jet1, jet2): "
+      << std::to_string(particle_in_fat1.size())
+      << ", " << std::to_string(particle_in_fat2.size())
+      << " - will insert empty fatjets & subjets"
+      << std::endl;
+
+    auto jetCollection = std::make_unique<pat::JetCollection>();
+    iEvent.put(std::move(jetCollection));
+    auto subjetCollection = std::make_unique<pat::JetCollection>();
+    iEvent.put(std::move(subjetCollection), subjetCollName_);
+    return;
   }
 
   // Run second clustering step (N=3, R=0.4) for each fat jet

--- a/core/plugins/XConeProducer.cc
+++ b/core/plugins/XConeProducer.cc
@@ -140,14 +140,6 @@ XConeProducer::produce(edm::StreamID id, edm::Event& iEvent, const edm::EventSet
   edm::Handle<edm::View<reco::Candidate>> particles;
   iEvent.getByToken(src_token_, particles);
 
-  if (particles->size() < 15) {
-    auto jetCollection = std::make_unique<pat::JetCollection>();
-    iEvent.put(std::move(jetCollection));
-    auto subjetCollection = std::make_unique<pat::JetCollection>();
-    iEvent.put(std::move(subjetCollection), subjetCollName_);
-    return;
-  }
-
   // Convert particles to PseudoJets
   std::vector<PseudoJet> _psj;
   for (const auto & cand: *particles) {
@@ -162,6 +154,15 @@ XConeProducer::produce(edm::StreamID id, edm::Event& iEvent, const edm::EventSet
 
     _psj.push_back(PseudoJet(cand.px(), cand.py(), cand.pz(), cand.energy()));
   }
+
+  if (_psj.size() < 15) {
+    auto jetCollection = std::make_unique<pat::JetCollection>();
+    iEvent.put(std::move(jetCollection));
+    auto subjetCollection = std::make_unique<pat::JetCollection>();
+    iEvent.put(std::move(subjetCollection), subjetCollName_);
+    return;
+  }
+
 
   // Run first clustering step (N=2, R=1.2)
   vector<PseudoJet> fatjets;

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -989,13 +989,25 @@ task.add(process.hotvrCHS)
 usePseudoXCone = cms.bool(True)
 process.xconePuppi = cms.EDProducer("XConeProducer",
     src=cms.InputTag("puppi"),
-    usePseudoXCone=usePseudoXCone
+    usePseudoXCone=usePseudoXCone,  # use PseudoXCone (faster) or XCone
+    NJets = cms.uint32(2),          # number of fatjets
+    RJets = cms.double(1.2),        # cone radius of fatjets
+    BetaJets = cms.double(2.0),     # conical mesure (beta = 2.0 is XCone default)
+    NSubJets = cms.uint32(3),       # number of subjets in each fatjet
+    RSubJets = cms.double(0.4),     # cone radius of subjetSrc
+    BetaSubJets = cms.double(2.0)   # conical mesure for subjets
 )
 task.add(process.xconePuppi)
 
 process.xconeCHS = cms.EDProducer("XConeProducer",
     src=cms.InputTag("chs"),
-    usePseudoXCone=usePseudoXCone
+    usePseudoXCone=usePseudoXCone,  # use PseudoXCone (faster) or XCone
+    NJets = cms.uint32(2),          # number of fatjets
+    RJets = cms.double(1.2),        # cone radius of fatjets
+    BetaJets = cms.double(2.0),     # conical mesure (beta = 2.0 is XCone default)
+    NSubJets = cms.uint32(3),       # number of subjets in each fatjet
+    RSubJets = cms.double(0.4),     # cone radius of subjetSrc
+    BetaSubJets = cms.double(2.0)   # conical mesure for subjets
 )
 task.add(process.xconeCHS)
 

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -1471,7 +1471,7 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
                                 genparticle_source=cms.InputTag(
                                     "prunedPrunedGenParticles"),
                                 stablegenparticle_source=cms.InputTag(
-                                    "packedGenParticles"),
+                                    "packedGenParticlesForJetsNoNu"),
                                 # set to true if you want to store all gen particles, otherwise, only
                                 # prunedPrunedGenParticles are stored (see
                                 # above)

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -986,13 +986,16 @@ process.hotvrCHS = cms.EDProducer("HOTVRProducer",
 )
 task.add(process.hotvrCHS)
 
+usePseudoXCone = cms.bool(True)
 process.xconePuppi = cms.EDProducer("XConeProducer",
-    src=cms.InputTag("puppi")
+    src=cms.InputTag("puppi"),
+    usePseudoXCone=usePseudoXCone
 )
 task.add(process.xconePuppi)
 
 process.xconeCHS = cms.EDProducer("XConeProducer",
-    src=cms.InputTag("chs")
+    src=cms.InputTag("chs"),
+    usePseudoXCone=usePseudoXCone
 )
 task.add(process.xconeCHS)
 

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -981,15 +981,20 @@ process.hotvrPuppi = cms.EDProducer("HOTVRProducer",
 )
 task.add(process.hotvrPuppi)
 
-process.hotvrPfCand = cms.EDProducer("HOTVRProducer",
-    src=cms.InputTag("packedPFCandidates")
+process.hotvrCHS = cms.EDProducer("HOTVRProducer",
+    src=cms.InputTag("chs")
 )
-task.add(process.hotvrPfCand)
+task.add(process.hotvrCHS)
 
-process.xconePfCand = cms.EDProducer("XConeProducer",
-    src=cms.InputTag("packedPFCandidates")
+process.xconePuppi = cms.EDProducer("XConeProducer",
+    src=cms.InputTag("puppi")
 )
-task.add(process.xconePfCand)
+task.add(process.xconePuppi)
+
+process.xconeCHS = cms.EDProducer("XConeProducer",
+    src=cms.InputTag("chs")
+)
+task.add(process.xconeCHS)
 
 
 # LEPTON cfg
@@ -1503,10 +1508,13 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
                                 doHOTVR=cms.bool(True),
                                 doXCone=cms.bool(True),
                                 HOTVR_sources=cms.VInputTag(
-                                    cms.InputTag("hotvrPfCand"),
+                                    cms.InputTag("hotvrCHS"),
                                     cms.InputTag("hotvrPuppi")
                                 ),
-                                XCone_sources=cms.VInputTag(cms.InputTag("xconePfCand")),
+                                XCone_sources=cms.VInputTag(
+                                    cms.InputTag("xconeCHS"),
+                                    cms.InputTag("xconePuppi")
+                                ),
 
                                 doGenHOTVR=cms.bool(not useData),
                                 doGenXCone=cms.bool(not useData),

--- a/core/src/UniversalGenJetCluster.cxx
+++ b/core/src/UniversalGenJetCluster.cxx
@@ -14,7 +14,8 @@ UniversalGenJetCluster::UniversalGenJetCluster(vector<GenParticle> *genparticles
     {
       //      _psj.push_back(ConvertGenToPsj(&(genparticles->at(i))));
       _psj.push_back(ConvertGenToPsj(genparticles->at(i))); //TEST
-      if(abs(genparticles->at(i).pdgId()==11) || abs(genparticles->at(i).pdgId()==13)){
+      uint pdgid = abs(genparticles->at(i).pdgId());
+      if(pdgid==11 || pdgid==13){
 	if(genparticles->at(i).v4().Pt() > pt_max){
 	  pt_max = genparticles->at(i).v4().Pt();
 	  lepton = genparticles->at(i);


### PR DESCRIPTION
Covers:
- Move to CHS & PUPPI for both XCone/HOTVR
- Allow user to choose PseudoXcone or normal (default = pseudo)
- Allow user to configure XCone plugin settings
- Gen level XCone/HOTVR now doesn't include neutrinos
- Properly handle cases where too few particles in XCone

Also includes equivalent fixes for #935 , #936 