### PR TITLE
[102X] Move to CMSSW_10_2_10 + properly do L1 prefiring

### DIFF
--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -559,9 +559,9 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
   branch(tr, "prefiringWeightDown", &event->prefiringWeightDown);
   if(doPrefire){
     std::string prefire_source = iConfig.getParameter<std::string>("prefire_source");
-    prefweight_token = consumes<double>(edm::InputTag(prefire_source, "NonPrefiringProb"));
-    prefweightup_token = consumes<double>(edm::InputTag(prefire_source, "NonPrefiringProbUp"));
-    prefweightdown_token = consumes<double>(edm::InputTag(prefire_source, "NonPrefiringProbDown"));
+    prefweight_token = consumes<double>(edm::InputTag(prefire_source, "nonPrefiringProb"));
+    prefweightup_token = consumes<double>(edm::InputTag(prefire_source, "nonPrefiringProbUp"));
+    prefweightdown_token = consumes<double>(edm::InputTag(prefire_source, "nonPrefiringProbDown"));
   }
   if(doAllPFParticles){
     event->pfparticles = new vector<PFParticle>;

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -1243,19 +1243,16 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
     do_prefire = prefire_era is not None
     prefire_source = "prefiringweight"
     if do_prefire:
-        # update this part when the EDProducer uses edm::FileInPath, so ugly:
-        L1Maps_file = os.path.join(os.environ['CMSSW_BASE'], "src/L1Prefiring/EventWeightProducer/files/L1PrefiringMaps_new.root")
-        # if using CRAB, you need this instead:
-        # L1Maps_file = "L1PrefiringMaps_new.root"
         setattr(process,
                 prefire_source,
                 cms.EDProducer("L1ECALPrefiringWeightProducer",
                     ThePhotons = cms.InputTag("slimmedPhotons"),
                     TheJets = cms.InputTag("slimmedJets"),
-                    L1Maps = cms.string(L1Maps_file),
+                    L1Maps = cms.string("L1PrefiringMaps.root"),
                     DataEra = cms.string(prefire_era),
-                    UseJetEMPt = cms.bool(False), #can be set to true to use jet prefiring maps parametrized vs pt(em) instead of pt
-                    PrefiringRateSystematicUncty = cms.double(0.2) #Minimum relative prefiring uncty per object
+                    UseJetEMPt = cms.bool(False),  # can be set to true to use jet prefiring maps parametrized vs pt(em) instead of pt
+                    PrefiringRateSystematicUncty = cms.double(0.2),  # Minimum relative prefiring uncty per object
+                    SkipWarnings = cms.bool(True)
                 )
         )
         task.add(getattr(process, prefire_source))

--- a/scripts/crab/crab_template.py
+++ b/scripts/crab/crab_template.py
@@ -44,12 +44,6 @@ config.JobType.pluginName = 'Analysis'
 config.JobType.psetName = os.path.join(os.environ['CMSSW_BASE'], 'src/UHH2/core/python/ntuplewriter_mc_2016v2.py')
 config.JobType.outputFiles = ["Ntuple.root"]
 config.JobType.maxMemoryMB = 2500
-# If you are using the L1 prefiring map, please modify the
-# L1Maps location in ntuple_generator to just "L1PrefiringMaps_new.root"
-# until this is properly handled
-# i.e.:
-# process.prefiringweight.L1Maps = cms.string("L1PrefiringMaps_new.root")
-config.JobType.inputFiles = [os.path.join(os.environ['CMSSW_BASE'], 'src/L1Prefiring/EventWeightProducer/files/L1PrefiringMaps_new.root')]
         
 config.Data.inputDBS = 'global'
 config.Data.splitting = 'EventAwareLumiBased'

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -90,7 +90,7 @@ time git clone https://github.com/UHH2/SFrame.git
 
 # Get CMSSW
 export SCRAM_ARCH=slc6_amd64_gcc700
-CMSREL=CMSSW_10_2_6
+CMSREL=CMSSW_10_2_10
 eval `cmsrel ${CMSREL}`
 cd ${CMSREL}/src
 eval `scramv1 runtime -sh`
@@ -107,8 +107,6 @@ time git cms-init -y  # not needed if not addpkg ing
 
 # Necessary for using our FastJet
 time git cms-addpkg RecoJets/JetProducers
-# For L1 prefiring. In future this should be in a 10_2_X release
-time git cms-merge-topic lathomas:L1Prefiring_10_2_6
 
 # Update FastJet and contribs for HOTVR and UniversalJetCluster
 FJINSTALL=$(fastjet-config --prefix)


### PR DESCRIPTION
With 10_2_10, they integrated the L1 ECAL prefiring module properly: https://github.com/cms-sw/cmssw/releases/tag/CMSSW_10_2_10.

This PR now changes the install script to use 10_2_10, and removes the L1 prefire merge-topic. We also now use this new module, which thankfully removes all the faff with finding the weights ROOT file. The user no longer needs to specify anything in their CRAB config, nor worry about changing paths in their `ntuple_generator.py`.

Note that the label capitalisation changed, hence the changes in `NtupleWriter.cc`

(I'm also tempted to just import the cff file and save a few lines of code? Although more explicit here what's going on (e.g. systematics size))