### PR TITLE
[102X] V2 electron IDs from 94X

### DIFF
--- a/core/include/Electron.h
+++ b/core/include/Electron.h
@@ -14,31 +14,31 @@ class Electron : public RecParticle {
   enum tag {
     twodcut_dRmin,
     twodcut_pTrel,
-    cutBasedElectronID_Fall17_94X_V1_veto,
-    cutBasedElectronID_Fall17_94X_V1_loose,
-    cutBasedElectronID_Fall17_94X_V1_medium,
-    cutBasedElectronID_Fall17_94X_V1_tight,
+    cutBasedElectronID_Fall17_94X_V2_veto,
+    cutBasedElectronID_Fall17_94X_V2_loose,
+    cutBasedElectronID_Fall17_94X_V2_medium,
+    cutBasedElectronID_Fall17_94X_V2_tight,
     heepElectronID_HEEPV70,
-    mvaEleID_Fall17_noIso_V1_wp90,
-    mvaEleID_Fall17_noIso_V1_wp80,
-    mvaEleID_Fall17_noIso_V1_wpLoose,
-    mvaEleID_Fall17_iso_V1_wp90,
-    mvaEleID_Fall17_iso_V1_wp80,
-    mvaEleID_Fall17_iso_V1_wpLoose
+    mvaEleID_Fall17_noIso_V2_wp90,
+    mvaEleID_Fall17_noIso_V2_wp80,
+    mvaEleID_Fall17_noIso_V2_wpLoose,
+    mvaEleID_Fall17_iso_V2_wp90,
+    mvaEleID_Fall17_iso_V2_wp80,
+    mvaEleID_Fall17_iso_V2_wpLoose
   };
 
   static tag tagname2tag(const std::string & tagname){
-    if(tagname == "cutBasedElectronID_Fall17_94X_V1_veto") return cutBasedElectronID_Fall17_94X_V1_veto;
-    if(tagname == "cutBasedElectronID_Fall17_94X_V1_loose") return cutBasedElectronID_Fall17_94X_V1_loose;
-    if(tagname == "cutBasedElectronID_Fall17_94X_V1_medium") return cutBasedElectronID_Fall17_94X_V1_medium;
-    if(tagname == "cutBasedElectronID_Fall17_94X_V1_tight") return cutBasedElectronID_Fall17_94X_V1_tight;
+    if(tagname == "cutBasedElectronID_Fall17_94X_V2_veto") return cutBasedElectronID_Fall17_94X_V2_veto;
+    if(tagname == "cutBasedElectronID_Fall17_94X_V2_loose") return cutBasedElectronID_Fall17_94X_V2_loose;
+    if(tagname == "cutBasedElectronID_Fall17_94X_V2_medium") return cutBasedElectronID_Fall17_94X_V2_medium;
+    if(tagname == "cutBasedElectronID_Fall17_94X_V2_tight") return cutBasedElectronID_Fall17_94X_V2_tight;
     if(tagname == "heepElectronID_HEEPV70") return heepElectronID_HEEPV70;
-    if(tagname == "mvaEleID_Fall17_noIso_V1_wp90") return mvaEleID_Fall17_noIso_V1_wp90;
-    if(tagname == "mvaEleID_Fall17_noIso_V1_wp80") return mvaEleID_Fall17_noIso_V1_wp80;
-    if(tagname == "mvaEleID_Fall17_noIso_V1_wpLoose") return mvaEleID_Fall17_noIso_V1_wpLoose;
-    if(tagname == "mvaEleID_Fall17_iso_V1_wp90") return mvaEleID_Fall17_iso_V1_wp90;
-    if(tagname == "mvaEleID_Fall17_iso_V1_wp80") return mvaEleID_Fall17_iso_V1_wp80;
-    if(tagname == "mvaEleID_Fall17_iso_V1_wpLoose") return mvaEleID_Fall17_iso_V1_wpLoose;
+    if(tagname == "mvaEleID_Fall17_noIso_V2_wp90") return mvaEleID_Fall17_noIso_V2_wp90;
+    if(tagname == "mvaEleID_Fall17_noIso_V2_wp80") return mvaEleID_Fall17_noIso_V2_wp80;
+    if(tagname == "mvaEleID_Fall17_noIso_V2_wpLoose") return mvaEleID_Fall17_noIso_V2_wpLoose;
+    if(tagname == "mvaEleID_Fall17_iso_V2_wp90") return mvaEleID_Fall17_iso_V2_wp90;
+    if(tagname == "mvaEleID_Fall17_iso_V2_wp80") return mvaEleID_Fall17_iso_V2_wp80;
+    if(tagname == "mvaEleID_Fall17_iso_V2_wpLoose") return mvaEleID_Fall17_iso_V2_wpLoose;
     throw std::runtime_error("unknown Electron::tag '" + tagname + "'");
   }
 

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -1144,14 +1144,16 @@ def generate_process(useData=True, isDebug=False, fatjet_ptmin=150.):
     switchOnVIDElectronIdProducer(process, DataFormat.MiniAOD)
 
     elecID_mod_ls = [
-        'RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Fall17_94X_V1_cff',
+        'RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Fall17_94X_V2_cff',
         'RecoEgamma.ElectronIdentification.Identification.heepElectronID_HEEPV70_cff',
-        'RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Fall17_noIso_V1_cff',
-        'RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Fall17_iso_V1_cff',
+        'RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Fall17_noIso_V2_cff',
+        'RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Fall17_iso_V2_cff',
     ]
 
     for mod in elecID_mod_ls:
         setupAllVIDIdsInModule(process, mod, setupVIDElectronSelection)
+
+    from RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Fall17_94X_V2_cff import isoInputs
 
     # slimmedElectronsUSER ( = slimmedElectrons + USER variables)
     process.slimmedElectronsUSER = cms.EDProducer('PATElectronUserData',
@@ -1160,42 +1162,41 @@ def generate_process(useData=True, isDebug=False, fatjet_ptmin=150.):
 
                                                   vmaps_bool=cms.PSet(
 
-                                                      cutBasedElectronID_Fall17_94X_V1_veto=cms.InputTag(
-                                                          'egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V1-veto'),
-                                                      cutBasedElectronID_Fall17_94X_V1_loose=cms.InputTag(
-                                                          'egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V1-loose'),
-                                                      cutBasedElectronID_Fall17_94X_V1_medium=cms.InputTag(
-                                                          'egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V1-medium'),
-                                                      cutBasedElectronID_Fall17_94X_V1_tight=cms.InputTag(
-                                                          'egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V1-tight'),
+                                                      cutBasedElectronID_Fall17_94X_V2_veto=cms.InputTag(
+                                                          'egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V2-veto'),
+                                                      cutBasedElectronID_Fall17_94X_V2_loose=cms.InputTag(
+                                                          'egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V2-loose'),
+                                                      cutBasedElectronID_Fall17_94X_V2_medium=cms.InputTag(
+                                                          'egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V2-medium'),
+                                                      cutBasedElectronID_Fall17_94X_V2_tight=cms.InputTag(
+                                                          'egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V2-tight'),
                                                       heepElectronID_HEEPV70=cms.InputTag(
                                                           'egmGsfElectronIDs:heepElectronID-HEEPV70'),
-                                                      mvaEleID_Fall17_noIso_V1_wp90=cms.InputTag(
-                                                          'egmGsfElectronIDs:mvaEleID-Fall17-noIso-V1-wp90'),
-                                                      mvaEleID_Fall17_noIso_V1_wp80=cms.InputTag(
-                                                          'egmGsfElectronIDs:mvaEleID-Fall17-noIso-V1-wp80'),
-                                                      mvaEleID_Fall17_noIso_V1_wpLoose=cms.InputTag(
-                                                          'egmGsfElectronIDs:mvaEleID-Fall17-noIso-V1-wpLoose'),
-                                                      mvaEleID_Fall17_iso_V1_wp90=cms.InputTag(
-                                                          'egmGsfElectronIDs:mvaEleID-Fall17-iso-V1-wp90'),
-                                                      mvaEleID_Fall17_iso_V1_wp80=cms.InputTag(
-                                                          'egmGsfElectronIDs:mvaEleID-Fall17-iso-V1-wp80'),
-                                                      mvaEleID_Fall17_iso_V1_wpLoose=cms.InputTag(
-                                                          'egmGsfElectronIDs:mvaEleID-Fall17-iso-V1-wpLoose'),
+                                                      mvaEleID_Fall17_noIso_V2_wp90=cms.InputTag(
+                                                          'egmGsfElectronIDs:mvaEleID-Fall17-noIso-V2-wp90'),
+                                                      mvaEleID_Fall17_noIso_V2_wp80=cms.InputTag(
+                                                          'egmGsfElectronIDs:mvaEleID-Fall17-noIso-V2-wp80'),
+                                                      mvaEleID_Fall17_noIso_V2_wpLoose=cms.InputTag(
+                                                          'egmGsfElectronIDs:mvaEleID-Fall17-noIso-V2-wpLoose'),
+                                                      mvaEleID_Fall17_iso_V2_wp90=cms.InputTag(
+                                                          'egmGsfElectronIDs:mvaEleID-Fall17-iso-V2-wp90'),
+                                                      mvaEleID_Fall17_iso_V2_wp80=cms.InputTag(
+                                                          'egmGsfElectronIDs:mvaEleID-Fall17-iso-V2-wp80'),
+                                                      mvaEleID_Fall17_iso_V2_wpLoose=cms.InputTag(
+                                                          'egmGsfElectronIDs:mvaEleID-Fall17-iso-V2-wpLoose'),
                                                   ),
 
                                                   vmaps_float=cms.PSet(
                                                       ElectronMVAEstimatorIso=cms.InputTag(
-                                                          'electronMVAValueMapProducer:ElectronMVAEstimatorRun2Fall17IsoV1Values'),
+                                                          'electronMVAValueMapProducer:ElectronMVAEstimatorRun2Fall17IsoV2Values'),
                                                       ElectronMVAEstimatorNoIso=cms.InputTag(
-                                                          'electronMVAValueMapProducer:ElectronMVAEstimatorRun2Fall17NoIsoV1Values')
+                                                          'electronMVAValueMapProducer:ElectronMVAEstimatorRun2Fall17NoIsoV2Values')
                                                   ),
 
                                                   vmaps_double=cms.vstring(
                                                       el_isovals),
 
