### PR TITLE
[102X] Add 2016 electron IDs back in

### DIFF
--- a/core/include/Electron.h
+++ b/core/include/Electron.h
@@ -58,13 +58,13 @@ class Electron : public RecParticle {
 
   Electron(){
 
-    m_supercluster_eta = 0; 
-    m_supercluster_phi = 0; 
-    m_dB = 0; 
-    m_neutralHadronIso = 0; 
-    m_chargedHadronIso = 0; 
+    m_supercluster_eta = 0;
+    m_supercluster_phi = 0;
+    m_dB = 0;
+    m_neutralHadronIso = 0;
+    m_chargedHadronIso = 0;
     m_photonIso = 0;
-    m_trackIso = 0; 
+    m_trackIso = 0;
     m_puChargedHadronIso = 0;
     m_gsfTrack_trackerExpectedHitsInner_numberOfLostHits = 0;
     m_gsfTrack_px = 0;
@@ -75,8 +75,8 @@ class Electron : public RecParticle {
     m_gsfTrack_vz = 0;
     m_passconversionveto = false;
     m_dEtaIn = 0;
-    m_dPhiIn = 0; 
-    m_sigmaIEtaIEta = 0; 
+    m_dPhiIn = 0;
+    m_sigmaIEtaIEta = 0;
     m_HoverE = 0;
     m_fbrem = 0;
     m_EoverPIn = 0;
@@ -105,19 +105,19 @@ class Electron : public RecParticle {
 
     m_isEcalDriven = false;
     m_dxy = 0;
-    m_dEtaInSeed = 0; 
+    m_dEtaInSeed = 0;
     m_full5x5_e1x5 = 0;
     m_full5x5_e2x5Max = 0;
     m_full5x5_e5x5 = 0;
   }
 
-  float supercluster_eta() const{return m_supercluster_eta;} 
-  float supercluster_phi() const{return m_supercluster_phi;} 
-  float dB() const{return m_dB;} 
-  float neutralHadronIso() const{return m_neutralHadronIso;} 
-  float chargedHadronIso() const{return m_chargedHadronIso;} 
+  float supercluster_eta() const{return m_supercluster_eta;}
+  float supercluster_phi() const{return m_supercluster_phi;}
+  float dB() const{return m_dB;}
+  float neutralHadronIso() const{return m_neutralHadronIso;}
+  float chargedHadronIso() const{return m_chargedHadronIso;}
   float photonIso() const{return m_photonIso;}
-  float trackIso() const{return m_trackIso;} 
+  float trackIso() const{return m_trackIso;}
   float puChargedHadronIso() const{return m_puChargedHadronIso;}
   int gsfTrack_trackerExpectedHitsInner_numberOfLostHits() const{return m_gsfTrack_trackerExpectedHitsInner_numberOfLostHits;}
   float gsfTrack_px() const{return m_gsfTrack_px;}
@@ -128,8 +128,8 @@ class Electron : public RecParticle {
   float gsfTrack_vz() const{return m_gsfTrack_vz;}
   bool passconversionveto() const{return m_passconversionveto;}
   float dEtaIn() const{return m_dEtaIn;}
-  float dPhiIn() const{return m_dPhiIn;} 
-  float sigmaIEtaIEta() const{return m_sigmaIEtaIEta;} 
+  float dPhiIn() const{return m_dPhiIn;}
+  float sigmaIEtaIEta() const{return m_sigmaIEtaIEta;}
   float HoverE() const{return m_HoverE;}
   float fbrem() const{return m_fbrem;}
   float EoverPIn() const{return m_EoverPIn;}
@@ -153,13 +153,13 @@ class Electron : public RecParticle {
 
   const std::vector<source_candidate>& source_candidates() const { return m_source_candidates; }
 
-  void set_supercluster_eta(float x){m_supercluster_eta=x;} 
-  void set_supercluster_phi(float x){m_supercluster_phi=x;} 
-  void set_dB(float x){m_dB=x;} 
-  void set_neutralHadronIso(float x){m_neutralHadronIso=x;} 
-  void set_chargedHadronIso(float x){m_chargedHadronIso=x;} 
+  void set_supercluster_eta(float x){m_supercluster_eta=x;}
+  void set_supercluster_phi(float x){m_supercluster_phi=x;}
+  void set_dB(float x){m_dB=x;}
+  void set_neutralHadronIso(float x){m_neutralHadronIso=x;}
+  void set_chargedHadronIso(float x){m_chargedHadronIso=x;}
   void set_photonIso(float x){m_photonIso=x;}
-  void set_trackIso(float x){m_trackIso=x;} 
+  void set_trackIso(float x){m_trackIso=x;}
   void set_puChargedHadronIso(float x){m_puChargedHadronIso=x;}
   void set_gsfTrack_trackerExpectedHitsInner_numberOfLostHits(int x){m_gsfTrack_trackerExpectedHitsInner_numberOfLostHits=x;}
   void set_gsfTrack_px(float x){m_gsfTrack_px=x;}
@@ -170,7 +170,7 @@ class Electron : public RecParticle {
   void set_gsfTrack_vz(float x){m_gsfTrack_vz=x;}
   void set_passconversionveto(bool x){m_passconversionveto=x;}
   void set_dEtaIn(float x){m_dEtaIn=x;}
-  void set_dPhiIn(float x){m_dPhiIn=x;} 
+  void set_dPhiIn(float x){m_dPhiIn=x;}
   void set_sigmaIEtaIEta(float x){m_sigmaIEtaIEta=x;}  // this is the 'full5x5sigma ieta ieta', (not the gsfelecton->sigmaIetaIeta)
   void set_HoverE(float x){m_HoverE=x;}
   void set_fbrem(float x){m_fbrem=x;}
@@ -209,12 +209,12 @@ class Electron : public RecParticle {
   void set_full5x5_e2x5Max(float x){m_full5x5_e2x5Max = x;}
   void set_full5x5_e5x5(float x){m_full5x5_e5x5 = x;}
 
-  float gsfTrack_dxy_vertex(const float point_x, const float point_y) const{ 
-    return ( - (m_gsfTrack_vx-point_x) * m_gsfTrack_py + (m_gsfTrack_vy-point_y) * m_gsfTrack_px ) / sqrt(m_gsfTrack_px*m_gsfTrack_px+m_gsfTrack_py*m_gsfTrack_py);  
+  float gsfTrack_dxy_vertex(const float point_x, const float point_y) const{
+    return ( - (m_gsfTrack_vx-point_x) * m_gsfTrack_py + (m_gsfTrack_vy-point_y) * m_gsfTrack_px ) / sqrt(m_gsfTrack_px*m_gsfTrack_px+m_gsfTrack_py*m_gsfTrack_py);
   };
 
-  float gsfTrack_dz_vertex(const float point_x, const float point_y, const float point_z) const{ 
-    return (m_gsfTrack_vz-point_z) - ((m_gsfTrack_vx-point_x)*m_gsfTrack_px+(m_gsfTrack_vy-point_y)*m_gsfTrack_py)/(m_gsfTrack_px*m_gsfTrack_px+m_gsfTrack_py*m_gsfTrack_py) * m_gsfTrack_pz; 
+  float gsfTrack_dz_vertex(const float point_x, const float point_y, const float point_z) const{
+    return (m_gsfTrack_vz-point_z) - ((m_gsfTrack_vx-point_x)*m_gsfTrack_px+(m_gsfTrack_vy-point_y)*m_gsfTrack_py)/(m_gsfTrack_px*m_gsfTrack_px+m_gsfTrack_py*m_gsfTrack_py) * m_gsfTrack_pz;
   }
 
   float relIso() const{
@@ -252,13 +252,13 @@ class Electron : public RecParticle {
   float dEtaInSeed() const {return m_dEtaInSeed;}
 
  private:
-  float m_supercluster_eta; 
-  float m_supercluster_phi; 
-  float m_dB; 
-  float m_neutralHadronIso; 
-  float m_chargedHadronIso; 
+  float m_supercluster_eta;
+  float m_supercluster_phi;
+  float m_dB;
+  float m_neutralHadronIso;
+  float m_chargedHadronIso;
   float m_photonIso;
-  float m_trackIso; 
+  float m_trackIso;
   float m_puChargedHadronIso;
   int m_gsfTrack_trackerExpectedHitsInner_numberOfLostHits;
   float m_gsfTrack_px;
@@ -269,8 +269,8 @@ class Electron : public RecParticle {
   float m_gsfTrack_vz;
   bool m_passconversionveto;
   float m_dEtaIn;
-  float m_dPhiIn; 
-  float m_sigmaIEtaIEta; 
+  float m_dPhiIn;
+  float m_sigmaIEtaIEta;
   float m_HoverE;
   float m_fbrem;
   float m_EoverPIn;

--- a/core/include/Electron.h
+++ b/core/include/Electron.h
@@ -14,6 +14,14 @@ class Electron : public RecParticle {
   enum tag {
     twodcut_dRmin,
     twodcut_pTrel,
+    // 2016
+    heepElectronID_HEEPV60,
+    cutBasedElectronID_Summer16_80X_V1_veto,
+    cutBasedElectronID_Summer16_80X_V1_loose,
+    cutBasedElectronID_Summer16_80X_V1_medium,
+    cutBasedElectronID_Summer16_80X_V1_tight,
+    cutBasedElectronHLTPreselection_Summer16_V1,
+    // 2017 & 2018
     cutBasedElectronID_Fall17_94X_V2_veto,
     cutBasedElectronID_Fall17_94X_V2_loose,
     cutBasedElectronID_Fall17_94X_V2_medium,
@@ -28,6 +36,12 @@ class Electron : public RecParticle {
   };
 
   static tag tagname2tag(const std::string & tagname){
+    if(tagname == "heepElectronID_HEEPV60") return heepElectronID_HEEPV60;
+    if(tagname == "cutBasedElectronID_Summer16_80X_V1_veto") return cutBasedElectronID_Summer16_80X_V1_veto;
+    if(tagname == "cutBasedElectronID_Summer16_80X_V1_loose") return cutBasedElectronID_Summer16_80X_V1_loose;
+    if(tagname == "cutBasedElectronID_Summer16_80X_V1_medium") return cutBasedElectronID_Summer16_80X_V1_medium;
+    if(tagname == "cutBasedElectronID_Summer16_80X_V1_tight") return cutBasedElectronID_Summer16_80X_V1_tight;
+    if(tagname == "cutBasedElectronHLTPreselection_Summer16_V1") return cutBasedElectronHLTPreselection_Summer16_V1;
     if(tagname == "cutBasedElectronID_Fall17_94X_V2_veto") return cutBasedElectronID_Fall17_94X_V2_veto;
     if(tagname == "cutBasedElectronID_Fall17_94X_V2_loose") return cutBasedElectronID_Fall17_94X_V2_loose;
     if(tagname == "cutBasedElectronID_Fall17_94X_V2_medium") return cutBasedElectronID_Fall17_94X_V2_medium;
@@ -71,6 +85,8 @@ class Electron : public RecParticle {
     m_ecalPFClusterIso = 0;
     m_hcalPFClusterIso = 0;
     m_dr03TkSumPt = 0;
+    m_mvaGeneralPurpose = 0;
+    m_mvaHZZ = 0;
     m_mvaIso = 0;
     m_mvaNoIso = 0;
     m_AEff = 0;
@@ -122,8 +138,10 @@ class Electron : public RecParticle {
   float ecalPFClusterIso() const { return m_ecalPFClusterIso; }
   float hcalPFClusterIso() const { return m_hcalPFClusterIso; }
   float dr03TkSumPt     () const { return m_dr03TkSumPt; }
-  float mvaIso() const { return m_mvaIso; }
-  float mvaNoIso() const { return m_mvaNoIso; }
+  float mvaGeneralPurpose() const{return m_mvaGeneralPurpose;} // 2016
+  float mvaHZZ() const{return m_mvaHZZ;}  // 2016
+  float mvaIso() const { return m_mvaIso; } // 2017 & 2018
+  float mvaNoIso() const { return m_mvaNoIso; } // 2017 & 2018
   float effArea() const{return m_AEff;}
 
   float pfMINIIso_CH      () const { return m_pfMINIIso_CH; }
@@ -162,6 +180,8 @@ class Electron : public RecParticle {
   void set_ecalPFClusterIso(float x){ m_ecalPFClusterIso = x; }
   void set_hcalPFClusterIso(float x){ m_hcalPFClusterIso = x; }
   void set_dr03TkSumPt     (float x){ m_dr03TkSumPt      = x; }
+  void set_mvaGeneralPurpose(float x){m_mvaGeneralPurpose=x;}
+  void set_mvaHZZ(float x){m_mvaHZZ=x;}
   void set_mvaIso(float x){m_mvaIso=x;}
   void set_mvaNoIso(float x){m_mvaNoIso=x;}
   void set_effArea(float x){m_AEff=x;}
@@ -259,6 +279,8 @@ class Electron : public RecParticle {
   float m_ecalPFClusterIso;
   float m_hcalPFClusterIso;
   float m_dr03TkSumPt;
+  float m_mvaGeneralPurpose;
+  float m_mvaHZZ;
   float m_mvaIso;
   float m_mvaNoIso;
   float m_AEff;

--- a/core/plugins/NtupleWriterLeptons.cxx
+++ b/core/plugins/NtupleWriterLeptons.cxx
@@ -77,8 +77,11 @@ void NtupleWriterElectrons::process(const edm::Event & event, uhh2::Event & ueve
         ele.set_hcalPFClusterIso(pat_ele.hcalPFClusterIso());
         ele.set_dr03TkSumPt     (pat_ele.dr03TkSumPt());
 
-        ele.set_mvaIso   (pat_ele.hasUserFloat("ElectronMVAEstimatorIso") ? pat_ele.userFloat("ElectronMVAEstimatorIso") : -999.);
-        ele.set_mvaNoIso   (pat_ele.hasUserFloat("ElectronMVAEstimatorNoIso") ? pat_ele.userFloat("ElectronMVAEstimatorNoIso") : -999.);
+        ele.set_mvaGeneralPurpose(pat_ele.hasUserFloat("mvaGeneralPurpose") ? pat_ele.userFloat("mvaGeneralPurpose") : -999.);
+        ele.set_mvaHZZ(pat_ele.hasUserFloat("mvaHZZ") ? pat_ele.userFloat("mvaHZZ") : -999.);
+
+        ele.set_mvaIso(pat_ele.hasUserFloat("ElectronMVAEstimatorIso") ? pat_ele.userFloat("ElectronMVAEstimatorIso") : -999.);
+        ele.set_mvaNoIso(pat_ele.hasUserFloat("ElectronMVAEstimatorNoIso") ? pat_ele.userFloat("ElectronMVAEstimatorNoIso") : -999.);
 
         ele.set_effArea(pat_ele.hasUserFloat("EffArea") ? pat_ele.userFloat("EffArea") : -999.);
 

--- a/core/plugins/NtupleWriterLeptons.cxx
+++ b/core/plugins/NtupleWriterLeptons.cxx
@@ -43,11 +43,11 @@ void NtupleWriterElectrons::process(const edm::Event & event, uhh2::Event & ueve
         ele.set_eta( pat_ele.eta());
         ele.set_phi( pat_ele.phi());
         ele.set_energy( pat_ele.energy());
-	//	cout<<"pat_ele.pt() = "<<pat_ele.pt()<<endl;
-	ele.set_ptError( pat_ele.gsfTrack()->ptError());
-	ele.set_etaError( pat_ele.gsfTrack()->etaError());
-	ele.set_phiError( pat_ele.gsfTrack()->phiError());
-	//	ele.set_energyError( pat_ele.energyError());
+        //	cout<<"pat_ele.pt() = "<<pat_ele.pt()<<endl;
+        ele.set_ptError( pat_ele.gsfTrack()->ptError());
+        ele.set_etaError( pat_ele.gsfTrack()->etaError());
+        ele.set_phiError( pat_ele.gsfTrack()->phiError());
+        //	ele.set_energyError( pat_ele.energyError());
         ele.set_supercluster_eta( pat_ele.superCluster()->eta() );
         ele.set_supercluster_phi( pat_ele.superCluster()->phi() );
         ele.set_dB(pat_ele.dB());
@@ -92,16 +92,16 @@ void NtupleWriterElectrons::process(const edm::Event & event, uhh2::Event & ueve
         ele.set_pfMINIIso_NH_pfwgt(pat_ele.hasUserFloat("elPFMiniIsoValueNHPFWGT") ? pat_ele.userFloat("elPFMiniIsoValueNHPFWGT") : -999.);
         ele.set_pfMINIIso_Ph_pfwgt(pat_ele.hasUserFloat("elPFMiniIsoValuePhPFWGT") ? pat_ele.userFloat("elPFMiniIsoValuePhPFWGT") : -999.);
 
-	ele.set_Nclusters(pat_ele.superCluster()->clusters().size());
-	ele.set_Class(pat_ele.classification()); 
+        ele.set_Nclusters(pat_ele.superCluster()->clusters().size());
+        ele.set_Class(pat_ele.classification());
 
-	ele.set_isEcalDriven(pat_ele.ecalDriven());
-	ele.set_full5x5_e1x5(pat_ele.full5x5_e1x5());
-	ele.set_full5x5_e2x5Max(pat_ele.full5x5_e2x5Max());
-	ele.set_full5x5_e5x5(pat_ele.full5x5_e5x5());
-	ele.set_dEtaInSeed(pat_ele.deltaEtaSeedClusterTrackAtVtx());
+        ele.set_isEcalDriven(pat_ele.ecalDriven());
+        ele.set_full5x5_e1x5(pat_ele.full5x5_e1x5());
+        ele.set_full5x5_e2x5Max(pat_ele.full5x5_e2x5Max());
+        ele.set_full5x5_e5x5(pat_ele.full5x5_e5x5());
+        ele.set_dEtaInSeed(pat_ele.deltaEtaSeedClusterTrackAtVtx());
 
-	ele.set_dxy(pat_ele.gsfTrack()->dxy(PV.position()));// correct for vertex postion
+        ele.set_dxy(pat_ele.gsfTrack()->dxy(PV.position()));// correct for vertex postion
 
         for(const auto& tag_str : IDtag_keys){
 
@@ -309,17 +309,17 @@ void NtupleWriterTaus::process(const edm::Event & event, uhh2::Event & uevent,  
          if(fabs(pat_tau.eta()) > etamax) continue;
          taus.emplace_back();
          Tau & tau = taus.back();
-         
+
          tau.set_charge( pat_tau.charge());
          tau.set_pt( pat_tau.pt());
          tau.set_eta( pat_tau.eta());
          tau.set_phi( pat_tau.phi());
          tau.set_energy( pat_tau.energy());
-         
+
          // use the macro to avoid typos: using this macro assures that the enum name
          // used in the same as the string used for the pat tauID.
          #define FILL_TAU_BIT(tauidname) tau.set_bool(Tau:: tauidname, pat_tau.tauID(#tauidname) > 0.5)
-        
+
          FILL_TAU_BIT(againstElectronVLooseMVA6);
          FILL_TAU_BIT(againstElectronLooseMVA6);
          FILL_TAU_BIT(againstElectronMediumMVA6);
@@ -337,14 +337,14 @@ void NtupleWriterTaus::process(const edm::Event & event, uhh2::Event & uevent,  
          FILL_TAU_BIT(byTightIsolationMVArun2v1DBnewDMwLT);
          FILL_TAU_BIT(byVTightIsolationMVArun2v1DBnewDMwLT);
          FILL_TAU_BIT(byVVTightIsolationMVArun2v1DBnewDMwLT);
-	 
-	 FILL_TAU_BIT(decayModeFinding); 
+
+	 FILL_TAU_BIT(decayModeFinding);
          FILL_TAU_BIT(decayModeFindingNewDMs);
 
 
 
          #define FILL_TAU_FLOAT(name) tau.set_##name (pat_tau.tauID(#name))
-         
+
          FILL_TAU_FLOAT(byCombinedIsolationDeltaBetaCorrRaw3Hits);
          FILL_TAU_FLOAT(byIsolationMVArun2v1DBnewDMwLTraw);
          FILL_TAU_FLOAT(chargedIsoPtSum);
@@ -359,7 +359,7 @@ void NtupleWriterTaus::process(const edm::Event & event, uhh2::Event & uevent,  
 	 FILL_TAU_FLOAT(neutralIsoPtSumWeight);
 	 FILL_TAU_FLOAT(footprintCorrection);
 	 FILL_TAU_FLOAT(photonPtSumOutsideSignalCone);
-         
+
          #undef FILL_TAU_BIT
          #undef FILL_TAU_FLOAT
 

--- a/core/plugins/PATElectronUserData.cc
+++ b/core/plugins/PATElectronUserData.cc
@@ -39,6 +39,9 @@ class PATElectronUserData : public edm::EDProducer {
 
   EffectiveAreas effAreas_;
 
+  std::string mva_GeneralPurpose_;
+  std::string mva_HZZ_;
+
   std::string mva_Iso_;
   std::string mva_NoIso_;
 };

--- a/core/plugins/PATElectronUserData.cc
+++ b/core/plugins/PATElectronUserData.cc
@@ -78,9 +78,6 @@ PATElectronUserData::PATElectronUserData(const edm::ParameterSet& iConfig):
     }
   }
 
-  if(iConfig.exists("mva_Iso")) mva_Iso_ = iConfig.getParameter<std::string>("mva_Iso"); 
-  if(iConfig.exists("mva_NoIso"))   mva_NoIso_   = iConfig.getParameter<std::string>("mva_NoIso"); 
-
   produces< pat::ElectronCollection >();
 }
 
@@ -125,7 +122,7 @@ void PATElectronUserData::produce(edm::Event& iEvent, const edm::EventSetup& iSe
     for(unsigned int j=0; j<vmapBs.size(); ++j){
 
       if(ele.hasUserInt(vmaps_bool_links_.at(j).vname))
-	throw cms::Exception("InputError") << "@@@ PATElectronUserData::produce -- PAT user-int label already exists: " << vmaps_bool_links_.at(j).vname;
+        throw cms::Exception("InputError") << "@@@ PATElectronUserData::produce -- PAT user-int label already exists: " << vmaps_bool_links_.at(j).vname;
 
       const bool& val = (*(vmapBs.at(j)))[patElecs->refAt(i)];
       ele.addUserInt(vmaps_bool_links_.at(j).vname, int(val));
@@ -134,7 +131,7 @@ void PATElectronUserData::produce(edm::Event& iEvent, const edm::EventSetup& iSe
     for(unsigned int j=0; j<vmapFs.size(); ++j){
 
       if(ele.hasUserFloat(vmaps_float_links_.at(j).vname))
-	throw cms::Exception("InputError") << "@@@ PATElectronUserData::produce -- PAT user-float label already exists: " << vmaps_float_links_.at(j).vname;
+        throw cms::Exception("InputError") << "@@@ PATElectronUserData::produce -- PAT user-float label already exists: " << vmaps_float_links_.at(j).vname;
 
       const float& val = (*(vmapFs.at(j)))[patElecs->refAt(i)];
       ele.addUserFloat(vmaps_float_links_.at(j).vname, float(val));
@@ -143,7 +140,7 @@ void PATElectronUserData::produce(edm::Event& iEvent, const edm::EventSetup& iSe
     for(unsigned int j=0; j<vmapDs.size(); ++j){
 
       if(ele.hasUserFloat(vmaps_double_.at(j)))
-	throw cms::Exception("InputError") << "@@@ PATElectronUserData::produce -- PAT user-float label already exists: " << vmaps_double_.at(j);
+        throw cms::Exception("InputError") << "@@@ PATElectronUserData::produce -- PAT user-float label already exists: " << vmaps_double_.at(j);
 
       const double& val = (*(vmapDs.at(j)))[patElecs->refAt(i)];
       ele.addUserFloat(vmaps_double_.at(j), float(val));
@@ -151,7 +148,6 @@ void PATElectronUserData::produce(edm::Event& iEvent, const edm::EventSetup& iSe
 
     const float eA  = effAreas_.getEffectiveArea(fabs(ele.superCluster()->eta()));
     ele.addUserFloat("EffArea", eA);
-
   }
 
   iEvent.put(std::move(newElecs));

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -1177,9 +1177,9 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
 
     elecID_mod_ls = [
         # For 2016
+        'RecoEgamma.ElectronIdentification.Identification.heepElectronID_HEEPV60_cff',
         'RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Summer16_80X_V1_cff',
         'RecoEgamma.ElectronIdentification.Identification.cutBasedElectronHLTPreselecition_Summer16_V1_cff',
-        'RecoEgamma.ElectronIdentification.Identification.heepElectronID_HEEPV60_cff',
         'RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Spring16_GeneralPurpose_V1_cff',
         'RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Spring16_HZZ_V1_cff',
         # For 2017 (& 2018 for now)
@@ -1208,6 +1208,8 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
 
                                                   vmaps_bool=cms.PSet(
                                                       # 2016
+                                                      heepElectronID_HEEPV60=cms.InputTag(
+                                                          'egmGsfElectronIDs:heepElectronID-HEEPV60'),
                                                       cutBasedElectronID_Summer16_80X_V1_veto=cms.InputTag(
                                                           'egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-veto'),
                                                       cutBasedElectronID_Summer16_80X_V1_loose=cms.InputTag(
@@ -1218,8 +1220,6 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
                                                           'egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-tight'),
                                                       cutBasedElectronHLTPreselection_Summer16_V1=cms.InputTag(
                                                           'egmGsfElectronIDs:cutBasedElectronHLTPreselection-Summer16-V1'),
-                                                      heepElectronID_HEEPV60=cms.InputTag(
-                                                          'egmGsfElectronIDs:heepElectronID-HEEPV60'),
                                                       # 2017 & 2018
                                                       cutBasedElectronID_Fall17_94X_V2_veto=cms.InputTag(
                                                           'egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V2-veto'),
@@ -1321,12 +1321,12 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
                                         # via the "userInt" method in the pat::Electron collection used 'electron_source'
                                         # [the configuration of the pat::Electron::userInt variables should be done in PATElectronUserData]
                                         # 2016
+                                        'heepElectronID_HEEPV60',
                                         'cutBasedElectronID_Summer16_80X_V1_veto',
                                         'cutBasedElectronID_Summer16_80X_V1_loose',
                                         'cutBasedElectronID_Summer16_80X_V1_medium',
                                         'cutBasedElectronID_Summer16_80X_V1_tight',
                                         'cutBasedElectronHLTPreselection_Summer16_V1',
-                                        'heepElectronID_HEEPV60',
                                         # 2017 & 2018
                                         'cutBasedElectronID_Fall17_94X_V2_veto',
                                         'cutBasedElectronID_Fall17_94X_V2_loose',

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -1176,6 +1176,13 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
     switchOnVIDElectronIdProducer(process, DataFormat.MiniAOD)
 
     elecID_mod_ls = [
+        # For 2016
+        'RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Summer16_80X_V1_cff',
+        'RecoEgamma.ElectronIdentification.Identification.cutBasedElectronHLTPreselecition_Summer16_V1_cff',
+        'RecoEgamma.ElectronIdentification.Identification.heepElectronID_HEEPV60_cff',
+        'RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Spring16_GeneralPurpose_V1_cff',
+        'RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Spring16_HZZ_V1_cff',
+        # For 2017 (& 2018 for now)
         'RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Fall17_94X_V2_cff',
         'RecoEgamma.ElectronIdentification.Identification.heepElectronID_HEEPV70_cff',
         'RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Fall17_noIso_V2_cff',
@@ -1185,7 +1192,14 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
     for mod in elecID_mod_ls:
         setupAllVIDIdsInModule(process, mod, setupVIDElectronSelection)
 
-    from RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Fall17_94X_V2_cff import isoInputs
+    from RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Summer16_80X_V1_cff import isoInputs as ele_iso_16
+    from RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Fall17_94X_V2_cff import isoInputs as ele_iso_17
+    iso_input_era_dict = {
+        "2016v2": ele_iso_16,
+        "2016v3": ele_iso_16,
+        "2017": ele_iso_17,
+        "2018": ele_iso_17,
+    }
 
     # slimmedElectronsUSER ( = slimmedElectrons + USER variables)
     process.slimmedElectronsUSER = cms.EDProducer('PATElectronUserData',
@@ -1193,7 +1207,20 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
                                                       'slimmedElectrons'),
 
                                                   vmaps_bool=cms.PSet(
-
+                                                      # 2016
+                                                      cutBasedElectronID_Summer16_80X_V1_veto=cms.InputTag(
+                                                          'egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-veto'),
+                                                      cutBasedElectronID_Summer16_80X_V1_loose=cms.InputTag(
+                                                          'egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-loose'),
+                                                      cutBasedElectronID_Summer16_80X_V1_medium=cms.InputTag(
+                                                          'egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-medium'),
+                                                      cutBasedElectronID_Summer16_80X_V1_tight=cms.InputTag(
+                                                          'egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-tight'),
+                                                      cutBasedElectronHLTPreselection_Summer16_V1=cms.InputTag(
+                                                          'egmGsfElectronIDs:cutBasedElectronHLTPreselection-Summer16-V1'),
+                                                      heepElectronID_HEEPV60=cms.InputTag(
+                                                          'egmGsfElectronIDs:heepElectronID-HEEPV60'),
+                                                      # 2017 & 2018
                                                       cutBasedElectronID_Fall17_94X_V2_veto=cms.InputTag(
                                                           'egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V2-veto'),
                                                       cutBasedElectronID_Fall17_94X_V2_loose=cms.InputTag(
@@ -1219,16 +1246,19 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
                                                   ),
 
                                                   vmaps_float=cms.PSet(
+                                                      mvaGeneralPurpose=cms.InputTag(
+                                                          'electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring16GeneralPurposeV1Values'),
+                                                      mvaHZZ=cms.InputTag(
+                                                          'electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring16HZZV1Values'),
                                                       ElectronMVAEstimatorIso=cms.InputTag(
                                                           'electronMVAValueMapProducer:ElectronMVAEstimatorRun2Fall17IsoV2Values'),
                                                       ElectronMVAEstimatorNoIso=cms.InputTag(
                                                           'electronMVAValueMapProducer:ElectronMVAEstimatorRun2Fall17NoIsoV2Values')
                                                   ),
 
-                                                  vmaps_double=cms.vstring(
-                                                      el_isovals),
+                                                  vmaps_double=cms.vstring(el_isovals),
 
-                                                  effAreas_file=cms.FileInPath(isoInputs.isoEffAreas),
+                                                  effAreas_file=cms.FileInPath(iso_input_era_dict[year].isoEffAreas)
                                                   )
     task.add(process.egmGsfElectronIDs)
     task.add(process.slimmedElectronsUSER)
@@ -1290,6 +1320,14 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
                                         # each string should correspond to a variable saved
                                         # via the "userInt" method in the pat::Electron collection used 'electron_source'
                                         # [the configuration of the pat::Electron::userInt variables should be done in PATElectronUserData]
+                                        # 2016
+                                        'cutBasedElectronID_Summer16_80X_V1_veto',
+                                        'cutBasedElectronID_Summer16_80X_V1_loose',
+                                        'cutBasedElectronID_Summer16_80X_V1_medium',
+                                        'cutBasedElectronID_Summer16_80X_V1_tight',
+                                        'cutBasedElectronHLTPreselection_Summer16_V1',
+                                        'heepElectronID_HEEPV60',
+                                        # 2017 & 2018
                                         'cutBasedElectronID_Fall17_94X_V2_veto',
                                         'cutBasedElectronID_Fall17_94X_V2_loose',
                                         'cutBasedElectronID_Fall17_94X_V2_medium',

--- a/examples/src/ExampleModuleElectronID.cxx
+++ b/examples/src/ExampleModuleElectronID.cxx
@@ -70,6 +70,12 @@ public:
     virtual bool process(Event & event) override;
 private:
     vector<string> electronIDs =  {
+        "heepElectronID_HEEPV60",
+        "cutBasedElectronID_Summer16_80X_V1_veto",
+        "cutBasedElectronID_Summer16_80X_V1_loose",
+        "cutBasedElectronID_Summer16_80X_V1_medium",
+        "cutBasedElectronID_Summer16_80X_V1_tight",
+        "cutBasedElectronHLTPreselection_Summer16_V1",
         "cutBasedElectronID_Fall17_94X_V2_veto",
         "cutBasedElectronID_Fall17_94X_V2_loose",
         "cutBasedElectronID_Fall17_94X_V2_medium",
@@ -97,6 +103,7 @@ bool ExampleModuleElectronID::process(Event & event) {
 
     for (const auto & eleItr : *event.electrons) {
         // We can use the enum directly, this is the easiest way
+        cout << "cutBasedElectronID_Summer16_80X_V1_veto: " << eleItr.get_tag(Electron::cutBasedElectronID_Summer16_80X_V1_veto) << endl;
         cout << "cutBasedElectronID_Fall17_94X_V2_veto: " << eleItr.get_tag(Electron::cutBasedElectronID_Fall17_94X_V2_veto) << endl;
     }
  

--- a/examples/src/ExampleModuleElectronID.cxx
+++ b/examples/src/ExampleModuleElectronID.cxx
@@ -6,17 +6,18 @@
 #include "UHH2/core/include/Hists.h"
 
 #include "TH1F.h"
+#include "TH2F.h"
 
 using namespace std;
 using namespace uhh2;
 
 /** \brief Example of how to use & check Electron IDs via tags
- * 
+ *
  * This is the preferred, POG-approved method to check Electron ID, since it uses
  * stored values made by the official POG recipes.
  * There are manual versions in ElectronIds.cxx, but these may not be up to date.
  *
- * This brief example shows how to use a tag, 
+ * This brief example shows how to use a tag,
  * and produces a histogram to show how many electrons passed each ID.
  *
  * For Muons, the approach is similar, but they are called "Selectors"
@@ -32,10 +33,11 @@ public:
     virtual ~ExampleElectronIDHists();
 private:
     TH1I * hElectronIDs;
+    TH2F * hElectronMVAs;
     vector<string> electronIDs;
 };
 
-ExampleElectronIDHists::ExampleElectronIDHists(Context & ctx, const string & dirname, const vector<string> & electronIDs_): 
+ExampleElectronIDHists::ExampleElectronIDHists(Context & ctx, const string & dirname, const vector<string> & electronIDs_):
 Hists(ctx, dirname),
 electronIDs(electronIDs_)
 {
@@ -44,6 +46,12 @@ electronIDs(electronIDs_)
     for (uint i=1;i<=electronIDs.size();i++) {
         hElectronIDs->GetXaxis()->SetBinLabel(i, electronIDs.at(i-1).c_str());
     }
+
+    hElectronMVAs = book<TH2F>("ele_mvas", ";Electron MVA;MVA value", 4, 0, 4, 60, -1.2, 1.2);
+    hElectronMVAs->GetXaxis()->SetBinLabel(1, "mvaGeneralPurpose");
+    hElectronMVAs->GetXaxis()->SetBinLabel(2, "mvaHZZ");
+    hElectronMVAs->GetXaxis()->SetBinLabel(3, "mvaIso");
+    hElectronMVAs->GetXaxis()->SetBinLabel(4, "mvaNoIso");
 }
 
 
@@ -57,7 +65,13 @@ void ExampleElectronIDHists::fill(const Event & event){
                 hElectronIDs->Fill(i, event.weight);
             }
         }
+        // Store MVA values, no easy way to automate this unless one uses std::bind
+        hElectronMVAs->Fill(0.1, eleItr.mvaGeneralPurpose(), event.weight);
+        hElectronMVAs->Fill(1.1, eleItr.mvaHZZ(), event.weight);
+        hElectronMVAs->Fill(2.1, eleItr.mvaIso(), event.weight);
+        hElectronMVAs->Fill(3.1, eleItr.mvaNoIso(), event.weight);
     }
+
 }
 
 ExampleElectronIDHists::~ExampleElectronIDHists(){}
@@ -65,7 +79,7 @@ ExampleElectronIDHists::~ExampleElectronIDHists(){}
 
 class ExampleModuleElectronID: public AnalysisModule {
 public:
-    
+
     explicit ExampleModuleElectronID(Context & ctx);
     virtual bool process(Event & event) override;
 private:
@@ -106,7 +120,7 @@ bool ExampleModuleElectronID::process(Event & event) {
         cout << "cutBasedElectronID_Summer16_80X_V1_veto: " << eleItr.get_tag(Electron::cutBasedElectronID_Summer16_80X_V1_veto) << endl;
         cout << "cutBasedElectronID_Fall17_94X_V2_veto: " << eleItr.get_tag(Electron::cutBasedElectronID_Fall17_94X_V2_veto) << endl;
     }
- 
+
     hists->fill(event);
 
     return true;


### PR DESCRIPTION
Adds back in the electron IDs from 80X branch:

- heepElectronID_HEEPV60
- cutBasedElectronID_Summer16_80X_V1_veto
- cutBasedElectronID_Summer16_80X_V1_loose
- cutBasedElectronID_Summer16_80X_V1_medium
- cutBasedElectronID_Summer16_80X_V1_tight
- cutBasedElectronHLTPreselection_Summer16_V1

(see https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedElectronIdentificationRun2#Working_points_for_2016_data_for)

+ the MVA values for GeneralPurpose and HZZ, and the correct eff area file.

I also updated the ExampleElectronID module with the new IDs, and also added in plots for the MVA values to check they're OK.
There's also some whitespace tidying up.

Some notes/questions:
- HEEPv7 is the one now recommended for 2016 and 2017/8, but it seems we had HEEPv6 in the 80X branch. I've added it back in for consistency, but should we just scrap it?
- the code now runs ALL IDs for ALL years (even though they may not be applicable). Is it better to explicitly **not** run the "wrong" IDs for a given year and just store them as 0s? It doesn't really save space or time, more of a conceptual question

