### PR TITLE
[102X] Add L1 prefire weights

### DIFF
--- a/core/include/Event.h
+++ b/core/include/Event.h
@@ -23,6 +23,10 @@ public:
 
   bool isRealData;
 
+  float prefiringWeight;
+  float prefiringWeightUp;
+  float prefiringWeightDown;
+
   float beamspot_x0;
   float beamspot_y0;
   float beamspot_z0;

--- a/core/include/EventHelper.h
+++ b/core/include/EventHelper.h
@@ -95,7 +95,7 @@ private:
     
     // handles:
     Event::Handle<int> h_run, h_lumi, h_event;
-    Event::Handle<float> h_rho, h_bsx, h_bsy, h_bsz;
+    Event::Handle<float> h_rho, h_bsx, h_bsy, h_bsz, h_prefire, h_prefireUp, h_prefireDown;
     Event::Handle<bool> h_isRealData;
     
     Event::Handle<std::vector<PrimaryVertex>> h_pvs;

--- a/core/plugins/NtupleWriter.h
+++ b/core/plugins/NtupleWriter.h
@@ -59,6 +59,7 @@ class NtupleWriter : public edm::EDFilter {
       bool doAllGenParticlesPythia8;
       bool doPV;
       bool doTrigger;
+      bool doPrefire;
       bool runOnMiniAOD;
       bool doRho;
       bool doTrigHTEmu;
@@ -123,6 +124,10 @@ class NtupleWriter : public edm::EDFilter {
       
       std::vector<std::string> trigger_prefixes;
       std::vector<std::string> triggerNames_outbranch;
+
+      edm::EDGetTokenT<double> prefweight_token;
+      edm::EDGetTokenT<double> prefweightup_token;
+      edm::EDGetTokenT<double> prefweightdown_token;
 
       bool newrun, setup_output_branches_done;
 

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -12,6 +12,8 @@ e.g.:
 """
 
 
+import os
+
 import FWCore.ParameterSet.Config as cms
 from Configuration.EventContent.EventContent_cff import *
 from RecoJets.Configuration.RecoPFJets_cff import *
@@ -24,14 +26,13 @@ from RecoBTag.SecondaryVertex.trackSelection_cff import *
 from UHH2.core.muon_pfMiniIsolation_cff import *
 from UHH2.core.electron_pfMiniIsolation_cff import *
 from PhysicsTools.SelectorUtils.tools.vid_id_tools import *
-from PhysicsTools.SelectorUtils.tools.vid_id_tools import *
 
 # NOTE: all from xxx import * must go here, not inside the function
 
 
 def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
     """Main function to make a cms.Process object to create ntuples.
-    
+
     Parameters
     ----------
     year : str
@@ -42,12 +43,12 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
         True for extra debug printout, don't use in production as slower
     fatjet_ptmin : float, optional
         Minimum pT for large-R reco jets & their corresponding genjets
-    
+
     Returns
     -------
     cms.Process
         Required process object for cmsRun configs
-    
+
     Raises
     ------
     ValueError
@@ -1232,6 +1233,31 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
     task.add(process.egmGsfElectronIDs)
     task.add(process.slimmedElectronsUSER)
 
+    # L1 prefiring, only needed for simulation in 2016/7
+    prefire_era_dict = {
+        '2016v2': '2016BtoH',
+        '2016v3': '2016BtoH',
+        '2017': '2017BtoF'
+    }
+    prefire_era = None if useData else prefire_era_dict.get(year, None)
+    do_prefire = prefire_era is not None
+    prefire_source = "prefiringweight"
+    if prefire_era:
+        L1Maps_file = os.path.join(os.environ['CMSSW_BASE'], "src/L1Prefiring/EventWeightProducer/files/L1PrefiringMaps_new.root") # update this when the EDProducer uses edm::FileInPath, so ugly.
+        setattr(process,
+                prefire_source,
+                cms.EDProducer("L1ECALPrefiringWeightProducer",
+                    ThePhotons = cms.InputTag("slimmedPhotons"),
+                    TheJets = cms.InputTag("slimmedJets"),
+                    L1Maps = cms.string(L1Maps_file),
+                    DataEra = cms.string(prefire_era),
+                    UseJetEMPt = cms.bool(False), #can be set to true to use jet prefiring maps parametrized vs pt(em) instead of pt
+                    PrefiringRateSystematicUncty = cms.double(0.2) #Minimum relative prefiring uncty per object
+                )
+        )
+        task.add(getattr(process, prefire_source))
+
+
     # NtupleWriter
 
     if useData:
@@ -1554,6 +1580,9 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
                                     #),
                                     trigger_objects=cms.InputTag("selectedPatTrigger" if year == "2016v2" else "slimmedPatTrigger"),
 
+                                    doPrefire=cms.bool(do_prefire),
+                                    prefire_source=cms.string(prefire_source),
+
                                     # *** gen stuff:
                                     doGenInfo=cms.bool(not useData),
                                     genparticle_source=cms.InputTag(
@@ -1623,6 +1652,8 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
         process.egmGsfElectronIDSequence *
         process.MyNtuple
     )
+    if do_prefire:
+        process.p.insert(0, process.prefiringweight)
     process.p.associate(task)
     process.p.associate(process.patAlgosToolsTask)
 

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -1242,7 +1242,10 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
     prefire_era = None if useData else prefire_era_dict.get(year, None)
     do_prefire = prefire_era is not None
     prefire_source = "prefiringweight"
-    if prefire_era:
+    # Enable once they have sorted out the location of the map ROOT file
+    # otherwise major pain at the moment
+    do_prefire = False
+    if do_prefire:
         L1Maps_file = os.path.join(os.environ['CMSSW_BASE'], "src/L1Prefiring/EventWeightProducer/files/L1PrefiringMaps_new.root") # update this when the EDProducer uses edm::FileInPath, so ugly.
         setattr(process,
                 prefire_source,

--- a/core/src/Event.cxx
+++ b/core/src/Event.cxx
@@ -8,6 +8,7 @@ using namespace std;
 void Event::clear(){
     run = luminosityBlock = event = -1;
     rho = beamspot_x0 = beamspot_y0 = beamspot_z0 = NAN;
+    prefiringWeight = prefiringWeightUp = prefiringWeightDown = 1.;
     electrons = 0;
     muons = 0;
     taus = 0;

--- a/core/src/EventHelper.cxx
+++ b/core/src/EventHelper.cxx
@@ -28,6 +28,9 @@ EventHelper::EventHelper(uhh2::Context & ctx_): ctx(ctx_), event(0), pvs(false),
     h_bsx = declare_in_out<float>("beamspot_x0", "beamspot_x0", ctx);
     h_bsy = declare_in_out<float>("beamspot_y0", "beamspot_y0", ctx);
     h_bsz = declare_in_out<float>("beamspot_z0", "beamspot_z0", ctx);
+    h_prefire = declare_in_out<float>("prefiringWeight", "prefiringWeight", ctx);
+    h_prefireUp = declare_in_out<float>("prefiringWeightUp", "prefiringWeightUp", ctx);
+    h_prefireDown = declare_in_out<float>("prefiringWeightDown", "prefiringWeightDown", ctx);
 }
 
 
@@ -86,7 +89,10 @@ void EventHelper::event_read(){
     event->beamspot_x0 = event->get(h_bsx);
     event->beamspot_y0 = event->get(h_bsy);
     event->beamspot_z0 = event->get(h_bsz);
-    
+    event->prefiringWeight = event->get(h_prefire);
+    event->prefiringWeightUp = event->get(h_prefireUp);
+    event->prefiringWeightDown = event->get(h_prefireDown);
+
     if(trigger){
         // fix triggerNames in case of a run change.
         if(triggernames_last_runid_event != event->run){
@@ -147,6 +153,9 @@ void EventHelper::event_write(){
     event->set(h_bsx, event->beamspot_x0);
     event->set(h_bsy, event->beamspot_y0);
     event->set(h_bsz, event->beamspot_z0);
+    event->set(h_prefire, event->prefiringWeight);
+    event->set(h_prefireUp, event->prefiringWeightUp);
+    event->set(h_prefireDown, event->prefiringWeightDown);
     
     // special case: trigger is saved only once per runid:
     if(trigger){

--- a/examples/src/ExampleModuleTrigger.cxx
+++ b/examples/src/ExampleModuleTrigger.cxx
@@ -67,6 +67,12 @@ bool ExampleModuleTrigger::process(Event & event) {
     passStr = passedMetFilter ? " passed " : " did not pass ";
     cout << "event " << event.event << passStr << "met filter " << metfiltername << endl;
 
+    if (!event.isRealData) {
+        cout << "event " << event.event << " has prefire weight: " << event.prefiringWeight;
+        cout << " up: " << event.prefiringWeightUp;
+        cout << " down: " << event.prefiringWeightDown << endl;
+    }
+
     return true;
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -107,6 +107,8 @@ time git cms-init -y  # not needed if not addpkg ing
 
 # Necessary for using our FastJet
 time git cms-addpkg RecoJets/JetProducers
+# For L1 prefiring. In future this should be in a 10_2_X release
+time git cms-merge-topic lathomas:L1Prefiring_10_2_6
 
 # Update FastJet and contribs for HOTVR and UniversalJetCluster
 FJINSTALL=$(fastjet-config --prefix)


### PR DESCRIPTION
This adds in the machinery to store weights to emulate L1 ECAL prefiring in 2016 & 2017. Ref: https://twiki.cern.ch/twiki/bin/viewauth/CMS/L1ECALPrefiringWeightRecipe

**It is currently disabled, since handling the location of the ROOT weights file is not easy/proper!**

This should be enabled only for `2016v2`, `2016v3`, and `2017` eras, and only for MC. (Maybe 2016v3 doesn't need it?)
However, we now always store the prefiring weights branches (main value, along with up & down variations) with a default value of 1, since it makes the `EventHelper` easier. Since these are only 3 floats, it doesn't take up a huge amount of space. But maybe I should only do it for the samples that need it?

Note that this isn't the final recipe: the prescription will become part of CMSSW_10_2_X at some point, with various fixes for e.g. the location of the ROOT weights file. However, the rest of the mechanism should be the same, so it's useful to have in already. See #25380 for the 10_4 version.

Whilst one can in theory use this, running CRAB jobs is non-trivial: you must add the `L1PrefiringMaps_new.root` file to `config.JobType.inputFiles`. However, CRAB doesn't respect your original directory structure, and will put it right at the top level on its worker node. So you need to manually edit the file location in `ntuple_generator.py` or your specific ntuple config to point to just `L1PrefiringMaps_new.root`. However this breaks local running (unless you copy the ROOT file to wherever you are running `cmsRun` from...).