-                                                  effAreas_file=cms.FileInPath(
-                                                      'RecoEgamma/ElectronIdentification/data/Fall17/effAreaElectrons_cone03_pfNeuHadronsAndPhotons_92X.txt'),
+                                                  effAreas_file=cms.FileInPath(isoInputs.isoEffAreas),
                                                   )
     task.add(process.egmGsfElectronIDs)
     task.add(process.slimmedElectronsUSER)
@@ -1229,24 +1230,18 @@ def generate_process(useData=True, isDebug=False, fatjet_ptmin=150.):
                                         # each string should correspond to a variable saved
                                         # via the "userInt" method in the pat::Electron collection used 'electron_source'
                                         # [the configuration of the pat::Electron::userInt variables should be done in PATElectronUserData]
-                                        'cutBasedElectronID_Fall17_94X_V1_veto',
-                                        'cutBasedElectronID_Fall17_94X_V1_loose',
-                                        'cutBasedElectronID_Fall17_94X_V1_medium',
-                                        'cutBasedElectronID_Fall17_94X_V1_tight',
+                                        'cutBasedElectronID_Fall17_94X_V2_veto',
+                                        'cutBasedElectronID_Fall17_94X_V2_loose',
+                                        'cutBasedElectronID_Fall17_94X_V2_medium',
+                                        'cutBasedElectronID_Fall17_94X_V2_tight',
                                         'heepElectronID_HEEPV70',
