### PR TITLE
[102X] Ignore -Wimplicit-fallthrough from BOOST unit_test header

### DIFF
--- a/common/test/test.cxx
+++ b/common/test/test.cxx
@@ -4,6 +4,7 @@
 #pragma GCC diagnostic push
 // turn off the specific warning. Can also use "-Wall"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
 
 #include <boost/test/included/unit_test.hpp>
 


### PR DESCRIPTION
This should remove the annoying warning when compiling:

```
In file included from /cvmfs/cms.cern.ch/slc6_amd64_gcc700/external/boost/1.63.0-gnimlf/include/boost/test/included/unit_test.hpp:21:0,
                 from test/test.cxx:8:
/cvmfs/cms.cern.ch/slc6_amd64_gcc700/external/boost/1.63.0-gnimlf/include/boost/test/impl/framework.ipp: In function 'void boost::unit_test::framework::run(boost::unit_test::test_unit_id, bool)':
/cvmfs/cms.cern.ch/slc6_amd64_gcc700/external/boost/1.63.0-gnimlf/include/boost/test/impl/framework.ipp:1436:14: warning: this statement may fall through [-Wimplicit-fallthrough=]
         seed = static_cast<unsigned>( std::rand() ^ std::time( 0 ) ); // better init using std::rand() ^ ...
         ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/cvmfs/cms.cern.ch/slc6_amd64_gcc700/external/boost/1.63.0-gnimlf/include/boost/test/impl/framework.ipp:1437:5: note: here
     default:
     ^~~~~~~
```