### PR TITLE
[102X] Remove pruned mass from TopJet collections

### DIFF
--- a/common/include/JetHists.h
+++ b/common/include/JetHists.h
@@ -36,7 +36,7 @@
 class JetHistsBase: public uhh2::Hists {
 protected:
   struct jetHist{
-      TH1F* pt, *eta, *phi, *mass, *csv, *mvahiggsdiscr, *prunedmass, *subjet_sum_mass; 
+      TH1F* pt, *eta, *phi, *mass, *csv, *mvahiggsdiscr, *subjet_sum_mass;
   };
     
   JetHistsBase(uhh2::Context & ctx, const std::string & dirname);

--- a/common/src/JetHists.cxx
+++ b/common/src/JetHists.cxx
@@ -130,7 +130,6 @@ void TopJetHists::fill_subjetHist(const TopJet & topjet, subjetHist & subjet_his
 JetHistsBase::jetHist TopJetHists::book_topJetHist(const std::string & axisSuffix, const std::string & histSuffix, double minPt, double maxPt) {
   auto jet_hist = book_jetHist(axisSuffix, histSuffix, minPt, maxPt);
   jet_hist.mvahiggsdiscr = book<TH1F>("mvahiggsdiscr"+histSuffix,"mva-higgs-disriminator "+axisSuffix,50,0,1);
-  jet_hist.prunedmass = book<TH1F>("mass_pruned"+histSuffix,"M^{ "+axisSuffix+"}_{pruned} [GeV/c^{2}]", 100, 0, 300);
   jet_hist.subjet_sum_mass = book<TH1F>("mass_subjet_sum"+histSuffix,"M^{ "+axisSuffix+"}_{subjet sum} [GeV/c^{2}]", 100, 0, 300);
   return jet_hist;
 }
@@ -142,7 +141,6 @@ void TopJetHists::fill_topJetHist(const TopJet & jet, JetHistsBase::jetHist & je
     subjet_sum += s.v4();
   }
   jet_hist.mvahiggsdiscr->Fill(jet.mvahiggsdiscr(), weight);
-  jet_hist.prunedmass->Fill(jet.prunedmass(), weight);
   jet_hist.subjet_sum_mass->Fill(subjet_sum.M(), weight);
 }
 

--- a/core/include/TopJet.h
+++ b/core/include/TopJet.h
@@ -81,7 +81,7 @@ public:
    }
 
   TopJet(){
-      m_qjets_volatility = m_tau1 = m_tau2 = m_tau3 = m_tau4 = m_mvahiggsdiscr = m_prunedmass = m_softdropmass = m_tau1_groomed = m_tau2_groomed = m_tau3_groomed = m_tau4_groomed = m_ecfN2_beta1 = m_ecfN2_beta2 = m_ecfN3_beta1 = m_ecfN3_beta2 = -1.0f;
+      m_qjets_volatility = m_tau1 = m_tau2 = m_tau3 = m_tau4 = m_mvahiggsdiscr = m_softdropmass = m_tau1_groomed = m_tau2_groomed = m_tau3_groomed = m_tau4_groomed = m_ecfN2_beta1 = m_ecfN2_beta2 = m_ecfN3_beta1 = m_ecfN3_beta2 = -1.0f;
   }
 
   // getters
@@ -103,8 +103,6 @@ public:
   float ecfN3_beta2() const {return m_ecfN3_beta2;}
 
   float mvahiggsdiscr() const {return m_mvahiggsdiscr;}
-
-  float prunedmass() const {return m_prunedmass;}
 
   float softdropmass() const {return m_softdropmass;}
 
@@ -131,8 +129,6 @@ public:
   void set_ecfN3_beta2(float x){m_ecfN3_beta2 = x;}
 
   void set_mvahiggsdiscr(float x){m_mvahiggsdiscr = x;}
-
-  void set_prunedmass(float x){m_prunedmass = x;}
 
   void set_softdropmass(float x){m_softdropmass = x;}
 
@@ -162,8 +158,6 @@ private:
   float m_ecfN3_beta2;
 
   float m_mvahiggsdiscr;
-
-  float m_prunedmass;
 
   float m_softdropmass;
 

--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -371,9 +371,6 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
           cfg.do_taginfo_subjets = false;
         }
 
-        if(topjets_list[j].exists("prunedmass_source")){
-          cfg.pruned_src = topjets_list[j].getParameter<std::string>("prunedmass_source");
-        }
         if(topjets_list[j].exists("softdropmass_source")){
           cfg.softdrop_src = topjets_list[j].getParameter<std::string>("softdropmass_source");
         }

