### PR TITLE
[94X_v3] Update to electron V2 cut & MVA IDs from V1

### DIFF
--- a/core/include/Electron.h
+++ b/core/include/Electron.h
@@ -14,31 +14,31 @@ class Electron : public RecParticle {
   enum tag {
     twodcut_dRmin,
     twodcut_pTrel,
-    cutBasedElectronID_Fall17_94X_V1_veto,
-    cutBasedElectronID_Fall17_94X_V1_loose,
-    cutBasedElectronID_Fall17_94X_V1_medium,
-    cutBasedElectronID_Fall17_94X_V1_tight,
+    cutBasedElectronID_Fall17_94X_V2_veto,
+    cutBasedElectronID_Fall17_94X_V2_loose,
+    cutBasedElectronID_Fall17_94X_V2_medium,
+    cutBasedElectronID_Fall17_94X_V2_tight,
     heepElectronID_HEEPV70,
-    mvaEleID_Fall17_noIso_V1_wp90,
-    mvaEleID_Fall17_noIso_V1_wp80,
-    mvaEleID_Fall17_noIso_V1_wpLoose,
-    mvaEleID_Fall17_iso_V1_wp90,
-    mvaEleID_Fall17_iso_V1_wp80,
-    mvaEleID_Fall17_iso_V1_wpLoose
+    mvaEleID_Fall17_noIso_V2_wp90,
+    mvaEleID_Fall17_noIso_V2_wp80,
+    mvaEleID_Fall17_noIso_V2_wpLoose,
+    mvaEleID_Fall17_iso_V2_wp90,
+    mvaEleID_Fall17_iso_V2_wp80,
+    mvaEleID_Fall17_iso_V2_wpLoose
   };
 
   static tag tagname2tag(const std::string & tagname){
-    if(tagname == "cutBasedElectronID_Fall17_94X_V1_veto") return cutBasedElectronID_Fall17_94X_V1_veto;
-    if(tagname == "cutBasedElectronID_Fall17_94X_V1_loose") return cutBasedElectronID_Fall17_94X_V1_loose;
-    if(tagname == "cutBasedElectronID_Fall17_94X_V1_medium") return cutBasedElectronID_Fall17_94X_V1_medium;
-    if(tagname == "cutBasedElectronID_Fall17_94X_V1_tight") return cutBasedElectronID_Fall17_94X_V1_tight;
+    if(tagname == "cutBasedElectronID_Fall17_94X_V2_veto") return cutBasedElectronID_Fall17_94X_V2_veto;
+    if(tagname == "cutBasedElectronID_Fall17_94X_V2_loose") return cutBasedElectronID_Fall17_94X_V2_loose;
+    if(tagname == "cutBasedElectronID_Fall17_94X_V2_medium") return cutBasedElectronID_Fall17_94X_V2_medium;
+    if(tagname == "cutBasedElectronID_Fall17_94X_V2_tight") return cutBasedElectronID_Fall17_94X_V2_tight;
     if(tagname == "heepElectronID_HEEPV70") return heepElectronID_HEEPV70;
-    if(tagname == "mvaEleID_Fall17_noIso_V1_wp90") return mvaEleID_Fall17_noIso_V1_wp90;
-    if(tagname == "mvaEleID_Fall17_noIso_V1_wp80") return mvaEleID_Fall17_noIso_V1_wp80;
-    if(tagname == "mvaEleID_Fall17_noIso_V1_wpLoose") return mvaEleID_Fall17_noIso_V1_wpLoose;
-    if(tagname == "mvaEleID_Fall17_iso_V1_wp90") return mvaEleID_Fall17_iso_V1_wp90;
-    if(tagname == "mvaEleID_Fall17_iso_V1_wp80") return mvaEleID_Fall17_iso_V1_wp80;
-    if(tagname == "mvaEleID_Fall17_iso_V1_wpLoose") return mvaEleID_Fall17_iso_V1_wpLoose;
+    if(tagname == "mvaEleID_Fall17_noIso_V2_wp90") return mvaEleID_Fall17_noIso_V2_wp90;
+    if(tagname == "mvaEleID_Fall17_noIso_V2_wp80") return mvaEleID_Fall17_noIso_V2_wp80;
+    if(tagname == "mvaEleID_Fall17_noIso_V2_wpLoose") return mvaEleID_Fall17_noIso_V2_wpLoose;
+    if(tagname == "mvaEleID_Fall17_iso_V2_wp90") return mvaEleID_Fall17_iso_V2_wp90;
+    if(tagname == "mvaEleID_Fall17_iso_V2_wp80") return mvaEleID_Fall17_iso_V2_wp80;
+    if(tagname == "mvaEleID_Fall17_iso_V2_wpLoose") return mvaEleID_Fall17_iso_V2_wpLoose;
     throw std::runtime_error("unknown Electron::tag '" + tagname + "'");
   }
 

--- a/core/python/ntuplewriter.py
+++ b/core/python/ntuplewriter.py
@@ -1166,10 +1166,10 @@ from PhysicsTools.SelectorUtils.tools.vid_id_tools import switchOnVIDElectronIdP
 switchOnVIDElectronIdProducer(process, DataFormat.MiniAOD)
 
 elecID_mod_ls = [
-    'RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Fall17_94X_V1_cff',
+    'RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Fall17_94X_V2_cff',
     'RecoEgamma.ElectronIdentification.Identification.heepElectronID_HEEPV70_cff',
-    'RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Fall17_noIso_V1_cff',
-    'RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Fall17_iso_V1_cff',
+    'RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Fall17_noIso_V2_cff',
+    'RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Fall17_iso_V2_cff',
 ]
 
 for mod in elecID_mod_ls:
@@ -1182,33 +1182,33 @@ process.slimmedElectronsUSER = cms.EDProducer('PATElectronUserData',
 
                                               vmaps_bool=cms.PSet(
 
-                                                  cutBasedElectronID_Fall17_94X_V1_veto=cms.InputTag(
-                                                      'egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V1-veto'),
-                                                  cutBasedElectronID_Fall17_94X_V1_loose=cms.InputTag(
-                                                      'egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V1-loose'),
-                                                  cutBasedElectronID_Fall17_94X_V1_medium=cms.InputTag(
-                                                      'egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V1-medium'),
-                                                  cutBasedElectronID_Fall17_94X_V1_tight=cms.InputTag(
-                                                      'egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V1-tight'),
+                                                  cutBasedElectronID_Fall17_94X_V2_veto=cms.InputTag(
+                                                      'egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V2-veto'),
+                                                  cutBasedElectronID_Fall17_94X_V2_loose=cms.InputTag(
+                                                      'egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V2-loose'),
+                                                  cutBasedElectronID_Fall17_94X_V2_medium=cms.InputTag(
+                                                      'egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V2-medium'),
+                                                  cutBasedElectronID_Fall17_94X_V2_tight=cms.InputTag(
+                                                      'egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V2-tight'),
                                                   heepElectronID_HEEPV70=cms.InputTag(
                                                       'egmGsfElectronIDs:heepElectronID-HEEPV70'),
-                                                  mvaEleID_Fall17_noIso_V1_wp90=cms.InputTag(
-                                                    'egmGsfElectronIDs:mvaEleID-Fall17-noIso-V1-wp90'),
-                                                  mvaEleID_Fall17_noIso_V1_wp80=cms.InputTag(
-                                                    'egmGsfElectronIDs:mvaEleID-Fall17-noIso-V1-wp80'),
-                                                  mvaEleID_Fall17_noIso_V1_wpLoose=cms.InputTag(
-                                                    'egmGsfElectronIDs:mvaEleID-Fall17-noIso-V1-wpLoose'),
-                                                  mvaEleID_Fall17_iso_V1_wp90=cms.InputTag(
-                                                    'egmGsfElectronIDs:mvaEleID-Fall17-iso-V1-wp90'),
-                                                  mvaEleID_Fall17_iso_V1_wp80=cms.InputTag(
-                                                    'egmGsfElectronIDs:mvaEleID-Fall17-iso-V1-wp80'),
-                                                  mvaEleID_Fall17_iso_V1_wpLoose=cms.InputTag(
-                                                    'egmGsfElectronIDs:mvaEleID-Fall17-iso-V1-wpLoose'),
+                                                  mvaEleID_Fall17_noIso_V2_wp90=cms.InputTag(
+                                                    'egmGsfElectronIDs:mvaEleID-Fall17-noIso-V2-wp90'),
+                                                  mvaEleID_Fall17_noIso_V2_wp80=cms.InputTag(
+                                                    'egmGsfElectronIDs:mvaEleID-Fall17-noIso-V2-wp80'),
+                                                  mvaEleID_Fall17_noIso_V2_wpLoose=cms.InputTag(
+                                                    'egmGsfElectronIDs:mvaEleID-Fall17-noIso-V2-wpLoose'),
+                                                  mvaEleID_Fall17_iso_V2_wp90=cms.InputTag(
+                                                    'egmGsfElectronIDs:mvaEleID-Fall17-iso-V2-wp90'),
+                                                  mvaEleID_Fall17_iso_V2_wp80=cms.InputTag(
+                                                    'egmGsfElectronIDs:mvaEleID-Fall17-iso-V2-wp80'),
+                                                  mvaEleID_Fall17_iso_V2_wpLoose=cms.InputTag(
+                                                    'egmGsfElectronIDs:mvaEleID-Fall17-iso-V2-wpLoose'),
                                               ),
 
                                                vmaps_float = cms.PSet(
-                                                   ElectronMVAEstimatorIso = cms.InputTag('electronMVAValueMapProducer:ElectronMVAEstimatorRun2Fall17IsoV1Values'),
-                                                   ElectronMVAEstimatorNoIso = cms.InputTag('electronMVAValueMapProducer:ElectronMVAEstimatorRun2Fall17NoIsoV1Values')
+                                                   ElectronMVAEstimatorIso = cms.InputTag('electronMVAValueMapProducer:ElectronMVAEstimatorRun2Fall17IsoV2Values'),
+                                                   ElectronMVAEstimatorNoIso = cms.InputTag('electronMVAValueMapProducer:ElectronMVAEstimatorRun2Fall17NoIsoV2Values')
                                                ),
 
                                               vmaps_double=cms.vstring(
@@ -1260,24 +1260,18 @@ process.MyNtuple = cms.EDFilter('NtupleWriter',
                                     # each string should correspond to a variable saved
                                     # via the "userInt" method in the pat::Electron collection used 'electron_source'
                                     # [the configuration of the pat::Electron::userInt variables should be done in PATElectronUserData]
-                                    'cutBasedElectronID_Fall17_94X_V1_veto',
-                                    'cutBasedElectronID_Fall17_94X_V1_loose',
-                                    'cutBasedElectronID_Fall17_94X_V1_medium',
-                                    'cutBasedElectronID_Fall17_94X_V1_tight',
+                                    'cutBasedElectronID_Fall17_94X_V2_veto',
+                                    'cutBasedElectronID_Fall17_94X_V2_loose',
+                                    'cutBasedElectronID_Fall17_94X_V2_medium',
+                                    'cutBasedElectronID_Fall17_94X_V2_tight',
                                     'heepElectronID_HEEPV70',
-                                    'mvaEleID_Fall17_noIso_V1_wp90',
-                                    'mvaEleID_Fall17_noIso_V1_wp80',
-                                    'mvaEleID_Fall17_noIso_V1_wpLoose',
-                                    'mvaEleID_Fall17_iso_V1_wp90',
-                                    'mvaEleID_Fall17_iso_V1_wp80',
-                                    'mvaEleID_Fall17_iso_V1_wpLoose',
+                                    'mvaEleID_Fall17_noIso_V2_wp90',
+                                    'mvaEleID_Fall17_noIso_V2_wp80',
+                                    'mvaEleID_Fall17_noIso_V2_wpLoose',
+                                    'mvaEleID_Fall17_iso_V2_wp90',
+                                    'mvaEleID_Fall17_iso_V2_wp80',
+                                    'mvaEleID_Fall17_iso_V2_wpLoose',
                                 ),
-                                # #Add variables to trace possible issues with the ECAL slew rate mitigation
-                                # #https://twiki.cern.ch/twiki/bin/view/CMSPublic/ReMiniAOD03Feb2017Notes#EGM
-                                # doEleAddVars = cms.bool(useData),
-                                # dupECALClusters_source = cms.InputTag('particleFlowEGammaGSFixed:dupECALClusters'),
-                                # hitsNotReplaced_source = cms.InputTag('ecalMultiAndGSGlobalRecHitEB:hitsNotReplaced'),
-                                doEleAddVars=cms.bool(False),
 
                                 doMuons=cms.bool(True),
                                 muon_sources=cms.vstring("slimmedMuonsUSER"),


### PR DESCRIPTION
Remove "preliminary" V1 electron IDs, moved to newer V2 IDs.

Note that in the V2 MVA ID there's a new Hzz working point which I **haven't** included as I assumed it isn't needed. But we can add it in if there's a use case

Refs:
https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedElectronIdentificationRun2#Recipe%20for%20regular%20users,%20format
https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2#(Recommended)%20MVA%20Recipe%20V2%20for

