### PR TITLE
[102X] Save links to  XCONE gen jets constituents

### DIFF
--- a/core/plugins/BuildFile.xml
+++ b/core/plugins/BuildFile.xml
@@ -13,6 +13,7 @@
 <use  name="CommonTools/Utils" />
 <use  name="EgammaAnalysis/ElectronTools" />
 <use  name="RecoJets/JetAlgorithms" />
+<use  name="RecoJets/JetProducers" />
 <use  name="SimDataFormats/GeneratorProducts" />
 <use name="RecoBTau/JetTagComputer" />
 <!--<use  name="AnalysisDataFormats/TopObjects"/>

--- a/core/plugins/GenXConeProducer.cc
+++ b/core/plugins/GenXConeProducer.cc
@@ -72,10 +72,6 @@ class GenXConeProducer : public edm::stream::EDProducer<> {
     virtual void endStream() override;
 
     virtual pat::Jet createPatJet(const fastjet::PseudoJet &, const edm::EventSetup&);
-  // void writeSpecific(reco::PFJet  & jet,
-  // 		     reco::Particle::LorentzVector const & p4,
-  // 		     reco::Particle::Point const & point, 
-  // 		     std::vector<reco::CandidatePtr> const & constituents, edm::EventSetup const & c );
 
     virtual void initPlugin(std::unique_ptr<NjettinessPlugin> & ptr, int N, double R0, double beta, bool usePseudoXCone);
 
@@ -170,8 +166,9 @@ GenXConeProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   seeds[0] = std::max(runNum_uint, minSeed_ + 3) + 3 * evNum_uint;
   seeds[1] = std::max(runNum_uint, minSeed_ + 5) + 5 * evNum_uint;
   gas.set_random_status(seeds);
-
-  vertex_=reco::Jet::Point(0,0,0);//dummy value, todo: copy it from pv-collection? see example https://github.com/cms-sw/cmssw/blob/master/RecoJets/JetProducers/plugins/VirtualJetProducer.cc#L292
+//dummy value, todo: copy it from pv-collection? see example https://github.com/cms-sw/cmssw/blob/master/RecoJets/JetProducers/plugins/VirtualJetProducer.cc#L292
+//ToDo: vertex info is not used in the clustering???
+  vertex_=reco::Jet::Point(0,0,0);
   particles_.clear(); 
   edm::Handle<edm::View<reco::Candidate>> particles;
   iEvent.getByToken(src_token_, particles);


### PR DESCRIPTION
To save gen information obtained by looping over gen jet constituents, add links to them for xcone gen jets. "transformation" from PseudoJet to pat::Jet is re-written with adding PseudoJet->reco::GenJet->pat::Jet steps. 
To large extend inspired by [1] 
[1] https://github.com/cms-sw/cmssw/blob/master/RecoJets/JetProducers/plugins/VirtualJetProducer.cc

P.S: parton and hadron flavor information is still not filled for unknown reasons :(