### PR TITLE
[102X] Add 2016v2 Muon Selectors back in, + module to test all Selectors & plot TrackType + SimType

### DIFF
--- a/core/include/Muon.h
+++ b/core/include/Muon.h
@@ -15,6 +15,13 @@ class Muon : public Particle {
     PF,
     Global,
     Standalone,
+    // 2016v2 selectors:
+    Soft,
+    Loose,
+    Medium,
+    Tight,
+    Highpt,
+    // 2016v3 & 2017 onwards selectors:
     CutBasedIdLoose,
     CutBasedIdMedium, 
     CutBasedIdMediumPrompt, 
@@ -50,6 +57,8 @@ class Muon : public Particle {
      C) classify as "light flavour/decay" (2)
   In any case, if the TP is not preferentially matched back to the same RECO muon,
   label as Ghost (flip the classification)
+
+  Note that this is only available for 2017 datasets and later
   */
   enum SimType{ 
     Unknown                     = 999, 

--- a/core/plugins/NtupleWriterLeptons.cxx
+++ b/core/plugins/NtupleWriterLeptons.cxx
@@ -176,6 +176,14 @@ void NtupleWriterMuons::process(const edm::Event & event, uhh2::Event & uevent, 
      mu.set_selector(Muon::Tracker   , pat_mu.isTrackerMuon());
      mu.set_selector(Muon::Standalone, pat_mu.isStandAloneMuon());
 
+     // 2016v2 specific ones
+     mu.set_selector(Muon::Soft  , pat_mu.isSoftMuon(PV));
+     mu.set_selector(Muon::Loose , pat_mu.isLooseMuon());
+     mu.set_selector(Muon::Medium, pat_mu.isMediumMuon());
+     mu.set_selector(Muon::Tight , pat_mu.isTightMuon(PV));
+     mu.set_selector(Muon::Highpt, pat_mu.isHighPtMuon(PV));
+
+     // 2016v3 & 2017 onwards uses these instead
      mu.set_selector(Muon::CutBasedIdLoose       , pat_mu.passed(reco::Muon::CutBasedIdLoose));
      mu.set_selector(Muon::CutBasedIdMedium      , pat_mu.passed(reco::Muon::CutBasedIdMedium));
      mu.set_selector(Muon::CutBasedIdMediumPrompt, pat_mu.passed(reco::Muon::CutBasedIdMediumPrompt));

--- a/examples/config/ExampleMuonID.xml
+++ b/examples/config/ExampleMuonID.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE JobConfiguration PUBLIC "" "JobConfig.dtd">
+
+<!-- OutputLevel controls which messages are printed; set to VERBOSE or DEBUG for more verbosity, to WARNING or ERROR for less -->
+<JobConfiguration JobName="ExampleCycleJob" OutputLevel="INFO">
+    <Library Name="libSUHH2examples"/>
+    <Package Name="SUHH2examples.par" />
+
+   <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="./" PostFix="" TargetLumi="1" >
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="MuonID" Cacheable="False">
+            <In FileName="../core/python/Ntuple.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+        </InputData>
+
+        <UserConfig>
+            <!-- define which collections to read from the input. Only specify what you need to save I/O time -->
+            <Item Name="MuonCollection" Value="slimmedMuonsUSER" />
+
+
+            <!-- the class name of the AnalysisModule subclasses to run: -->
+            <Item Name="AnalysisModule" Value="ExampleModuleMuonID" />
+
+
+            <!-- tell AnalysisModuleRunner NOT to use the MC event weight from SFrame; rather let
+                 MCLumiWeight (called via CommonModules) calculate the MC event weight. The MC
+                 event weight assigned by MCLumiWeight is InputData.Lumi / Cycle.TargetLumi. -->
+            <Item Name="use_sframe_weight" Value="false" />
+
+        </UserConfig>
+    </Cycle>
+</JobConfiguration>

--- a/examples/src/ExampleModuleMuonID.cxx
+++ b/examples/src/ExampleModuleMuonID.cxx
@@ -1,0 +1,125 @@
+#include <iostream>
+#include <memory>
+#include <numeric>
+#include <algorithm>
+#include <vector>
+
+#include "UHH2/core/include/AnalysisModule.h"
+#include "UHH2/core/include/Event.h"
+#include "UHH2/core/include/Hists.h"
+
+#include "TH1F.h"
+#include "TH2F.h"
+
+using namespace std;
+using namespace uhh2;
+
+/** \brief Example of how to use & check Muon IDs via selectors
+ *
+ * This is the preferred, POG-approved method to check Muon ID, since it uses
+ * stored values made by the official POG recipes.
+ *
+ * Note that there are a variety of selectors, some appropriate for 2016/80X,
+ * and some appropriate for 2017 onwards. Whilst both might be filled, you should
+ * know which one is actually sensible.
+ *
+ * There are manual versions in MuonIDs.cxx, but these may not be up to date.
+ *
+ * This brief example shows how to use a selector,
+ * and produces a histogram to show how many muons passed each ID.
+ *
+ * For Electrons, the approach is similar, but they are called "tags"
+ */
+
+namespace uhh2examples {
+
+class ExampleMuonIDHists: public uhh2::Hists {
+public:
+    ExampleMuonIDHists(uhh2::Context & ctx, const std::string & dirname);
+
+    virtual void fill(const uhh2::Event & ev) override;
+    virtual ~ExampleMuonIDHists();
+private:
+    TH1F * hMuonSelector;
+    TH1F * hMuonSimType;
+    TH1F * hMuonTrackType;
+    vector<float> selectorBins;
+    vector<float> simTypeBins = {-15, -13, -11, -3, -2, -1, 0, 1, 2, 3, 11, 13, 15, 999, 1100}; // last value for bin
+    vector<float> trackTypeBins;
+};
+
+ExampleMuonIDHists::ExampleMuonIDHists(Context & ctx, const string & dirname):
+Hists(ctx, dirname)
+{
+    selectorBins.resize(34); // should be 1 more than # selectors
+    std::iota(selectorBins.begin(), selectorBins.end(), 0.);
+    hMuonSelector = book<TH1F>("mu_selector", ";Muon Selector;N", selectorBins.size()-1, &selectorBins[0]);
+
+    hMuonSimType = book<TH1F>("mu_simtype", ";Muon SimType;N", simTypeBins.size()-1, &simTypeBins[0]);
+
+    trackTypeBins.resize(6); // should be 1 more than # track types
+    std::iota(trackTypeBins.begin(), trackTypeBins.end(), 0.);
+    hMuonTrackType = book<TH1F>("mu_tracktype", ";MuonTrackType;N", trackTypeBins.size()-1, &trackTypeBins[0]);
+}
+
+
+void ExampleMuonIDHists::fill(const Event & event){
+    // Loop over all IDs for all muons, and store values
+    for (auto & muItr : *event.muons) {
+        // selectors
+        for (auto selInd : selectorBins) {
+            if (muItr.get_selector(static_cast<Muon::Selector>(selInd))) {
+                hMuonSelector->Fill(selInd);
+            }
+        }
+        // simTypes
+        hMuonSimType->Fill(muItr.simType());
+
+        // trackTypes
+        hMuonTrackType->Fill(muItr.tunePTrackType());
+    }
+
+}
+
+ExampleMuonIDHists::~ExampleMuonIDHists(){}
+
+
+class ExampleModuleMuonID: public AnalysisModule {
+public:
+
+    explicit ExampleModuleMuonID(Context & ctx);
+    virtual bool process(Event & event) override;
+private:
+    unique_ptr<ExampleMuonIDHists> hists;
+    bool firstPrint;
+};
+
+
+ExampleModuleMuonID::ExampleModuleMuonID(Context & ctx):
+firstPrint(false)
+{
+    cout << "Hello World from ExampleModuleMuonID!" << endl;
+    hists.reset(new ExampleMuonIDHists(ctx, "MuonID"));
+}
+
+
+bool ExampleModuleMuonID::process(Event & event) {
+
+    if (!firstPrint) {
+        for (const auto & muItr : *event.muons) {
+            cout << "Loose: " << muItr.get_selector(Muon::Loose) << endl;
+            cout << "CutBasedIdLoose: " << muItr.get_selector(Muon::CutBasedIdLoose) << endl;
+        }
+        firstPrint = true;
+    }
+
+    hists->fill(event);
+
+    return true;
+}
+
+// as we want to run the ExampleCycleNew directly with AnalysisModuleRunner,
+// make sure the ExampleModuleMuonID is found by class name. This is ensured by this macro:
+UHH2_REGISTER_ANALYSIS_MODULE(ExampleModuleMuonID)
+
+}


### PR DESCRIPTION
Add 2016v2/80X Selectors back in, since those samples to do not use the more fine-grained Selectors that are used in 94X.

Also add in example module that plots which Selectors are filled, and the distributions of TrackTypes and SimTypes. Good for testing & showing how to use `Muon::get_selector()`