-                                        'mvaEleID_Fall17_noIso_V1_wp90',
-                                        'mvaEleID_Fall17_noIso_V1_wp80',
-                                        'mvaEleID_Fall17_noIso_V1_wpLoose',
-                                        'mvaEleID_Fall17_iso_V1_wp90',
-                                        'mvaEleID_Fall17_iso_V1_wp80',
-                                        'mvaEleID_Fall17_iso_V1_wpLoose',
+                                        'mvaEleID_Fall17_noIso_V2_wp90',
+                                        'mvaEleID_Fall17_noIso_V2_wp80',
+                                        'mvaEleID_Fall17_noIso_V2_wpLoose',
+                                        'mvaEleID_Fall17_iso_V2_wp90',
+                                        'mvaEleID_Fall17_iso_V2_wp80',
+                                        'mvaEleID_Fall17_iso_V2_wpLoose',
                                     ),
-                                    # #Add variables to trace possible issues with the ECAL slew rate mitigation
-                                    # #https://twiki.cern.ch/twiki/bin/view/CMSPublic/ReMiniAOD03Feb2017Notes#EGM
-                                    # doEleAddVars = cms.bool(useData),
-                                    # dupECALClusters_source = cms.InputTag('particleFlowEGammaGSFixed:dupECALClusters'),
-                                    # hitsNotReplaced_source = cms.InputTag('ecalMultiAndGSGlobalRecHitEB:hitsNotReplaced'),
-                                    doEleAddVars=cms.bool(False),
 
                                     doMuons=cms.bool(True),
                                     muon_sources=cms.vstring("slimmedMuonsUSER"),

