### PR TITLE
Fixed bug in type-1 correction of PuppiMET

### DIFF
--- a/common/src/JetCorrections.cxx
+++ b/common/src/JetCorrections.cxx
@@ -1977,7 +1977,7 @@ namespace {
   //propagate to MET
   //apply type1 MET correction to RAW MET
   //NB: jet with substracted muon Pt should be used
-  void correct_MET(const Event & event, const bool & do_L1corr, double pt_thresh, double eta_thresh_low, double eta_thresh_high){
+  void correct_MET(const Event & event, double pt_thresh, double eta_thresh_low, double eta_thresh_high){
     //we start from raw MET
     LorentzVector metv4= event.met->uncorr_v4();
     for(auto & jet : *event.jets){
@@ -1993,11 +1993,9 @@ namespace {
         LorentzVector L123corr = jet.v4();                                      //L123 corrected jets (L23 in case of puppi)
         metv4 -=  L123corr;
 
-        //For Puppi jets, no L1 correction is needed
-        if(do_L1corr){
-          //slimmed MET is corrected by L1FastJet
-          metv4 += L1corr;
-        }
+        //slimmed MET is corrected by L1FastJet, for Puppi: L1factor_raw = 1 --> L1corr = raw-jet pT.
+        metv4 += L1corr;
+
       }
     }
     event.met->set_pt(metv4.Pt());
@@ -2125,8 +2123,7 @@ bool JetCorrector::correct_met(uhh2::Event & event, const bool & isCHSmet, doubl
   assert(event.jets);
   if(!isCHSmet){ //for standart MET collection (most of the case) proceed with standart correction
     //propagate jet corrections to MET
-    bool correct_with_chs = used_ak4chs || metprop_possible_ak8chs;//for CHS use L1, for PUPPI L1 is not used
-    correct_MET(event, correct_with_chs, pt_thresh, eta_thresh_low,  eta_thresh_high);
+    correct_MET(event, pt_thresh, eta_thresh_low,  eta_thresh_high);
   }
   else{
     correct_MET(event, *corrector_L1RC, pt_thresh, eta_thresh_low,  eta_thresh_high);


### PR DESCRIPTION
This fixes the type-1 correction of PuppiMET. Before it was done incorrectly, leading to unreasonably large values of MET if using PuppiMET.