### PR TITLE
[102X] Add note to setup L1 prefiring for CRAB jobs, update crab_template as well

### DIFF
--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -1242,11 +1242,11 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
     prefire_era = None if useData else prefire_era_dict.get(year, None)
     do_prefire = prefire_era is not None
     prefire_source = "prefiringweight"
-    # Enable once they have sorted out the location of the map ROOT file
-    # otherwise major pain at the moment
-    do_prefire = False
     if do_prefire:
-        L1Maps_file = os.path.join(os.environ['CMSSW_BASE'], "src/L1Prefiring/EventWeightProducer/files/L1PrefiringMaps_new.root") # update this when the EDProducer uses edm::FileInPath, so ugly.
+        # update this part when the EDProducer uses edm::FileInPath, so ugly:
+        L1Maps_file = os.path.join(os.environ['CMSSW_BASE'], "src/L1Prefiring/EventWeightProducer/files/L1PrefiringMaps_new.root")
+        # if using CRAB, you need this instead:
+        L1Maps_file = "L1PrefiringMaps_new.root"
         setattr(process,
                 prefire_source,
                 cms.EDProducer("L1ECALPrefiringWeightProducer",

--- a/scripts/crab/crab_template.py
+++ b/scripts/crab/crab_template.py
@@ -32,7 +32,7 @@ for x in inputDatasets:
 #
 
 from CRABClient.UserUtilities import config, getUsernameFromSiteDB
-
+import os
 
 config = config()
 config.General.workArea = 'crab_Test'
@@ -40,10 +40,15 @@ config.General.transferOutputs = True
 config.General.transferLogs = True
         
 config.JobType.pluginName = 'Analysis'
-config.JobType.psetName = '/afs/desy.de/user/p/peiffer/xxl-af-cms/CMSSW_8_0_24_patch1/src/UHH2/core/python/ntuplewriter.py'
+config.JobType.psetName = os.path.join(os.environ['CMSSW_BASE'], 'src/UHH2/core/python/ntuplewriter_mc_2016v2.py')
 config.JobType.outputFiles = ["Ntuple.root"]
 config.JobType.maxMemoryMB = 2500
-#config.JobType.inputFiles = ['/nfs/dust/cms/user/gonvaq/CMSSW/CMSSW_7_4_15_patch1/src/UHH2/core/python/Summer15_25nsV2_MC.db']
+# If you are using the L1 prefiring map, please modify the
+# L1Maps location in ntuple_generator to just "L1PrefiringMaps_new.root"
+# until this is properly handled
+# i.e.:
+# process.prefiringweight.L1Maps = cms.string("L1PrefiringMaps_new.root")
+config.JobType.inputFiles = [os.path.join(os.environ['CMSSW_BASE'], 'src/L1Prefiring/EventWeightProducer/files/L1PrefiringMaps_new.root')]
         
 config.Data.inputDBS = 'global'
 config.Data.splitting = 'EventAwareLumiBased'


### PR DESCRIPTION
As requested after #1061 I've added a note about setting up L1 prefiring for CRAB jobs, both in the ntuple generator, and the crab template. I've also updated the inputfiles for crab_template, since we have to manually tell it where the file is since they didn't put it in a `data` dir.

I've also turned off the always-disabled that was on before.