### PR TITLE
[94Xv2] Remove .git from EGamma external files as inflates CRAB tarball

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -160,9 +160,8 @@ rm TMVA_*.weights.xml
 rm -r Spring16*
 rm -r  Spring15/
 rm -r PHYS14/
-# prune their .git as it gets included in crab tarball
-# remove if you really struggle for space
-git gc --prune
+# remove their .git as it gets included in crab tarball
+rm -rf .git
 cd $CMSSW_BASE/src
 
 # Get the UHH2 repo & JEC files


### PR DESCRIPTION
This is the largest file in the CRAB tarball, making it perilously close to the upload limit of 100MB:
```
33028538 external/slc6_amd64_gcc630/data/RecoEgamma/ElectronIdentification/data/.git/objects/pack/pack-29a80f55679276cfbf198603acd6889a96414597.pack
```
(size in Bytes)

It has no purpose for analysis. And since they now move to v2 IDs (which is in 94X_v3 branch as it requires 9_4_9+), we shouldn't ever need to pull