### PR TITLE
[102X] Add ECAL bad crystal filter bool

### DIFF
--- a/core/include/Event.h
+++ b/core/include/Event.h
@@ -24,6 +24,8 @@ public:
 
   bool isRealData;
 
+  bool passEcalBadCalib;
+
   float prefiringWeight;
   float prefiringWeightUp;
   float prefiringWeightDown;

--- a/core/include/EventHelper.h
+++ b/core/include/EventHelper.h
@@ -96,7 +96,7 @@ private:
     // handles:
     Event::Handle<int> h_run, h_lumi, h_event;
     Event::Handle<float> h_rho, h_bsx, h_bsy, h_bsz, h_prefire, h_prefireUp, h_prefireDown;
-    Event::Handle<bool> h_isRealData;
+    Event::Handle<bool> h_isRealData, h_passEcalBadCalib;
     Event::Handle<std::string> h_year;
 
     Event::Handle<std::vector<PrimaryVertex>> h_pvs;

--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -250,6 +250,7 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
   bool doTopJets = iConfig.getParameter<bool>("doTopJets");
 
   doTrigger = iConfig.getParameter<bool>("doTrigger");
+  doEcalBadCalib = iConfig.getParameter<bool>("doEcalBadCalib");
   doPrefire = iConfig.getParameter<bool>("doPrefire");
 
   doHOTVR = iConfig.getParameter<bool>("doHOTVR");
@@ -588,6 +589,12 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
       branch(tr, name, "std::vector<FlavorParticle>", &triggerObjects_out[j]);
     }
   }
+
+  branch(tr, "passEcalBadCalib", &event->passEcalBadCalib);
+  if(doEcalBadCalib) {
+    ecalBadCalibFilterUpdate_token = consumes<bool>(iConfig.getParameter<edm::InputTag>("ecalBadCalib_source"));
+  }
+
   branch(tr, "prefiringWeight", &event->prefiringWeight);
   branch(tr, "prefiringWeightUp", &event->prefiringWeightUp);
   branch(tr, "prefiringWeightDown", &event->prefiringWeightDown);
@@ -1282,6 +1289,12 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
          event->set_triggernames(triggerNames_outbranch);
      }
      newrun=false;
