### PR TITLE
[102X] Save year arg in `generate_process()` to Event class

### DIFF
--- a/core/include/Event.h
+++ b/core/include/Event.h
@@ -18,6 +18,7 @@ public:
   int run;
   int luminosityBlock;
   long long event;
+  std::string year;
 
   float rho;
 

--- a/core/include/EventHelper.h
+++ b/core/include/EventHelper.h
@@ -97,7 +97,8 @@ private:
     Event::Handle<int> h_run, h_lumi, h_event;
     Event::Handle<float> h_rho, h_bsx, h_bsy, h_bsz, h_prefire, h_prefireUp, h_prefireDown;
     Event::Handle<bool> h_isRealData;
-    
+    Event::Handle<std::string> h_year;
+
     Event::Handle<std::vector<PrimaryVertex>> h_pvs;
     Event::Handle<std::vector<Electron>> h_electrons;
     Event::Handle<std::vector<Muon>> h_muons;

--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -402,11 +402,13 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
   // initialization of tree variables
   event.reset(new uhh2::Event(*ges));
 
-  branch(tr, "run",&event->run);
-  branch(tr, "event",&event->event);
-  branch(tr, "luminosityBlock",&event->luminosityBlock);
-  branch(tr, "isRealData",&event->isRealData);
-  branch(tr, "rho",&event->rho);
+  branch(tr, "run", &event->run);
+  branch(tr, "event", &event->event);
+  branch(tr, "luminosityBlock", &event->luminosityBlock);
+  branch(tr, "isRealData", &event->isRealData);
+  year = iConfig.getParameter<std::string>("year");
+  branch(tr, "year", &event->year);
+  branch(tr, "rho", &event->rho);
   //always create rho branch, as some SFrame modules rely on it being present; only fill it
   // if doRho is true.
   if(doRho){
@@ -640,6 +642,7 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
    event->event = iEvent.id().event();
    event->luminosityBlock = iEvent.luminosityBlock();
    event->isRealData      = iEvent.isRealData();
+   event->year = year;
 
    if(doRho){
       edm::Handle<double> m_rho;

--- a/core/plugins/NtupleWriter.h
+++ b/core/plugins/NtupleWriter.h
@@ -46,7 +46,7 @@ class NtupleWriter : public edm::EDFilter {
       // ----------member data ---------------------------
       TFile *outfile;
       TTree *tr;
-      std::string fileName;
+      std::string fileName, year;
 
       bool doGenJets;
       bool doGenJetsWithParts;

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -1303,6 +1303,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
                                     #    TestKey = cms.string("TestValue")
                                     #),
                                     fileName=cms.string("Ntuple.root"),
+                                    year=cms.string(year),
                                     doPV=cms.bool(True),
                                     pv_sources=cms.vstring("offlineSlimmedPrimaryVertices"),
                                     doRho=cms.untracked.bool(True),

--- a/core/src/Event.cxx
+++ b/core/src/Event.cxx
@@ -7,6 +7,7 @@ using namespace std;
 
 void Event::clear(){
     run = luminosityBlock = event = -1;
+    year = "";
     rho = beamspot_x0 = beamspot_y0 = beamspot_z0 = NAN;
     prefiringWeight = prefiringWeightUp = prefiringWeightDown = 1.;
     electrons = 0;

--- a/core/src/EventHelper.cxx
+++ b/core/src/EventHelper.cxx
@@ -25,6 +25,7 @@ EventHelper::EventHelper(uhh2::Context & ctx_): ctx(ctx_), event(0), pvs(false),
     h_event = declare_in_out<int>("event", "event", ctx);
     h_rho = declare_in_out<float>("rho", "rho", ctx);
     h_isRealData = declare_in_out<bool>("isRealData", "isRealData", ctx);
+    h_year = declare_in_out<std::string>("year", "year", ctx);
     h_bsx = declare_in_out<float>("beamspot_x0", "beamspot_x0", ctx);
     h_bsy = declare_in_out<float>("beamspot_y0", "beamspot_y0", ctx);
     h_bsz = declare_in_out<float>("beamspot_z0", "beamspot_z0", ctx);
@@ -86,6 +87,7 @@ void EventHelper::event_read(){
     event->event = event->get(h_event);
     event->rho = event->get(h_rho);
     event->isRealData = event->get(h_isRealData);
+    event->year = event->get(h_year);
     event->beamspot_x0 = event->get(h_bsx);
     event->beamspot_y0 = event->get(h_bsy);
     event->beamspot_z0 = event->get(h_bsz);
@@ -150,6 +152,7 @@ void EventHelper::event_write(){
     event->set(h_event, event->event);
     event->set(h_rho, event->rho);
     event->set(h_isRealData, event->isRealData);
+    event->set(h_year, event->year);
     event->set(h_bsx, event->beamspot_x0);
     event->set(h_bsy, event->beamspot_y0);
     event->set(h_bsz, event->beamspot_z0);


### PR DESCRIPTION
This saves the `year` parameter used in the ntuple_generator to the Ntuple tree itself.

Analysis modules can then dynamically change their behaviour depending on this parameter, or the user can choose how to utilise it.

A string was chosen instead of an int, because the latter relies on some immutable mapping (or rather, never changing the order of existing values). This way, the user can immediately inspect and has more control over how to react. 1 string is also a very small overhead.

I guess the only question is: is "year" a good variable name? Or should it be something like "era"? (Can change the arg name in `generate_process()` as well)