### PR TITLE
bug fixed in trigger pass

### DIFF
--- a/core/src/Event.cxx
+++ b/core/src/Event.cxx
@@ -85,15 +85,15 @@ bool Event::lookup_trigger_index(TriggerIndex & ti) const{
             }
         }
     }
-    if(ti.runid == -1){
+    if(ti.runid == -1 || ti.index >= triggerNames_currentrun.size()){
         return false;
     }
-    assert(ti.index < triggerNames_currentrun.size());
+    
     return true;
 }
 
 namespace {
-    
+
 string format_list(const vector<string> & l){
     string result;
     for(const auto & i : l){
@@ -140,5 +140,3 @@ bool Event::trigger_prescale(TriggerIndex & ti) const{
     assert(triggerNames_currentrun.size() == triggerPrescales->size());
     return triggerPrescales->at(ti.index);
 }
-
-


### PR DESCRIPTION
This commit is to raise the same error: assertion error ->runtime error. It's easier to catch.
In the past runtime error was raised if the trigger Name was not present since the first event of the sample. Whereas assertion occurs if the trigger name was not present in the middle of the sample. 
Now both cases raise a runtime error.