+   }
+
+   if (doEcalBadCalib) {
+     edm::Handle<bool> passEcalBadCalibFilterUpdate;
+     iEvent.getByToken(ecalBadCalibFilterUpdate_token, passEcalBadCalibFilterUpdate);
+     event->passEcalBadCalib = (*passEcalBadCalibFilterUpdate);
    }
 
    if (doPrefire) {

--- a/core/plugins/NtupleWriter.h
+++ b/core/plugins/NtupleWriter.h
@@ -65,6 +65,7 @@ class NtupleWriter : public edm::EDFilter {
       unsigned doGenJetConstituents;
       bool doPV;
       bool doTrigger;
+      bool doEcalBadCalib;
       bool doPrefire;
       bool runOnMiniAOD;
       bool doRho;
@@ -128,6 +129,8 @@ class NtupleWriter : public edm::EDFilter {
       
       std::vector<std::string> trigger_prefixes;
       std::vector<std::string> triggerNames_outbranch;
+
+      edm::EDGetTokenT<bool> ecalBadCalibFilterUpdate_token;
 
       edm::EDGetTokenT<double> prefweight_token;
       edm::EDGetTokenT<double> prefweightup_token;

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -1421,6 +1421,40 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
         )
         task.add(getattr(process, prefire_source))
 
+    # Deal with bad ECAL endcap crystals
+    # https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETOptionalFiltersRun2#How_to_run_ecal_BadCalibReducedM
+    bad_ecal = year in ['2017', '2018'] and useData
+    if bad_ecal:
+        process.load('RecoMET.METFilters.ecalBadCalibFilter_cfi')
+
+        baddetEcallist = cms.vuint32(
+            [872439604,872422825,872420274,872423218,
+             872423215,872416066,872435036,872439336,
+             872420273,872436907,872420147,872439731,
+             872436657,872420397,872439732,872439339,
+             872439603,872439861,872437051,
+             872437052,872420649,872422436,872421950,
+             872437185,872422564,872421566,872421695,
+             872421955,872421567,872437184,872421951,
+             872421694,872437056,872437057,872437313
+
+             # Are these supposed to be used as well?
+             # 872438182,872438951,872439990,872439864,
+             # 872439609,872437181,872437182,872437053,
+             # 872436794,872436667,872436536,872421541,
+             # 872421413,872421414,872421031,872423083,872421439
+             ])
+
+
+        process.ecalBadCalibReducedMINIAODFilter = cms.EDFilter("EcalBadCalibFilter",
+            EcalRecHitSource = cms.InputTag("reducedEgamma:reducedEERecHits"),
+            ecalMinEt = cms.double(50.),
+            baddetEcal = baddetEcallist,
+            taggingMode = cms.bool(True),
+            debug = cms.bool(False)
+        )
+        task.add(process.ecalBadCalibReducedMINIAODFilter)
+
 
     # NtupleWriter
 
@@ -1745,6 +1779,9 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
                                     #),
                                     trigger_objects=cms.InputTag("selectedPatTrigger" if year == "2016v2" else "slimmedPatTrigger"),
 
+                                    doEcalBadCalib=cms.bool(bad_ecal),
+                                    ecalBadCalib_source=cms.InputTag("ecalBadCalibReducedMINIAODFilter"),
+
                                     doPrefire=cms.bool(do_prefire),
                                     prefire_source=cms.string(prefire_source),
 
@@ -1838,6 +1875,9 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
     )
     if do_prefire:
         process.p.insert(0, process.prefiringweight)
+
+    if bad_ecal:
+        process.p.insert(0, process.ecalBadCalibReducedMINIAODFilter)
 
     if year == "2016v2" and (not useData):
         process.load("PhysicsTools.JetMCAlgos.HadronAndPartonSelector_cfi")

--- a/core/src/Event.cxx
+++ b/core/src/Event.cxx
@@ -9,6 +9,7 @@ void Event::clear(){
     run = luminosityBlock = event = -1;
     year = "";
     rho = beamspot_x0 = beamspot_y0 = beamspot_z0 = NAN;
+    passEcalBadCalib = true;
     prefiringWeight = prefiringWeightUp = prefiringWeightDown = 1.;
     electrons = 0;
     muons = 0;

--- a/core/src/EventHelper.cxx
+++ b/core/src/EventHelper.cxx
@@ -25,6 +25,7 @@ EventHelper::EventHelper(uhh2::Context & ctx_): ctx(ctx_), event(0), pvs(false),
     h_event = declare_in_out<int>("event", "event", ctx);
     h_rho = declare_in_out<float>("rho", "rho", ctx);
     h_isRealData = declare_in_out<bool>("isRealData", "isRealData", ctx);
+    h_passEcalBadCalib = declare_in_out<bool>("passEcalBadCalib", "passEcalBadCalib", ctx);
     h_year = declare_in_out<std::string>("year", "year", ctx);
     h_bsx = declare_in_out<float>("beamspot_x0", "beamspot_x0", ctx);
     h_bsy = declare_in_out<float>("beamspot_y0", "beamspot_y0", ctx);
@@ -87,6 +88,7 @@ void EventHelper::event_read(){
     event->event = event->get(h_event);
     event->rho = event->get(h_rho);
     event->isRealData = event->get(h_isRealData);
+    event->passEcalBadCalib = event->get(h_passEcalBadCalib);
     event->year = event->get(h_year);
     event->beamspot_x0 = event->get(h_bsx);
     event->beamspot_y0 = event->get(h_bsy);
@@ -152,6 +154,7 @@ void EventHelper::event_write(){
     event->set(h_event, event->event);
     event->set(h_rho, event->rho);
     event->set(h_isRealData, event->isRealData);
+    event->set(h_passEcalBadCalib, event->passEcalBadCalib);
     event->set(h_year, event->year);
     event->set(h_bsx, event->beamspot_x0);
     event->set(h_bsy, event->beamspot_y0);


### PR DESCRIPTION
Store a bool. `True` if no bad crystals over the threshold.
As per https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETOptionalFiltersRun2#How_to_run_ecal_BadCalibReducedM it is only run for 2017,8 data
Unsure exactly which list of DetIDs to use as there are 2 in the twiki page, TBC later.