### PR TITLE
[102X] Fix trigger prescale access; trigger collection for 2016v2; trigger example

### DIFF
--- a/core/include/Event.h
+++ b/core/include/Event.h
@@ -104,7 +104,7 @@ public:
    * Throws the same exceptions as \c lookup_trigger_index. In addition, throws a runtime_error
    * if \c lookup_trigger_index returns false.
    */
-  bool trigger_prescale(TriggerIndex & ti) const;
+  int trigger_prescale(TriggerIndex & ti) const;
   
   /** \brief Test whether a given trigger is available for the current event
    * 

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -1552,7 +1552,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
                                     #  'hltL3crIsoL1sMu25L1f0L2f10QL3f27QL3trkIsoFiltered0p09', # HLT_IsoMu27_v*
                                     #  'hltEle27WPLooseGsfTrackIsoFilter',                      # HLT_Ele27_eta2p1_WPLoose_Gsf_v*
                                     #),
-                                    trigger_objects=cms.InputTag("slimmedPatTrigger"),
+                                    trigger_objects=cms.InputTag("selectedPatTrigger" if year == "2016v2" else "slimmedPatTrigger"),
 
                                     # *** gen stuff:
                                     doGenInfo=cms.bool(not useData),

--- a/core/src/Event.cxx
+++ b/core/src/Event.cxx
@@ -116,7 +116,7 @@ bool Event::passes_trigger(TriggerIndex & ti) const{
 }
 
 
-bool Event::trigger_prescale(TriggerIndex & ti) const{
+int Event::trigger_prescale(TriggerIndex & ti) const{
     if(!lookup_trigger_index(ti)){
         throw runtime_error("Event does not have trigger '" + ti.triggername + "'. Available triggers:\n" + format_list(triggerNames_currentrun));
     }

--- a/examples/config/ExampleTrigger.xml
+++ b/examples/config/ExampleTrigger.xml
@@ -11,8 +11,9 @@
         </InputData>
             
         <UserConfig>
-            <Item Name="AnalysisModule" Value="ExampleModuleTrigger" /> 
-            <Item Name="TriggerName" Value="HLT_Mu40_v*" />
+            <Item Name="AnalysisModule" Value="ExampleModuleTrigger" />
+            <Item Name="TriggerName" Value="HLT_PFJet80_v*" />
+            <Item Name="MetFilterName" Value="Flag_HBHENoiseFilter" />
         </UserConfig>
     </Cycle>
 </JobConfiguration>

--- a/examples/src/ExampleModuleTrigger.cxx
+++ b/examples/src/ExampleModuleTrigger.cxx
@@ -56,7 +56,9 @@ bool ExampleModuleTrigger::process(Event & event) {
 
     bool passedTrigger = event.passes_trigger(trigindex);
     string passStr = passedTrigger ? " passed " : " did not pass ";
-    cout << "event " << event.event << passStr << "trigger " << triggername << endl;
+    int trigPrescale = -1;
+    if (event.isRealData) trigPrescale = event.trigger_prescale(trigindex);
+    cout << "event " << event.event << passStr << "trigger " << triggername << " with prescale " << trigPrescale << endl;
 
     // More most analyses, you would use a TriggerSelection object like this:
     bool passedMetFilter = met_filter_selection->passes(event);

--- a/examples/src/ExampleModuleTrigger.cxx
+++ b/examples/src/ExampleModuleTrigger.cxx
@@ -47,9 +47,11 @@ bool ExampleModuleTrigger::process(Event & event) {
     }
 
     // lookup_trigger_index allows to check whether a trigger is available.
-    // The code here is not really that useful, because the default
-    // behaviour of event.passes_trigger is also to throw an exception in case
-    // a trigger does not exist.
+    // Note that the default behaviour of event.passes_trigger
+    // is also to throw an exception in case a trigger does not exist,
+    // so normally one should use a TriggerSelection object.
+    // However it is useful if you also wish to lookup the trigger prescale,
+    // since you need the TriggerIndex
     if(!event.lookup_trigger_index(trigindex)){
         throw runtime_error("Trigger with name '" + triggername + "' not available");
     }


### PR DESCRIPTION
3 trigger-related fixes:

- Fix return type for `Event::trigger_prescale` from `bool` to `int` (was already storing correctly as `int` in the Ntuplewriter, just accessing it was wrong).
- Fix trigger collection name for 2016v2 (dunno why it's different there...)
- Update example trigger module to show `TriggerSelection` usage, trigger prescale lookup, and MET filter check as well. This makes it useful for more general trigger testing (i.e. did we actually store things correctly!)