### PR TITLE
[80Xv6] Fix subjet area - don't merge yet! - questions for users

### DIFF
--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -569,6 +569,7 @@ addJetCollection(process,labelName = 'AK8PFCHS', jetSource = cms.InputTag('ak8CH
     elSource = cms.InputTag('slimmedElectrons')
 )
 
+# Pack together ungroomed and groomed parts
 process.packedPatJetsAk8PuppiJets = cms.EDProducer("JetSubstructurePacker",
     jetSrc = cms.InputTag("patJetsAk8PuppiJetsFat"),
     distMax = cms.double(0.8),
@@ -577,6 +578,18 @@ process.packedPatJetsAk8PuppiJets = cms.EDProducer("JetSubstructurePacker",
     ),
     algoLabels = cms.vstring(
         'SoftDropPuppi'
+    ),
+    fixDaughters = cms.bool(False)
+)
+
+process.packedPatJetsAk8CHSJets = cms.EDProducer("JetSubstructurePacker",
+    jetSrc = cms.InputTag("patJetsAk8CHSJets"),
+    distMax = cms.double(0.8),
+    algoTags = cms.VInputTag(
+        cms.InputTag("patJetsAk8CHSJetsSoftDropPacked")
+    ),
+    algoLabels = cms.vstring(
+        'SoftDrop'
     ),
     fixDaughters = cms.bool(False)
 )
@@ -895,11 +908,12 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
         topjet_etamax = cms.double(5.0),
         # The collection here determines the pt, eta, energy fractions, daughters etc for a TopJet collection
         # Thus you should be careful if you are using groomed or ungroomed collections
-        # Use a JetSubstructurePacker if you want ungroomed, along with the correct subjet name in subjet_sources
-        topjet_sources = cms.vstring("slimmedJetsAK8","patJetsAk8CHSJetsSoftDropPacked","patJetsHepTopTagCHSPacked","patJetsHepTopTagPuppiPacked","packedPatJetsAk8PuppiJets"),
+        # The BoostedJetMerger collection should be used for groomed jet quantities,
+        # but use a JetSubstructurePacker if you want ungroomed (along with the correct subjet name in subjet_sources)
+        topjet_sources = cms.vstring("slimmedJetsAK8","packedPatJetsAk8CHSJets","patJetsHepTopTagCHSPacked","patJetsHepTopTagPuppiPacked","packedPatJetsAk8PuppiJets"),
         #Note: use label "daughters" for  subjet_sources if you want to store as subjets the linked daughters of the topjets (NOT for slimmedJetsAK8 in miniAOD!)
         #to store a subjet collection present in miniAOD indicate the proper label of the subjets method in pat::Jet: SoftDrop or CMSTopTag
-        subjet_sources = cms.vstring("SoftDrop","daughters","daughters","daughters","SoftDropPuppi"),
+        subjet_sources = cms.vstring("SoftDrop","SoftDrop","daughters","daughters","SoftDropPuppi"),
         #Specify "store" if you want to store b-tagging taginfos for subjet collection, make sure to have included them with .addTagInfos = True
         #addTagInfos = True is currently true by default, however, only for collections produced and not read directly from miniAOD
         #If you don't want to store stubjet taginfos leave string empy ""

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -387,11 +387,10 @@ def add_fatjets_subjets(process, fatjets_name, groomed_jets_name, jetcorr_label 
         assert groomed_jetproducer.type_() in ('FastjetJetProducer', 'CATopJetProducer'), "do not know how to construct genjet collection for %s" % repr(groomed_jetproducer)
         groomed_genjets_name = genjets_name(groomed_jets_name)
         if verbose: print "Adding groomed genjets ", groomed_genjets_name
-        # disable area calcuation as faster + only needed for L1JEC anyway
         groomed_genjet_producer = groomed_jetproducer.clone(
             src=cms.InputTag('packedGenParticlesForJetsNoNu'),
             jetType='GenJet',
-            doAreaFastjet=cms.bool(False)
+            doAreaFastjet=cms.bool(True)
         )
         duplicate_name = check_for_duplicate_module(process, groomed_genjet_producer)
         if duplicate_name:
@@ -403,11 +402,10 @@ def add_fatjets_subjets(process, fatjets_name, groomed_jets_name, jetcorr_label 
         assert ungroomed_jetproducer.type_() == 'FastjetJetProducer'
         ungroomed_genjets_name = genjets_name(fatjets_name)
         if verbose: print "Adding ungroomed genjets ", ungroomed_genjets_name
-        # disable area calcuation as faster + only needed for L1JEC anyway
         ungroomed_genjet_producer = ungroomed_jetproducer.clone(
             src=cms.InputTag('packedGenParticlesForJetsNoNu'),
             jetType='GenJet',
-            doAreaFastjet=cms.bool(False)
+            doAreaFastjet=cms.bool(True)
         )
         duplicate_name = check_for_duplicate_module(process, ungroomed_genjet_producer)
         if duplicate_name:

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -255,8 +255,8 @@ process.hepTopTagCHS = cms.EDProducer(
 ### Softdrop
 
 from RecoJets.Configuration.RecoPFJets_cff import ak8PFJetsCHS
-process.ak8CHSJetsSoftDrop = ak8PFJetsCHSSoftDrop.clone(src = cms.InputTag('chs'), jetPtMin = fatjet_ptmin)
-process.ca15CHSJetsSoftDrop = ak8PFJetsCHSSoftDrop.clone(src = cms.InputTag('chs'), jetPtMin = fatjet_ptmin, jetAlgorithm = cms.string("CambridgeAachen"), rParam = 1.5, R0 = 1.5, zcut = cms.double(0.2), beta = cms.double(1.0))
+process.ak8CHSJetsSoftDrop = ak8PFJetsCHSSoftDrop.clone(src = cms.InputTag('chs'), jetPtMin = fatjet_ptmin, doAreaFastjet = cms.bool(True))  # need the area for L1 JEC on subjets
+process.ca15CHSJetsSoftDrop = ak8PFJetsCHSSoftDrop.clone(src = cms.InputTag('chs'), jetPtMin = fatjet_ptmin, jetAlgorithm = cms.string("CambridgeAachen"), rParam = 1.5, R0 = 1.5, zcut = cms.double(0.2), beta = cms.double(1.0), doAreaFastjet = cms.bool(True))
 process.ca15CHSJetsSoftDropforsub = process.ca8CHSJets.clone (rParam = 1.5, jetPtMin = fatjet_ptmin, zcut = cms.double(0.2), beta = cms.double(1.0), useSoftDrop = cms.bool(True), useExplicitGhosts = cms.bool(True), R0 = cms.double(1.5))
 process.ak8CHSJetsSoftDropforsub = process.ak8CHSJetsFat.clone (rParam = 0.8, jetPtMin = fatjet_ptmin, zcut = cms.double(0.1), beta = cms.double(0.0), useSoftDrop = cms.bool(True), useExplicitGhosts = cms.bool(True), R0 = cms.double(0.8))
 
@@ -276,7 +276,7 @@ process.puppi.useExistingWeights   = cms.bool(True)
 
 process.ca15PuppiJetsSoftDrop = ak8PFJetsCHSSoftDrop.clone(src = cms.InputTag('puppi'), jetPtMin = fatjet_ptmin, jetAlgorithm = cms.string("CambridgeAachen"), rParam = 1.5, R0 = 1.5, zcut = cms.double(0.2), beta = cms.double(1.0))
 
-process.ak8PuppiJetsSoftDrop = ak8PFJetsCHSSoftDrop.clone(src = cms.InputTag('puppi'), jetPtMin = fatjet_ptmin*safety_factor)
+process.ak8PuppiJetsSoftDrop = ak8PFJetsCHSSoftDrop.clone(src = cms.InputTag('puppi'), jetPtMin = fatjet_ptmin*safety_factor, doAreaFastjet = cms.bool(True))
 
 process.ca15PuppiJetsSoftDropforsub = process.ca8CHSJets.clone (rParam = 1.5, jetPtMin = fatjet_ptmin, zcut = cms.double(0.2), beta = cms.double(1.0), useSoftDrop = cms.bool(True), useExplicitGhosts = cms.bool(True), R0 = cms.double(1.5), src = cms.InputTag('puppi'))
 process.ak8PuppiJetsSoftDropforsub = process.ak8CHSJetsFat.clone (rParam = 0.8, jetPtMin = fatjet_ptmin*safety_factor, zcut = cms.double(0.1), beta = cms.double(0.0), useSoftDrop = cms.bool(True), useExplicitGhosts = cms.bool(True), R0 = cms.double(0.8), src = cms.InputTag('puppi'))
@@ -362,13 +362,15 @@ def add_fatjets_subjets(process, fatjets_name, groomed_jets_name, jetcorr_label 
         assert groomed_jetproducer.type_() in ('FastjetJetProducer', 'CATopJetProducer'), "do not know how to construct genjet collection for %s" % repr(groomed_jetproducer)
         groomed_genjets_name = genjets_name(groomed_jets_name)
         if verbose: print "Adding groomed genjets ", groomed_genjets_name
-        setattr(process, groomed_genjets_name, groomed_jetproducer.clone(src = cms.InputTag('packedGenParticlesForJetsNoNu'), jetType = 'GenJet'))
+        # disable area calcuation as faster + only needed for L1JEC anyway
+        setattr(process, groomed_genjets_name, groomed_jetproducer.clone(src = cms.InputTag('packedGenParticlesForJetsNoNu'), jetType = 'GenJet', doAreaFastjet = cms.bool(False)))
         # add for ungroomed jets if not done yet (maybe never used in case ungroomed are not added, but that's ok ..)
         ungroomed_jetproducer = getattr(process, fatjets_name)
         assert ungroomed_jetproducer.type_() == 'FastjetJetProducer'
         ungroomed_genjets_name = genjets_name(fatjets_name)
         if verbose: print "Adding ungroomed genjets ", ungroomed_genjets_name
-        setattr(process, ungroomed_genjets_name, ungroomed_jetproducer.clone(src = cms.InputTag('packedGenParticlesForJetsNoNu'), jetType = 'GenJet'))
+        # disable area calcuation as faster + only needed for L1JEC anyway
+        setattr(process, ungroomed_genjets_name, ungroomed_jetproducer.clone(src = cms.InputTag('packedGenParticlesForJetsNoNu'), jetType = 'GenJet', doAreaFastjet = cms.bool(False)))
 
 
     # patify ungroomed jets, if not already done:


### PR DESCRIPTION
This adds in area for the subjets for the `patJetsAk8CHSJetsSoftDropPacked_daughters` and `packedPatJetsAk8PuppiJets_SoftDropPuppi` collections by enabling `doAreaFastjet` in their respective softdrop FastjetJetProducer modules.

**Important:** as a side-effect, it also adds in jet area for the main fatjets in `patJetsAk8CHSJetsSoftDropPacked_daughters` (which are **groomed**). 
**Since we apply L1 JEC to those jets, the main fat jet pt & number of jets also changes!** (since we apply a pT cut of 150 GeV on incoming topjet collection)

Previously, since the main jet area was 0, there wasn't any L1 correction applied.

The main jet pt in `packedPatJetsAk8PuppiJets_SoftDropPuppi` already had jet area, since it's ungroomed, so the main jet pt etc is not affected.

Since calculating the jet area is slowwww, we see a slight increase in runtime:

```
time [s] / event
ak8CHSJetsSoftDrop: 0.004 -> 0.042
ak8PuppiJetsSoftDrop: 0.0005 -> 0.034
ak8GenJetsSoftDrop: 0.0015 -> 0.036
```

However, I also spotted that there are some duplicate genjet producers being added. I have now added a function to spot these and remove them, which removes `ak8GenJetsFat`, saving ~ 0.037s /evt. So overall not a massive penalty to pay. Altogether, this increases runtime ~0.08s/evt.

Some questions for users before merging, especially @karavdin @tordreyer:

- are you happy with the changes for the AK8CHS topjets, especially the change in pT & number of jets?

- do you need the corresponding genjet areas? At the moment they are enabled (they weren't before for `ak8GenJetsSoftDrop`, which although we save, we don't store the genjet area). Disabling would regain a little time (~0.2s / evt)

- do we actually want the area for the PUPPI subjets?

- are the main fatjet & subjet areas needed for the two HepTopTag TopJet collections? At the moment they are all 0.