### PR TITLE
[102X] Remove HOTVR jets with CHS input

### DIFF
--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -994,11 +994,6 @@ def generate_process(useData=True, isDebug=False, fatjet_ptmin=150.):
                                         )
     task.add(process.hotvrPuppi)
 
-    process.hotvrCHS = cms.EDProducer("HOTVRProducer",
-        src=cms.InputTag("chs")
-    )
-    task.add(process.hotvrCHS)
-
     process.hotvrGen = cms.EDProducer("GenHOTVRProducer",
         src=cms.InputTag("packedGenParticlesForJetsNoNu"),
         mu=cms.double(30),
@@ -1576,7 +1571,6 @@ def generate_process(useData=True, isDebug=False, fatjet_ptmin=150.):
                                     doHOTVR=cms.bool(True),
                                     doXCone=cms.bool(True),
                                     HOTVR_sources=cms.VInputTag(
-                                        cms.InputTag("hotvrCHS"),
                                         cms.InputTag("hotvrPuppi")
                                     ),
                                     XCone_sources=cms.VInputTag(


### PR DESCRIPTION
As requested by @rkogler , this removes HOTVR with CHS input, as it will no longer be needed since HOTVR w/PUPPI outperforms it.

This also saves us some processing time (#1050 suggests ~ 8%). It also saves a little disk space (~ 500KB reduction in ntuple file size for 500 events)