### PR TITLE
[102X] Comment out wrong L1 prefire file location

### DIFF
--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -1246,7 +1246,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
         # update this part when the EDProducer uses edm::FileInPath, so ugly:
         L1Maps_file = os.path.join(os.environ['CMSSW_BASE'], "src/L1Prefiring/EventWeightProducer/files/L1PrefiringMaps_new.root")
         # if using CRAB, you need this instead:
-        L1Maps_file = "L1PrefiringMaps_new.root"
+        # L1Maps_file = "L1PrefiringMaps_new.root"
         setattr(process,
                 prefire_source,
                 cms.EDProducer("L1ECALPrefiringWeightProducer",


### PR DESCRIPTION
This was erroneously uncommented during CRAB testing