### PR TITLE
[102X] MET fixes: rawCHS for 2016v2, add sumEt, use proper MET significance

### DIFF
--- a/core/include/MET.h
+++ b/core/include/MET.h
@@ -6,6 +6,7 @@ public:
   MET(){
       m_pt = 0;
       m_phi = 0;
+      m_sumEt = 0;
       m_mEtSig = 0;
       m_uncorr_pt = 0;
       m_uncorr_phi = 0;
@@ -44,6 +45,8 @@ public:
    float pt() const{return m_pt;}
    /// phi
    float phi() const{return m_phi;}
+   /// sum of ET in the event
+   float sumEt() const{return m_sumEt;}
    /// transverse momentum significance
    float mEtSig() const{return m_mEtSig;}
 
@@ -116,6 +119,8 @@ public:
    void set_pt(float pt){m_pt=pt;}  
    /// set phi
    void set_phi(float phi){m_phi=phi;}
+   /// set sum Et
+   void set_sumEt(float sumEt){m_sumEt=sumEt;}
    /// set transverse momentum significance
    void set_mEtSig(float mEtSig){m_mEtSig=mEtSig;}
 
@@ -200,6 +205,7 @@ public:
 private:
    float m_pt;
    float m_phi;
+   float m_sumEt;
    float m_mEtSig;
    float m_shiftedPx_JetEnUp;
    float m_shiftedPx_JetEnDown;

--- a/core/include/MET.h
+++ b/core/include/MET.h
@@ -7,7 +7,7 @@ public:
       m_pt = 0;
       m_phi = 0;
       m_sumEt = 0;
-      m_mEtSig = 0;
+      m_mEtSignificance = 0;
       m_uncorr_pt = 0;
       m_uncorr_phi = 0;
       m_shiftedPx_JetEnUp = 0;
@@ -47,8 +47,8 @@ public:
    float phi() const{return m_phi;}
    /// sum of ET in the event
    float sumEt() const{return m_sumEt;}
-   /// transverse momentum significance
-   float mEtSig() const{return m_mEtSig;}
+   /// transverse momentum significance from covariance matrix
+   float mEtSignificance() const{return m_mEtSignificance;}
 
    /// uncorrected transverse momentum
    float uncorr_pt() const{return m_uncorr_pt;}
@@ -121,8 +121,8 @@ public:
    void set_phi(float phi){m_phi=phi;}
    /// set sum Et
    void set_sumEt(float sumEt){m_sumEt=sumEt;}
-   /// set transverse momentum significance
-   void set_mEtSig(float mEtSig){m_mEtSig=mEtSig;}
+   /// set transverse momentum significance (should be from covariance matrix)
+   void set_mEtSignificance(float mEtSignificance){m_mEtSignificance=mEtSignificance;}
 
    /// set uncorrected transverse momentum
    void set_uncorr_pt(float pt){m_uncorr_pt=pt;}  
@@ -206,7 +206,7 @@ private:
    float m_pt;
    float m_phi;
    float m_sumEt;
-   float m_mEtSig;
+   float m_mEtSignificance;
    float m_shiftedPx_JetEnUp;
    float m_shiftedPx_JetEnDown;
    float m_shiftedPx_JetResUp; 

--- a/core/include/MET.h
+++ b/core/include/MET.h
@@ -106,6 +106,7 @@ public:
 
    float shiftedPy_MuonEnUp() const{return m_shiftedPy_MuonEnUp;}
    
+   // For 2016v2, rawCHS does not exist, so it just returns the normal MET px & py
    float rawCHS_px() const{return m_rawCHS_px;}
 
    float rawCHS_py() const{return m_rawCHS_py;}

--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -1107,6 +1107,7 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
          pat::MET pat_met = pat_mets[0];
          met[j].set_pt(pat_met.pt());
          met[j].set_phi(pat_met.phi());
+         met[j].set_sumEt(pat_met.sumEt());
          met[j].set_mEtSig(pat_met.mEtSig());
          met[j].set_uncorr_pt(pat_met.uncorPt());
          met[j].set_uncorr_phi(pat_met.uncorPhi());
@@ -1156,6 +1157,7 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
          pat::MET pat_genmet = pat_genmets[0];
          genmet[j].set_pt(pat_genmet.genMET()->pt());
          genmet[j].set_phi(pat_genmet.genMET()->phi());
+         genmet[j].set_sumEt(pat_genmet.genMET()->sumEt());
          genmet[j].set_mEtSig(pat_genmet.genMET()->mEtSig());
          //uncorrected MET is equal to normal MET for GenMET
          genmet[j].set_uncorr_pt(pat_genmet.genMET()->pt());

--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -1108,7 +1108,7 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
          met[j].set_pt(pat_met.pt());
          met[j].set_phi(pat_met.phi());
          met[j].set_sumEt(pat_met.sumEt());
-         met[j].set_mEtSig(pat_met.mEtSig());
+         met[j].set_mEtSignificance(pat_met.metSignificance());
          met[j].set_uncorr_pt(pat_met.uncorPt());
          met[j].set_uncorr_phi(pat_met.uncorPhi());
          // std::cout<<"MET uncorrPt = "<<pat_met.uncorPt()<<" uncorrPhi = "<<pat_met.uncorPhi()<<" corrPt = "<<pat_met.pt()<<" corrPhi = "<<pat_met.phi()<<std::endl;
@@ -1158,7 +1158,11 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
          genmet[j].set_pt(pat_genmet.genMET()->pt());
          genmet[j].set_phi(pat_genmet.genMET()->phi());
          genmet[j].set_sumEt(pat_genmet.genMET()->sumEt());
-         genmet[j].set_mEtSig(pat_genmet.genMET()->mEtSig());
+         // Calculate the met significance ourselves, since it isn't stored
+         // this doesn't actually work for genMET - significane matrix probably needs calculating
+         // genmet[j].set_mEtSignificance(metsig::METSignificance::getSignificance(pat_genmet.genMET()->getSignificanceMatrix(), *(pat_genmet.genMET())));
+         // Instead just store MET/sqrt(sumEt)
+         genmet[j].set_mEtSignificance(pat_genmet.genMET()->mEtSig());
          //uncorrected MET is equal to normal MET for GenMET
          genmet[j].set_uncorr_pt(pat_genmet.genMET()->pt());
          genmet[j].set_uncorr_phi(pat_genmet.genMET()->phi());

--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -1137,8 +1137,8 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
                met[j].set_shiftedPy_TauEnDown(pat_met.shiftedPy(pat::MET::METUncertainty::TauEnDown, pat::MET::METCorrectionLevel::Type1));
                met[j].set_shiftedPy_MuonEnDown(pat_met.shiftedPy(pat::MET::METUncertainty::MuonEnDown, pat::MET::METCorrectionLevel::Type1));
                met[j].set_shiftedPy_MuonEnUp(pat_met.shiftedPy(pat::MET::METUncertainty::MuonEnUp, pat::MET::METCorrectionLevel::Type1));
-               met[j].set_rawCHS_px(pat_met.corPx(pat::MET::METCorrectionLevel::RawChs));
-               met[j].set_rawCHS_py(pat_met.corPy(pat::MET::METCorrectionLevel::RawChs));
+               met[j].set_rawCHS_px((year != "2016v2" ? pat_met.corPx(pat::MET::METCorrectionLevel::RawChs) : pat_met.px()));  // for 2016v2, rawCHS wasn't stored,
+               met[j].set_rawCHS_py((year != "2016v2" ? pat_met.corPy(pat::MET::METCorrectionLevel::RawChs) : pat_met.py()));  // so while it "works", it just returns junk
             }
        }
       }


### PR DESCRIPTION
A hodgepodge of MET changes:

- for 2016v2, rawCHS is not stored. The code does run & store something, but no idea where it gets those values from. This variable often shows up in our tests as differing (with massive values sometimes), even though nothing has changed. So now I've just it to the usual MET px & py.

- now store sumET in MET

- replaced `MET::mEtSig` (which was actually = MET/sqrt(sumEt)) with `MET::mEtSignificance`, taken from the full covariance matrix. I changed the name (a) to match the `pat::MET` method, and (b) to ensure that any analyses using `mEtSig` are alerted to this change. The old `mEtSig` is still available, since we now store sumEt.
Note that for gen met, the significance matrix isn't stored, and instead requires explicit calculation. Given we don't even store gen met (should we?) I have not enacted this, but left a comment incase of future development there.