### PR TITLE
[102X] Add CMSSW flags to fastjet(-contrib) compilation, including optimisation & more error checking

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -50,7 +50,7 @@ setupFastjet() {
 	# Optimisation flags same as in CMSSW
 	# But not -fffast-time as fails Nsubjettiness checks
 	FJCXXFLAGS="-O3 -Wall -ftree-vectorize -msse3 -fPIC"
-	./configure --prefix="${FJINSTALLDIR}" --enable-allplugins --enable-allcxxplugins --enable-pyext --disable-auto-ptr CXXFLAGS="${FJCXXFLAGS}"
+	./configure --prefix="${FJINSTALLDIR}" --enable-atlascone --enable-cmsiterativecone --enable-siscone --enable-allcxxplugins --enable-pyext --disable-auto-ptr CXXFLAGS="${FJCXXFLAGS}"
 	make $MAKEFLAGS
 	# make check  # fails for siscone
 	make install

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -47,7 +47,10 @@ setupFastjet() {
 	git clone -b cms/v$FJVER https://github.com/UHH2/fastjet.git
 	cd fastjet
 	autoreconf -f -i  # needed to avoid 'aclocal-1.15' is missing on your system
-	./configure --prefix="${FJINSTALLDIR}" --enable-allplugins --enable-allcxxplugins --enable-pyext --disable-auto-ptr CXXFLAGS=-fPIC
+	# Optimisation flags same as in CMSSW
+	# But not -fffast-time as fails Nsubjettiness checks
+	FJCXXFLAGS="-O3 -Wall -ftree-vectorize -msse3 -fPIC"
+	./configure --prefix="${FJINSTALLDIR}" --enable-allplugins --enable-allcxxplugins --enable-pyext --disable-auto-ptr CXXFLAGS="${FJCXXFLAGS}"
 	make $MAKEFLAGS
 	# make check  # fails for siscone
 	make install
@@ -70,7 +73,7 @@ setupFastjet() {
 	git clone https://github.com/UHH2/HOTVRContrib.git HOTVR/
 	# although we add fastjet-config to path, due to a bug we need to
 	# explicitly state its path to ensure the necessary fragile library gets built
-	./configure --fastjet-config="${FJINSTALLDIR}/bin/fastjet-config" CXXFLAGS=-fPIC
+	./configure --fastjet-config="${FJINSTALLDIR}/bin/fastjet-config" CXXFLAGS="${FJCXXFLAGS}"
 	make $MAKEFLAGS
 	make check
 	make install


### PR DESCRIPTION
I  checked how CMSSW compile fastjet - turns out they add in a series of optimisation flags, that until we now we did not use.

I tried adding recompiling with these, and it is now significantly faster. However, I didn't enable `-ffast-time`, since when running fastjet-contrib checks it fails the Nsubjettiness tests. Reading up on the flag, it seems to take some shortcuts in float-point math, so I'm going to leave it out for safety.

I also updates the list of builtin plugins fastjet compiles to match the CMSSW list (basically just drop PxCone).

I ran over 500 QCD MC events from Fall17 with & without the optimisation flags, and all variables have the exact same distributions, so the maths shouldn't be affected (if it is, it will be in CMSSW as well!).

Here are some timings from those 500 MC events:

| Measure [s] | Original | With optimisations |
| --- | --- | --- |
| CPU/event | 2.06 | 0.68 |
| Real/event | 2.28 | 0.98 |

So you can see it's now a factor of ~2.2-3x faster (depending on whether you use Real or CPU timings). This is with all the HOTVR & XCone reco & gen collections turned on.

Here are details of the 25 modules with the largest per-event time reduction:

| ORIGINAL [s] | OPTIMISED [s] | MODULE                                  | DIFFERENCE [s] | % DIFFERENCE |
|----------|-----------|-----------------------------------------|------------|--------------|
| 0.218908 | 0.073451  | hotvrCHS                                | -0.145457  | -66.44663512 |
| 0.162186 | 0.044009  | hepTopTagCHS                            | -0.118177  | -72.8651055  |
| 0.109415 | 0.03297   | xconeCHS                                | -0.076445  | -69.86702006 |
| 0.09576  | 0.029033  | xconePuppi                              | -0.066727  | -69.68149541 |
| 0.094556 | 0.031539  | hotvrPuppi                              | -0.063017  | -66.64516265 |
| 0.083314 | 0.023841  | ca15CHSJets                             | -0.059473  | -71.38416113 |
| 0.082962 | 0.023737  | ca15CHSJetsSoftDropforsub               | -0.059225  | -71.3881054  |
| 0.076408 | 0.019871  | ak8CHSJetsPruned                        | -0.056537  | -73.99356088 |
| 0.074171 | 0.019255  | ak8CHSJets                              | -0.054916  | -74.03971903 |
| 0.070352 | 0.019016  | ak8CHSJetsSoftDrop                      | -0.051336  | -72.97020696 |
| 0.069793 | 0.018476  | ak8CHSJetsSoftDropforsub                | -0.051317  | -73.52743112 |
| 0.062262 | 0.01302   | NjettinessAk8CHS                        | -0.049242  | -79.08836851 |
| 0.06127  | 0.015819  | ak8GenJetsFat                           | -0.045451  | -74.18149176 |
| 0.060782 | 0.015974  | ak8GenJetsPruned                        | -0.044808  | -73.71919318 |
| 0.059185 | 0.015235  | ak8GenJets                              | -0.04395   | -74.25868041 |
| 0.059197 | 0.015745  | ak8GenJetsSoftDrop                      | -0.043452  | -73.40236836 |
| 0.056687 | 0.014443  | ak8PuppiJetsFat                         | -0.042244  | -74.52149523 |
| 0.056807 | 0.014566  | ak8PuppiJets                            | -0.042241  | -74.35879381 |
| 0.056992 | 0.014957  | ak8PuppiJetsSoftDropforsub              | -0.042035  | -73.75596575 |
| 0.044802 | 0.014926  | ECFNbeta1Ak8SoftDropCHS                 | -0.029876  | -66.68452301 |
| 0.044385 | 0.014591  | ECFNbeta2Ak8SoftDropCHS                 | -0.029794  | -67.1262814  |
| 0.025865 | 0.006057  | pfBoostedDoubleSVTagInfos               | -0.019808  | -76.58225401 |
| 0.026562 | 0.006812  | pfBoostedDoubleSVAK8TagInfosAk8CHSJets  | -0.01975   | -74.35434079 |
| 0.029789 | 0.010067  | pfBoostedDoubleSVCA15TagInfosAk8CHSJets | -0.019722  | -66.20564638 |
| 0.010487 | 0.002425 | NjettinessCa15CHS | -0.008062 | -76.87613235 |

Full spreadsheet comparing all modules: https://docs.google.com/spreadsheets/d/1IG3qXvrd9eyMrZEQYV4vmgcA1pcxJ9wP0Fv9yMGVGQI/edit?usp=sharing

So there are savings across all jet modules!

Reference MC file: `/store/mc/RunIIFall17MiniAOD/QCD_Pt-15to7000_TuneCP5_Flat_13TeV_pythia8/MINIAODSIM/94X_mc2017_realistic_v10-v1/50000/00197229-2FDD-E711-9070-0025904AC2C4.root`

Obligatory quote: https://www.youtube.com/watch?v=4PzpztFJZP8