--- a/examples/config/ExampleElectronID.xml
+++ b/examples/config/ExampleElectronID.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE JobConfiguration PUBLIC "" "JobConfig.dtd">
+
+<!-- OutputLevel controls which messages are printed; set to VERBOSE or DEBUG for more verbosity, to WARNING or ERROR for less -->
+<JobConfiguration JobName="ExampleCycleJob" OutputLevel="INFO">
+    <Library Name="libSUHH2examples"/>
+    <Package Name="SUHH2examples.par" />
+
+   <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="./" PostFix="" TargetLumi="1" >
+        
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ElectronID" Cacheable="False">
+            <In FileName="../core/python/Ntuple.root" Lumi="0.0"/> 
+            <InputTree Name="AnalysisTree" /> 
+        </InputData>
+            
+        <UserConfig>
+            <!-- define which collections to read from the input. Only specify what you need to save I/O time -->
+            <Item Name="ElectronCollection" Value="slimmedElectronsUSER" />
+            
+            
+            <!-- the class name of the AnalysisModule subclasses to run: -->
+            <Item Name="AnalysisModule" Value="ExampleModuleElectronID" /> 
+            
+            
+            <!-- tell AnalysisModuleRunner NOT to use the MC event weight from SFrame; rather let
+                 MCLumiWeight (called via CommonModules) calculate the MC event weight. The MC
+                 event weight assigned by MCLumiWeight is InputData.Lumi / Cycle.TargetLumi. -->
+            <Item Name="use_sframe_weight" Value="false" />
+            
+        </UserConfig>
+    </Cycle>
+</JobConfiguration>