--- a/core/plugins/NtupleWriterJets.cxx
+++ b/core/plugins/NtupleWriterJets.cxx
@@ -365,11 +365,6 @@ NtupleWriterTopJets::NtupleWriterTopJets(Config & cfg, bool set_jets_member): pt
       src_hepTopTag_token = cfg.cc.consumes<edm::View<reco::HTTTopJetTagInfo> >(edm::InputTag(cfg.toptagging_src));
     }
 
-    pruned_src = cfg.pruned_src;
-    if(pruned_src.find("Mass")==string::npos){
-      src_pruned_token = cfg.cc.consumes<std::vector<pat::Jet>>(cfg.pruned_src);
-    }
-
     softdrop_src = cfg.softdrop_src;
     if(softdrop_src.find("Mass")==string::npos){
       src_softdrop_token = cfg.cc.consumes<std::vector<pat::Jet>>(cfg.softdrop_src);
@@ -750,38 +745,6 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
         if (ecf_beta2_src.empty()) {
           topjet.set_ecfN2_beta2(getPatJetUserFloat(pat_topjet, "ak8PFJetsPuppiSoftDropValueMap:nb2AK8PuppiSoftDropN2", -1.));
           topjet.set_ecfN3_beta2(getPatJetUserFloat(pat_topjet, "ak8PFJetsPuppiSoftDropValueMap:nb2AK8PuppiSoftDropN3", -1.));
-        }
-        /*---------------------*/
-
-        /*--- pruned mass -----*/
-        if(pruned_src.find("Mass")!=string::npos){
-
-          topjet.set_prunedmass(getPatJetUserFloat(pat_topjet, pruned_src, -1.));
-        }
-        else if(pruned_src!=""){//pruned mass set through matching with pruned-jet collection
-
-          edm::Handle<pat::JetCollection> pruned_pat_topjets;
-          event.getByToken(src_pruned_token, pruned_pat_topjets);
-          const vector<pat::Jet> & pat_prunedjets = *pruned_pat_topjets;
-
-          //match a jet from pruned collection
-          int i_pat_prunedjet = -1;
-          double drmin = numeric_limits<double>::infinity();
-          for (unsigned int ih = 0; ih < pat_prunedjets.size(); ih++) {
-
-            const pat::Jet & pruned_jet = pat_prunedjets[ih];
-            auto dr = reco::deltaR(pruned_jet, pat_topjet);
-            if(dr < drmin){
-              i_pat_prunedjet = ih;
-              drmin = dr;
-            }
-          }
-
-          if(i_pat_prunedjet >= 0 && drmin < 1.0){
-
-            const pat::Jet & pruned_jet = pat_prunedjets[i_pat_prunedjet];
-            topjet.set_prunedmass(pruned_jet.mass());
-          }
         }
         /*---------------------*/
 

--- a/core/plugins/NtupleWriterJets.h
+++ b/core/plugins/NtupleWriterJets.h
@@ -34,7 +34,6 @@ private:
     edm::InputTag src;
     edm::EDGetToken src_token;
     edm::EDGetToken src_higgs_token;
-    edm::EDGetToken src_pruned_token;
     edm::EDGetToken src_softdrop_token;
     float ptmin, etamax;
     Event::Handle<std::vector<Jet>> handle; // main handle to write output to
@@ -64,7 +63,6 @@ public:
         std::string higgs_src;
         std::string higgs_name;
         std::string higgstaginfo_src;
-        std::string pruned_src;
         std::string softdrop_src;
         std::string toptagging_src;
         std::string ecf_beta1_src;
@@ -82,13 +80,13 @@ private:
     edm::InputTag src;
     float ptmin, etamax;
     bool do_btagging, do_btagging_subjets, do_taginfo_subjets, do_toptagging;
-    edm::EDGetToken src_token, src_higgs_token, src_pruned_token, src_softdrop_token, substructure_variables_src_token, substructure_variables_src_tokenreco, substructure_groomed_variables_src_token, substructure_groomed_variables_src_tokenreco;
+    edm::EDGetToken src_token, src_higgs_token, src_softdrop_token, substructure_variables_src_token, substructure_variables_src_tokenreco, substructure_groomed_variables_src_token, substructure_groomed_variables_src_tokenreco;
     edm::EDGetToken src_njettiness1_token, src_njettiness2_token, src_njettiness3_token, src_njettiness4_token, src_qjets_token;
     edm::EDGetToken src_njettiness1_groomed_token, src_njettiness2_groomed_token, src_njettiness3_groomed_token, src_njettiness4_groomed_token;
     edm::EDGetToken src_ecf_beta1_N2_token, src_ecf_beta1_N3_token, src_ecf_beta2_N2_token, src_ecf_beta2_N3_token;
     edm::EDGetToken src_hepTopTag_token;
     edm::EDGetToken src_higgstaginfo_token;
-    std::string njettiness_src, njettiness_groomed_src, qjets_src, ecf_beta1_src, ecf_beta2_src, subjet_src, higgs_src, higgs_name, higgstaginfo_src, pruned_src, softdrop_src, topjet_collection, topjet_puppiSpecificProducer;
+    std::string njettiness_src, njettiness_groomed_src, qjets_src, ecf_beta1_src, ecf_beta2_src, subjet_src, higgs_src, higgs_name, higgstaginfo_src, softdrop_src, topjet_collection, topjet_puppiSpecificProducer;
     Event::Handle<std::vector<TopJet>> handle;
     boost::optional<Event::Handle<std::vector<TopJet>>> topjets_handle;
     std::vector<TopJet::tag> id_tags;

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -378,46 +378,6 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
     # )
     # task.add(process.ca15CHSJetsSoftDropforsub)
 
-    #################################################
-    # Pruning
-
-    # Note low pt threshold as jets currently not stored but used just to
-    # derived pruned mass
-
-    ak4PFJetsPruned = ak4PFJets.clone(
-        SubJetParameters,
-        usePruning=cms.bool(True),
-        useExplicitGhosts=cms.bool(True),
-        writeCompound=cms.bool(True),
-        jetCollInstanceName=cms.string("SubJets")
-    )
-
-    process.ak8CHSJetsPruned = ak4PFJetsPruned.clone(
-        rParam=0.8,
-        doAreaFastjet=True,
-        src='chs',
-        jetPtMin=70
-    )
-    task.add(process.ak8CHSJetsPruned)
-
-    # process.ca8CHSJetsPruned = ak4PFJetsPruned.clone(
-    #     rParam=0.8,
-    #     jetAlgorithm="CambridgeAachen",
-    #     doAreaFastjet=True,
-    #     src='chs',
-    #     jetPtMin=fatjet_ptmin
-    # )
-    # task.add(process.ca8CHSJetsPruned)
-
-    # process.ca15CHSJetsPruned = ak4PFJetsPruned.clone(
-    #     rParam=1.5,
-    #     jetAlgorithm="CambridgeAachen",
-    #     doAreaFastjet=True,
-    #     src='chs',
-    #     jetPtMin=process.ca15CHSJets.jetPtMin
-    # )
-    # task.add(process.ca15CHSJetsPruned)
-
     ###############################################
     # PUPPI JETS
     process.load('CommonTools/PileupAlgos/Puppi_cff')
@@ -752,10 +712,6 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
 
     add_fatjets_subjets(process, 'ak8CHSJets', 'ak8CHSJetsSoftDrop',
                         genjets_name=lambda s: s.replace('CHS', 'Gen'))
-
-    # B-tagging not needed for pruned jets, they are just used to get the mass
-    add_fatjets_subjets(process, 'ak8CHSJets', 'ak8CHSJetsPruned',
-                        genjets_name=lambda s: s.replace('CHS', 'Gen'), btagging=False)
 
     add_fatjets_subjets(process, 'ak8PuppiJetsFat', 'ak8PuppiJetsSoftDrop',
                         genjets_name=lambda s: s.replace('Puppi', 'Gen'),
@@ -1423,14 +1379,6 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
                                                 "NjettinessAk8SoftDropPuppi"),
                                             substructure_groomed_variables_source = cms.string(
                                                 "ak8PuppiJetsSoftDropforsub"),
-                                            # Note: for slimmedJetsAK8 on miniAOD, the pruned mass is
-                                            # available as user float, with label ak8PFJetsCHSPrunedMass.
-                                            # Alternatively it is possible to specify another pruned jet collection
-                                            # (to be produced here), from which to get it by jet-matching.
-                                            # Finally, it is also possible to leave
-                                            # the pruned mass empty with ""
-                                            prunedmass_source=cms.string(
-                                                "ak8PFJetsCHSValueMap:ak8PFJetsCHSPrunedMass"),
                                             softdropmass_source=cms.string(
                                                 "ak8PFJetsPuppiSoftDropMass"),
                                             # switch off qjets for now, as it takes a long time:
@@ -1461,8 +1409,6 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
                                                 "NjettinessAk8SoftDropCHS"),
                                             substructure_groomed_variables_source=cms.string(
                                                 "ak8CHSJetsSoftDropforsub"),
-                                            prunedmass_source=cms.string(
-                                                "patJetsAk8CHSJetsPrunedPacked"),
                                             softdropmass_source=cms.string(
                                                 "patJetsAk8CHSJetsSoftDropPacked"),
                                             ecf_beta1_source=cms.string(


### PR DESCRIPTION
SoftDrop now the standard. Checked OK with Andreas, also OK with @rkogler ? Saves a reasonable amount of processing time since pruning for AK8CHS required running separate clustering etc