### PR TITLE
[102X] Store MET with EE noise mitigation only for 2017

### DIFF
--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -238,6 +238,26 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
 
 
     ###############################################
+    # Modified TypeI MET
+    #
+    # Only applicable during 2017, this corrects the MET due to excess EE noise
+    # https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETUncertaintyPrescription?rev=89#Instructions_for_9_4_X_X_9_or_10
+    # To be used with 17Nov2017 and 31Mar2018 rereco of 2017 data, and MC events.
+    # The more accurate and long-term solution will come incorporated in planed "Ultra-Legacy" recreco
+    if year in ['2017']:
+        from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMetCorAndUncFromMiniAOD
+
+        runMetCorAndUncFromMiniAOD(
+            process,
+            isData=useData,
+            fixEE2017=True,
+            fixEE2017Params={'userawPt': True, 'ptThreshold': 50.0, 'minEtaThreshold': 2.65, 'maxEtaThreshold': 3.139},
+            postfix="ModifiedMET"
+        )
+
+        met_sources_GL.append("slimmedMETsModifiedMET")
+
+    ###############################################
     # CHS JETS
     #
     # configure additional jet collections, based on chs.


### PR DESCRIPTION
Same as in 94X_v3. Note that the necessary updates went into 10_2_7 release, so no extra recipes steps required since we are now on 10_2_10 (see #1091 )

References: 
https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETUncertaintyPrescription?rev=89#Instructions_for_9_4_X_X_9_or_10
https://github.com/cms-sw/cmssw/releases/tag/CMSSW_10_2_7