--- a/examples/src/ExampleModuleElectronID.cxx
+++ b/examples/src/ExampleModuleElectronID.cxx
@@ -1,0 +1,112 @@
+#include <iostream>
+#include <memory>
+
+#include "UHH2/core/include/AnalysisModule.h"
+#include "UHH2/core/include/Event.h"
+#include "UHH2/core/include/Hists.h"
+
+#include "TH1F.h"
+
+using namespace std;
+using namespace uhh2;
+
+/** \brief Example of how to use & check Electron IDs via tags
+ * 
+ * This is the preferred, POG-approved method to check Electron ID, since it uses
+ * stored values made by the official POG recipes.
+ * There are manual versions in ElectronIds.cxx, but these may not be up to date.
+ *
+ * This brief example shows how to use a tag, 
+ * and produces a histogram to show how many electrons passed each ID.
+ *
+ * For Muons, the approach is similar, but they are called "Selectors"
+ */
+
+namespace uhh2examples {
+
+class ExampleElectronIDHists: public uhh2::Hists {
+public:
+    ExampleElectronIDHists(uhh2::Context & ctx, const std::string & dirname, const vector<string> & electronIDs_);
+
+    virtual void fill(const uhh2::Event & ev) override;
+    virtual ~ExampleElectronIDHists();
+private:
+    TH1I * hElectronIDs;
+    vector<string> electronIDs;
+};
+
+ExampleElectronIDHists::ExampleElectronIDHists(Context & ctx, const string & dirname, const vector<string> & electronIDs_): 
+Hists(ctx, dirname),
+electronIDs(electronIDs_)
+{
+    hElectronIDs = book<TH1I>("ele_ids", ";Electron ID;N", electronIDs.size(), 0, electronIDs.size());
+    // set custom x axis labels
+    for (uint i=1;i<=electronIDs.size();i++) {
+        hElectronIDs->GetXaxis()->SetBinLabel(i, electronIDs.at(i-1).c_str());
+    }
+}
+
+
+void ExampleElectronIDHists::fill(const Event & event){
+    // Loop over all IDs for all electrons, and store which pass
+    for (auto & eleItr : *event.electrons) {
+        for (uint i=0; i < electronIDs.size(); i++) {
+            // Here we want the ID status from the ID string name
+            // Use tagname2tag to convert string to a tag, then use get_tag
+            if (eleItr.get_tag(eleItr.tagname2tag(electronIDs.at(i)))) {
+                hElectronIDs->Fill(i, event.weight);
+            }
+        }
+    }
+}
+
+ExampleElectronIDHists::~ExampleElectronIDHists(){}
+
+
+class ExampleModuleElectronID: public AnalysisModule {
+public:
+    
+    explicit ExampleModuleElectronID(Context & ctx);
+    virtual bool process(Event & event) override;
+private:
+    vector<string> electronIDs =  {
+        "cutBasedElectronID_Fall17_94X_V2_veto",
+        "cutBasedElectronID_Fall17_94X_V2_loose",
+        "cutBasedElectronID_Fall17_94X_V2_medium",
+        "cutBasedElectronID_Fall17_94X_V2_tight",
+        "heepElectronID_HEEPV70",
+        "mvaEleID_Fall17_noIso_V2_wp90",
+        "mvaEleID_Fall17_noIso_V2_wp80",
+        "mvaEleID_Fall17_noIso_V2_wpLoose",
+        "mvaEleID_Fall17_iso_V2_wp90",
+        "mvaEleID_Fall17_iso_V2_wp80",
+        "mvaEleID_Fall17_iso_V2_wpLoose"
+    };
+    unique_ptr<ExampleElectronIDHists> hists;
+};
+
+
+ExampleModuleElectronID::ExampleModuleElectronID(Context & ctx)
+{
+    cout << "Hello World from ExampleModuleElectronID!" << endl;
+    hists.reset(new ExampleElectronIDHists(ctx, "electronID", electronIDs));
+}
+
+
+bool ExampleModuleElectronID::process(Event & event) {
+
+    for (const auto & eleItr : *event.electrons) {
+        // We can use the enum directly, this is the easiest way
+        cout << "cutBasedElectronID_Fall17_94X_V2_veto: " << eleItr.get_tag(Electron::cutBasedElectronID_Fall17_94X_V2_veto) << endl;
+    }
+ 
+    hists->fill(event);
+
+    return true;
+}
+
+// as we want to run the ExampleCycleNew directly with AnalysisModuleRunner,
+// make sure the ExampleModuleElectronID is found by class name. This is ensured by this macro:
+UHH2_REGISTER_ANALYSIS_MODULE(ExampleModuleElectronID)
+
+}


### PR DESCRIPTION
Update from V1 to V2 of the 2017 Electron IDs. Also add in example module to show how to use Electron ID tags, and check they're actually being filled. Basically a copy of #1043 and #1044.

Note that this is somewhat temporary; it will need changing depending on whether the user is running over 2016/7/8. 