### PR TITLE
[94Xv3] Remove old EGamma ID files during installation to slim CRAB tarball

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -106,6 +106,15 @@ time git cms-init -y  # not needed if not addpkg ing
 
 # Add in both cut-based and MVA EGamma VID
 git cms-merge-topic guitargeek:EgammaID_9_4_X
+# Remove old IDs that inflate CRAB tarball over limit
+rm -r RecoEgamma/PhotonIdentification/data/MVA/PHYS14
+rm -r RecoEgamma/PhotonIdentification/data/MVA/Spring16
+rm -r RecoEgamma/PhotonIdentification/data/MVA/Spring15
+rm -r RecoEgamma/ElectronIdentification/data/PHYS14
+rm -r RecoEgamma/ElectronIdentification/data/Spring15
+rm -r RecoEgamma/ElectronIdentification/data/Spring16_GeneralPurpose_V1
+rm -r RecoEgamma/ElectronIdentification/data/Spring16_HZZ_V1
+rm -r RecoEgamma/ElectronIdentification/data/Summer16
 
 # Necessary for using our FastJet
 git cms-addpkg RecoJets/JetProducers


### PR DESCRIPTION
This removes the following EGamma ID data files since they contribute unnecessarily to the CRAB tarball and make it too large:

- PHYS14
- Spring15
- Spring16
- Summer16

as seen in #1076 .
Note that the only Electron IDs in this branch used are the Fall17 V2 ones, so should be safe.

CRAB tarball drops dramatically in size, I measured it now as 75MB, down from 108MB.