### PR TITLE
[102X] Recluster AK8PUPPI for TopJets ourselves

### DIFF
--- a/core/plugins/NtupleWriterJets.cxx
+++ b/core/plugins/NtupleWriterJets.cxx
@@ -42,15 +42,8 @@ float getPatJetUserFloat(const pat::Jet & jet, const std::string & key, float de
 
 // Generate the name of the puppiJetSpecificProducer module
 // So ugly, really should get the user to configure this in the NtupleWriter py
-std::string getPuppiJetSpecificProducer(const std::string & name){
+std::string getPuppiJetSpecificProducer(const std::string & name) {
   std::string multiplicity_name = "patPuppiJetSpecificProducer"+name;
-  if(multiplicity_name == "patPuppiJetSpecificProducerselectedUpdatedPatJetsSlimmedJetsPuppiNewDFTraining"){
-    multiplicity_name = "patPuppiJetSpecificProducerupdatedPatJetsTransientCorrectedSlimmedJetsPuppiNewDFTraining";
-  }else if(multiplicity_name == "patPuppiJetSpecificProducerselectedUpdatedPatJetsPatJetsAK8PFPUPPINewDFTraining"){
-   multiplicity_name = "patPuppiJetSpecificProducerupdatedPatJetsTransientCorrectedPatJetsAK8PFPUPPINewDFTraining";
-  }else if("selectedUpdatedPatJetsSlimmedJetsAK8NewDFTraining"){
-    multiplicity_name = "patPuppiJetSpecificProducerupdatedPatJetsTransientCorrectedSlimmedJetsAK8NewDFTraining";
-  }
   return multiplicity_name;
 }
 

--- a/core/plugins/NtupleWriterJets.cxx
+++ b/core/plugins/NtupleWriterJets.cxx
@@ -222,7 +222,7 @@ void NtupleWriterJets::fill_jet_info(const pat::Jet & pat_jet, Jet & jet, bool d
     jetbtaginfo.set_TrackDecayLenVal(tvlIP.getList(reco::btau::trackDecayLenVal,false));
     jetbtaginfo.set_TrackChi2(tvlIP.getList(reco::btau::trackChi2,false));
     jetbtaginfo.set_TrackNTotalHits(tvlIP.getList(reco::btau::trackNTotalHits,false));
-    jetbtaginfo.set_TrackNPixelHits(tvlIP.getList(reco::btau::trackNPixelHits,false));     
+    jetbtaginfo.set_TrackNPixelHits(tvlIP.getList(reco::btau::trackNPixelHits,false));
     jetbtaginfo.set_TrackPtRel(tvlIP.getList(reco::btau::trackPtRel,false));
     jetbtaginfo.set_TrackPPar(tvlIP.getList(reco::btau::trackPPar,false));
     jetbtaginfo.set_TrackPtRatio(tvlIP.getList(reco::btau::trackPtRatio,false));
@@ -250,9 +250,9 @@ void NtupleWriterJets::fill_jet_info(const pat::Jet & pat_jet, Jet & jet, bool d
       sizetracks.push_back(sv.numberOfSourceCandidatePtrs());
       ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> > p4 = sv.p4();
       vp4.push_back(TLorentzVector(p4.px(),p4.py(),p4.pz(),p4.e()));
-      vchi2.push_back(sv.vertexChi2());  
-      vndof.push_back(sv.vertexNdof());  
-      vchi2ndof.push_back(sv.vertexNormalizedChi2());  
+      vchi2.push_back(sv.vertexChi2());
+      vndof.push_back(sv.vertexNdof());
+      vchi2ndof.push_back(sv.vertexNormalizedChi2());
     }
     jetbtaginfo.set_SecondaryVertex(vp4);
     jetbtaginfo.set_VertexChi2(vchi2);
@@ -269,7 +269,7 @@ void NtupleWriterJets::fill_jet_info(const pat::Jet & pat_jet, Jet & jet, bool d
       {
       std::vector<const reco::BaseTagInfo*>  baseTagInfos;
       baseTagInfos.push_back(pat_jet.tagInfoTrackIP("pfImpactParameter") );
-      baseTagInfos.push_back(pat_jet.tagInfoSecondaryVertex("pfInclusiveSecondaryVertexFinder") );      
+      baseTagInfos.push_back(pat_jet.tagInfoSecondaryVertex("pfInclusiveSecondaryVertexFinder") );
       JetTagComputer::TagInfoHelper helper(baseTagInfos);
       reco::TaggingVariableList vars = computer->taggingVariables(helper);
       jetbtaginfo.set_VertexMassJTC(vars.get(reco::btau::vertexMass,-9999));
@@ -287,234 +287,254 @@ void NtupleWriterJets::fill_jet_info(const pat::Jet & pat_jet, Jet & jet, bool d
       const auto & name = name_value.first;
       const auto & value = name_value.second;
       if(name == "pfCombinedInclusiveSecondaryVertexV2BJetTags"){
-	jet.set_btag_combinedSecondaryVertex(value);
-	csv = true;
+        jet.set_btag_combinedSecondaryVertex(value);
+        csv = true;
       }
-      else if(name == "pfCombinedMVAV2BJetTags"){                                                                                                            
-        jet.set_btag_combinedSecondaryVertexMVA(value);                                                                                                                              
-        csvmva = true;                                                                                                                                                               
-      }   
-      else if(name == "pfDeepCSVJetTags:probb"){                                                                                                            
-        jet.set_btag_DeepCSV_probb(value);                                                                                                                              
-        deepcsv_b = true;                                                                                                                                                               
-      }   
-      else if(name == "pfDeepCSVJetTags:probbb"){                                                                                                            
-        jet.set_btag_DeepCSV_probbb(value);                                                                                                                              
-        deepcsv_bb = true;                                                                                                                                                               
-      }   
+      else if(name == "pfCombinedMVAV2BJetTags"){
+        jet.set_btag_combinedSecondaryVertexMVA(value);
+        csvmva = true;
+      }
+      else if(name == "pfDeepCSVJetTags:probb"){
+        jet.set_btag_DeepCSV_probb(value);
+        deepcsv_b = true;
+      }
+      else if(name == "pfDeepCSVJetTags:probbb"){
+        jet.set_btag_DeepCSV_probbb(value);
+        deepcsv_bb = true;
+      }
       else if(name == "pfBoostedDoubleSecondaryVertexAK8BJetTags"){
-	jet.set_btag_BoostedDoubleSecondaryVertexAK8(value);
-	doubleak8 = true;
+        jet.set_btag_BoostedDoubleSecondaryVertexAK8(value);
+        doubleak8 = true;
       }
       else if(name == "pfBoostedDoubleSecondaryVertexCA15BJetTags"){
-	jet.set_btag_BoostedDoubleSecondaryVertexCA15(value);
-	doubleca15 = true;
+        jet.set_btag_BoostedDoubleSecondaryVertexCA15(value);
+        doubleca15 = true;
       }
       else if(name=="pfDeepFlavourJetTags:probbb"){
-      	jet.set_btag_DeepFlavour_probbb(value);
-      	deepflavour_bb =true;
+        jet.set_btag_DeepFlavour_probbb(value);
+        deepflavour_bb =true;
       }
       else if(name=="pfDeepFlavourJetTags:probb"){
-      	jet.set_btag_DeepFlavour_probb(value);
-      	deepflavour_b =true;
+        jet.set_btag_DeepFlavour_probb(value);
+        deepflavour_b =true;
       }
       else if(name=="pfDeepFlavourJetTags:problepb"){
-      	jet.set_btag_DeepFlavour_problepb(value);
-      	deepflavour_lepb =true;
+        jet.set_btag_DeepFlavour_problepb(value);
+        deepflavour_lepb =true;
       }
       else if(name=="pfDeepFlavourJetTags:probc"){
-      	jet.set_btag_DeepFlavour_probc(value);
-      	deepflavour_c =true;
+        jet.set_btag_DeepFlavour_probc(value);
+        deepflavour_c =true;
       }
       else if(name=="pfDeepFlavourJetTags:probuds"){
-      	jet.set_btag_DeepFlavour_probuds(value);
-      	deepflavour_uds =true;
+        jet.set_btag_DeepFlavour_probuds(value);
+        deepflavour_uds =true;
       }
       else if(name=="pfDeepFlavourJetTags:probg"){
-      	jet.set_btag_DeepFlavour_probg(value);
-      	deepflavour_g =true;
+        jet.set_btag_DeepFlavour_probg(value);
+        deepflavour_g =true;
       }
       else if(name == "pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:bbvsLight"){
-	jet.set_btag_MassDecorrelatedDeepBoosted_bbvsLight(value);
-	decorrmass_deepboosted_bbvsLight=true;
+        jet.set_btag_MassDecorrelatedDeepBoosted_bbvsLight(value);
+        decorrmass_deepboosted_bbvsLight=true;
       }
       else if(name == "pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:ccvsLight"){
-	jet.set_btag_MassDecorrelatedDeepBoosted_ccvsLight(value);
-	decorrmass_deepboosted_ccvsLight=true;
+        jet.set_btag_MassDecorrelatedDeepBoosted_ccvsLight(value);
+        decorrmass_deepboosted_ccvsLight=true;
       }
       else if(name == "pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:TvsQCD"){
-	jet.set_btag_MassDecorrelatedDeepBoosted_TvsQCD(value);
-	decorrmass_deepboosted_TvsQCD=true;
+        jet.set_btag_MassDecorrelatedDeepBoosted_TvsQCD(value);
+        decorrmass_deepboosted_TvsQCD=true;
       }
       else if(name == "pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:ZHccvsQCD"){
-	jet.set_btag_MassDecorrelatedDeepBoosted_ZHccvsQCD(value);
-	decorrmass_deepboosted_ZHccvsQCD=true;
+        jet.set_btag_MassDecorrelatedDeepBoosted_ZHccvsQCD(value);
+        decorrmass_deepboosted_ZHccvsQCD=true;
       }
       else if(name == "pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:WvsQCD"){
-	jet.set_btag_MassDecorrelatedDeepBoosted_WvsQCD(value);
-	decorrmass_deepboosted_WvsQCD=true;
+        jet.set_btag_MassDecorrelatedDeepBoosted_WvsQCD(value);
+        decorrmass_deepboosted_WvsQCD=true;
       }
       else if(name == "pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:ZHbbvsQCD"){
-	jet.set_btag_MassDecorrelatedDeepBoosted_ZHbbvsQCD(value);
-	decorrmass_deepboosted_ZHbbvsQCD=true;
+        jet.set_btag_MassDecorrelatedDeepBoosted_ZHbbvsQCD(value);
+        decorrmass_deepboosted_ZHbbvsQCD=true;
       }
       else if(name == "pfMassDecorrelatedDeepBoostedJetTags:probHbb"){
-	jet.set_btag_MassDecorrelatedDeepBoosted_probHbb(value);
-	decorrmass_deepboosted_probHbb=true;
+        jet.set_btag_MassDecorrelatedDeepBoosted_probHbb(value);
+        decorrmass_deepboosted_probHbb=true;
       }
       else if(name == "pfMassDecorrelatedDeepBoostedJetTags:probQCD"){
-	jet.set_btag_MassDecorrelatedDeepBoosted_probQCD(value);
-	decorrmass_deepboosted_probQCDc=true;
+        jet.set_btag_MassDecorrelatedDeepBoosted_probQCD(value);
+        decorrmass_deepboosted_probQCDc=true;
       }
       else if(name == "pfMassDecorrelatedDeepBoostedJetTags:probQCDbb"){
-	jet.set_btag_MassDecorrelatedDeepBoosted_probQCDbb(value);
-	decorrmass_deepboosted_probQCDbb=true;
+        jet.set_btag_MassDecorrelatedDeepBoosted_probQCDbb(value);
+        decorrmass_deepboosted_probQCDbb=true;
       }
       else if(name == "pfMassDecorrelatedDeepBoostedJetTags:probTbqq"){
-	jet.set_btag_MassDecorrelatedDeepBoosted_probTbqq(value);
-	decorrmass_deepboosted_probTbqq=true;
+        jet.set_btag_MassDecorrelatedDeepBoosted_probTbqq(value);
+        decorrmass_deepboosted_probTbqq=true;
       }
       else if(name == "pfMassDecorrelatedDeepBoostedJetTags:probTbcq"){
-	jet.set_btag_MassDecorrelatedDeepBoosted_probTbcq(value);
-	decorrmass_deepboosted_probTbcq=true;
+        jet.set_btag_MassDecorrelatedDeepBoosted_probTbcq(value);
+        decorrmass_deepboosted_probTbcq=true;
       }
       else if(name == "pfMassDecorrelatedDeepBoostedJetTags:probTbq"){
-	jet.set_btag_MassDecorrelatedDeepBoosted_probTbq(value);
-	decorrmass_deepboosted_probTbq=true;
+        jet.set_btag_MassDecorrelatedDeepBoosted_probTbq(value);
+        decorrmass_deepboosted_probTbq=true;
       }
       else if(name == "pfMassDecorrelatedDeepBoostedJetTags:probQCDothers"){
-	jet.set_btag_MassDecorrelatedDeepBoosted_probQCDothers(value);
-	decorrmass_deepboosted_probQCDothers=true;
+        jet.set_btag_MassDecorrelatedDeepBoosted_probQCDothers(value);
+        decorrmass_deepboosted_probQCDothers=true;
       }
       else if(name == "pfMassDecorrelatedDeepBoostedJetTags:probQCDb"){
-	jet.set_btag_MassDecorrelatedDeepBoosted_probQCDb(value);
-	decorrmass_deepboosted_probQCDb=true;
+        jet.set_btag_MassDecorrelatedDeepBoosted_probQCDb(value);
+        decorrmass_deepboosted_probQCDb=true;
       }
       else if(name == "pfMassDecorrelatedDeepBoostedJetTags:probTbc"){
-	jet.set_btag_MassDecorrelatedDeepBoosted_probTbc(value);
-	decorrmass_deepboosted_probTbc=true;
+        jet.set_btag_MassDecorrelatedDeepBoosted_probTbc(value);
+        decorrmass_deepboosted_probTbc=true;
       }
       else if(name == "pfMassDecorrelatedDeepBoostedJetTags:probWqq"){
-	jet.set_btag_MassDecorrelatedDeepBoosted_probWqq(value);
-	decorrmass_deepboosted_probWqq=true;
+        jet.set_btag_MassDecorrelatedDeepBoosted_probWqq(value);
+        decorrmass_deepboosted_probWqq=true;
       }
       else if(name == "pfMassDecorrelatedDeepBoostedJetTags:probQCDcc"){
-	jet.set_btag_MassDecorrelatedDeepBoosted_probQCDcc(value);
-	decorrmass_deepboosted_probQCDcc=true;
+        jet.set_btag_MassDecorrelatedDeepBoosted_probQCDcc(value);
+        decorrmass_deepboosted_probQCDcc=true;
       }
       else if(name == "pfMassDecorrelatedDeepBoostedJetTags:probHbb"){
-	jet.set_btag_MassDecorrelatedDeepBoosted_probHbb(value);
-	decorrmass_deepboosted_probHbb=true;
+        jet.set_btag_MassDecorrelatedDeepBoosted_probHbb(value);
+        decorrmass_deepboosted_probHbb=true;
       }
       else if(name == "pfMassDecorrelatedDeepBoostedJetTags:probHcc"){
-	jet.set_btag_MassDecorrelatedDeepBoosted_probHcc(value);
-	decorrmass_deepboosted_probHcc=true;
+        jet.set_btag_MassDecorrelatedDeepBoosted_probHcc(value);
+        decorrmass_deepboosted_probHcc=true;
       }
       else if(name == "pfMassDecorrelatedDeepBoostedJetTags:probWcq"){
-	jet.set_btag_MassDecorrelatedDeepBoosted_probWcq(value);
-	decorrmass_deepboosted_probWcq=true;
+        jet.set_btag_MassDecorrelatedDeepBoosted_probWcq(value);
+        decorrmass_deepboosted_probWcq=true;
       }
       else if(name == "pfMassDecorrelatedDeepBoostedJetTags:probZcc"){
-	jet.set_btag_MassDecorrelatedDeepBoosted_probZcc(value);
-	decorrmass_deepboosted_probZcc=true;
+        jet.set_btag_MassDecorrelatedDeepBoosted_probZcc(value);
+        decorrmass_deepboosted_probZcc=true;
       }
       else if(name == "pfMassDecorrelatedDeepBoostedJetTags:probZqq"){
-	jet.set_btag_MassDecorrelatedDeepBoosted_probZqq(value);
-	decorrmass_deepboosted_probZqq=true;
+        jet.set_btag_MassDecorrelatedDeepBoosted_probZqq(value);
+        decorrmass_deepboosted_probZqq=true;
       }
       else if(name == "pfMassDecorrelatedDeepBoostedJetTags:probHqqqq"){
-	jet.set_btag_MassDecorrelatedDeepBoosted_probHqqqq(value);
-	decorrmass_deepboosted_probHqqqq=true;
+        jet.set_btag_MassDecorrelatedDeepBoosted_probHqqqq(value);
+        decorrmass_deepboosted_probHqqqq=true;
       }
       else if(name == "pfMassDecorrelatedDeepBoostedJetTags:probZbb"){
-	jet.set_btag_MassDecorrelatedDeepBoosted_probZbb(value);
-	decorrmass_deepboosted_probZbb=true;
+        jet.set_btag_MassDecorrelatedDeepBoosted_probZbb(value);
+        decorrmass_deepboosted_probZbb=true;
       }
       else if(name=="pfDeepDoubleBJetTags:probH"){
-	jet.set_btag_DeepDoubleB_probH(value);
-	deepdouble_H = true;
+        jet.set_btag_DeepDoubleB_probH(value);
+        deepdouble_H = true;
       }
       else if(name=="pfDeepDoubleBJetTags:probQCD"){
-	jet.set_btag_DeepDoubleB_probQCD(value);
-	deepdouble_QCD = true;
+        jet.set_btag_DeepDoubleB_probQCD(value);
+        deepdouble_QCD = true;
       }
       else if(name == "pfDeepBoostedJetTags:probHbb"){
-	jet.set_btag_DeepBoosted_probHbb(value);
-	deepboosted_probHbb=true;
+        jet.set_btag_DeepBoosted_probHbb(value);
+        deepboosted_probHbb=true;
       }
       else if(name == "pfDeepBoostedJetTags:probQCD"){
-	jet.set_btag_DeepBoosted_probQCD(value);
-	deepboosted_probQCDc=true;
+        jet.set_btag_DeepBoosted_probQCD(value);
+        deepboosted_probQCDc=true;
       }
       else if(name == "pfDeepBoostedJetTags:probQCDbb"){
-	jet.set_btag_DeepBoosted_probQCDbb(value);
-	deepboosted_probQCDbb=true;
+        jet.set_btag_DeepBoosted_probQCDbb(value);
+        deepboosted_probQCDbb=true;
       }
       else if(name == "pfDeepBoostedJetTags:probTbqq"){
-	jet.set_btag_DeepBoosted_probTbqq(value);
-	deepboosted_probTbqq=true;
+        jet.set_btag_DeepBoosted_probTbqq(value);
+        deepboosted_probTbqq=true;
       }
       else if(name == "pfDeepBoostedJetTags:probTbcq"){
-	jet.set_btag_DeepBoosted_probTbcq(value);
-	deepboosted_probTbcq=true;
+        jet.set_btag_DeepBoosted_probTbcq(value);
+        deepboosted_probTbcq=true;
       }
       else if(name == "pfDeepBoostedJetTags:probTbq"){
-	jet.set_btag_DeepBoosted_probTbq(value);
-	deepboosted_probTbq=true;
+        jet.set_btag_DeepBoosted_probTbq(value);
+        deepboosted_probTbq=true;
       }
       else if(name == "pfDeepBoostedJetTags:probQCDothers"){
-	jet.set_btag_DeepBoosted_probQCDothers(value);
-	deepboosted_probQCDothers=true;
+        jet.set_btag_DeepBoosted_probQCDothers(value);
+        deepboosted_probQCDothers=true;
       }
       else if(name == "pfDeepBoostedJetTags:probQCDb"){
-	jet.set_btag_DeepBoosted_probQCDb(value);
-	deepboosted_probQCDb=true;
+        jet.set_btag_DeepBoosted_probQCDb(value);
+        deepboosted_probQCDb=true;
       }
       else if(name == "pfDeepBoostedJetTags:probTbc"){
-	jet.set_btag_DeepBoosted_probTbc(value);
-	deepboosted_probTbc=true;
+        jet.set_btag_DeepBoosted_probTbc(value);
+        deepboosted_probTbc=true;
       }
       else if(name == "pfDeepBoostedJetTags:probWqq"){
-	jet.set_btag_DeepBoosted_probWqq(value);
-	deepboosted_probWqq=true;
+        jet.set_btag_DeepBoosted_probWqq(value);
+        deepboosted_probWqq=true;
       }
       else if(name == "pfDeepBoostedJetTags:probQCDcc"){
-	jet.set_btag_DeepBoosted_probQCDcc(value);
-	deepboosted_probQCDcc=true;
+        jet.set_btag_DeepBoosted_probQCDcc(value);
+        deepboosted_probQCDcc=true;
       }
       else if(name == "pfDeepBoostedJetTags:probHbb"){
-	jet.set_btag_DeepBoosted_probHbb(value);
-	deepboosted_probHbb=true;
+        jet.set_btag_DeepBoosted_probHbb(value);
+        deepboosted_probHbb=true;
       }
       else if(name == "pfDeepBoostedJetTags:probHcc"){
-	jet.set_btag_DeepBoosted_probHcc(value);
-	deepboosted_probHcc=true;
+        jet.set_btag_DeepBoosted_probHcc(value);
+        deepboosted_probHcc=true;
       }
       else if(name == "pfDeepBoostedJetTags:probWcq"){
-	jet.set_btag_DeepBoosted_probWcq(value);
-	deepboosted_probWcq=true;
+        jet.set_btag_DeepBoosted_probWcq(value);
+        deepboosted_probWcq=true;
       }
       else if(name == "pfDeepBoostedJetTags:probZcc"){
-	jet.set_btag_DeepBoosted_probZcc(value);
-	deepboosted_probZcc=true;
+        jet.set_btag_DeepBoosted_probZcc(value);
+        deepboosted_probZcc=true;
       }
       else if(name == "pfDeepBoostedJetTags:probZqq"){
-	jet.set_btag_DeepBoosted_probZqq(value);
-	deepboosted_probZqq=true;
+        jet.set_btag_DeepBoosted_probZqq(value);
+        deepboosted_probZqq=true;
       }
       else if(name == "pfDeepBoostedJetTags:probHqqqq"){
-	jet.set_btag_DeepBoosted_probHqqqq(value);
-	deepboosted_probHqqqq=true;
+        jet.set_btag_DeepBoosted_probHqqqq(value);
+        deepboosted_probHqqqq=true;
       }
       else if(name == "pfDeepBoostedJetTags:probZbb"){
-	jet.set_btag_DeepBoosted_probZbb(value);
-	deepboosted_probZbb=true;
+        jet.set_btag_DeepBoosted_probZbb(value);
+        deepboosted_probZbb=true;
       }
 
     }
 
 
-       if(!csv || !csvmva || !doubleak8 || !doubleca15 || !deepcsv_b || !deepcsv_bb || !deepflavour_bb || !deepflavour_b || !deepflavour_lepb || !deepflavour_uds || !deepflavour_c || !deepflavour_g || !decorrmass_deepboosted_bbvsLight || !decorrmass_deepboosted_ccvsLight || !decorrmass_deepboosted_TvsQCD || !decorrmass_deepboosted_ZHccvsQCD || !decorrmass_deepboosted_WvsQCD || !decorrmass_deepboosted_ZHbbvsQCD || !deepboosted_probHbb || !deepboosted_probQCDbb|| !deepboosted_probQCDc|| !deepboosted_probTbqq|| !deepboosted_probTbcq|| !deepboosted_probTbq|| !deepboosted_probQCDothers|| !deepboosted_probQCDb|| !deepboosted_probTbc|| !deepboosted_probWqq|| !deepboosted_probQCDcc|| !deepboosted_probHcc|| !deepboosted_probWcq|| !deepboosted_probZcc|| !deepboosted_probZqq|| !deepboosted_probHqqqq|| !deepboosted_probZbb|| !deepdouble_H|| !deepdouble_QCD|| !decorrmass_deepboosted_probHbb || !decorrmass_deepboosted_probQCDbb|| !decorrmass_deepboosted_probQCDc|| !decorrmass_deepboosted_probTbqq|| !decorrmass_deepboosted_probTbcq|| !decorrmass_deepboosted_probTbq|| !decorrmass_deepboosted_probQCDothers|| !decorrmass_deepboosted_probQCDb|| !decorrmass_deepboosted_probTbc|| !decorrmass_deepboosted_probWqq|| !decorrmass_deepboosted_probQCDcc|| !decorrmass_deepboosted_probHcc|| !decorrmass_deepboosted_probWcq|| !decorrmass_deepboosted_probZcc|| !decorrmass_deepboosted_probZqq|| !decorrmass_deepboosted_probHqqqq|| !decorrmass_deepboosted_probZbb){
+    if(!csv || !csvmva || !doubleak8 || !doubleca15 || !deepcsv_b || !deepcsv_bb
+       || !deepflavour_bb || !deepflavour_b || !deepflavour_lepb
+       || !deepflavour_uds || !deepflavour_c || !deepflavour_g
+       || !decorrmass_deepboosted_bbvsLight || !decorrmass_deepboosted_ccvsLight
+       || !decorrmass_deepboosted_TvsQCD || !decorrmass_deepboosted_ZHccvsQCD
+       || !decorrmass_deepboosted_WvsQCD || !decorrmass_deepboosted_ZHbbvsQCD
+       || !deepboosted_probHbb || !deepboosted_probQCDbb || !deepboosted_probQCDc
+       || !deepboosted_probTbqq || !deepboosted_probTbcq || !deepboosted_probTbq
+       || !deepboosted_probQCDothers || !deepboosted_probQCDb || !deepboosted_probTbc
+       || !deepboosted_probWqq || !deepboosted_probQCDcc || !deepboosted_probHcc
+       || !deepboosted_probWcq || !deepboosted_probZcc || !deepboosted_probZqq
+       || !deepboosted_probHqqqq || !deepboosted_probZbb || !deepdouble_H
+       || !deepdouble_QCD || !decorrmass_deepboosted_probHbb || !decorrmass_deepboosted_probQCDbb
+       || !decorrmass_deepboosted_probQCDc || !decorrmass_deepboosted_probTbqq
+       || !decorrmass_deepboosted_probTbcq || !decorrmass_deepboosted_probTbq
+       || !decorrmass_deepboosted_probQCDothers || !decorrmass_deepboosted_probQCDb
+       || !decorrmass_deepboosted_probTbc || !decorrmass_deepboosted_probWqq
+       || !decorrmass_deepboosted_probQCDcc || !decorrmass_deepboosted_probHcc
+       || !decorrmass_deepboosted_probWcq || !decorrmass_deepboosted_probZcc
+       || !decorrmass_deepboosted_probZqq || !decorrmass_deepboosted_probHqqqq
+       || !decorrmass_deepboosted_probZbb){
       if(btag_warning){
         std::string btag_list = "";
         for(const auto & name_value : bdisc){
@@ -536,13 +556,13 @@ NtupleWriterTopJets::NtupleWriterTopJets(Config & cfg, bool set_jets_member): pt
         topjets_handle = cfg.ctx.get_handle<vector<TopJet>>("topjets");
     }
     src_token = cfg.cc.consumes<std::vector<pat::Jet>>(cfg.src);
-    njettiness_src = cfg.njettiness_src;    
+    njettiness_src = cfg.njettiness_src;
     src_njettiness1_token = cfg.cc.consumes<edm::ValueMap<float> >(edm::InputTag(njettiness_src, "tau1"));
     src_njettiness2_token = cfg.cc.consumes<edm::ValueMap<float> >(edm::InputTag(njettiness_src, "tau2"));
     src_njettiness3_token = cfg.cc.consumes<edm::ValueMap<float> >(edm::InputTag(njettiness_src, "tau3"));
     src_njettiness4_token = cfg.cc.consumes<edm::ValueMap<float> >(edm::InputTag(njettiness_src, "tau4"));
 
-    njettiness_groomed_src = cfg.njettiness_groomed_src;    
+    njettiness_groomed_src = cfg.njettiness_groomed_src;
     src_njettiness1_groomed_token = cfg.cc.consumes<edm::ValueMap<float> >(edm::InputTag(njettiness_groomed_src, "tau1"));
     src_njettiness2_groomed_token = cfg.cc.consumes<edm::ValueMap<float> >(edm::InputTag(njettiness_groomed_src, "tau2"));
     src_njettiness3_groomed_token = cfg.cc.consumes<edm::ValueMap<float> >(edm::InputTag(njettiness_groomed_src, "tau3"));
@@ -633,7 +653,7 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
 
     edm::Handle<reco::BasicJetCollection> topjets_groomed_with_cands;
     edm::Handle<reco::PFJetCollection> topjets_groomed_with_cands_reco;
-    
+
     if(!njettiness_src.empty()){
         event.getByToken(src_njettiness1_token, h_njettiness1);
         event.getByToken(src_njettiness2_token, h_njettiness2);
@@ -716,46 +736,16 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
 
     for (unsigned int i = 0; i < pat_topjets.size(); i++) {
         const pat::Jet & pat_topjet =  pat_topjets[i];
-        //use CHS jet momentum in case of CHS subjet collection (see https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016#Jets)
-        // if(subjet_src.find("CHS")!=string::npos){
-        //   TLorentzVector puppi_v4;
-        //   if (!pat_topjet.hasUserFloat("ak8PFJetsCHSValueMap:pt")) {
-        //     throw cms::Exception("Missing userFloat", "You wanted CHS subjets but no ak8PFJetsCHSValueMap entries in the ValueMap");
-        //   }
-        //   puppi_v4.SetPtEtaPhiM(pat_topjet.userFloat("ak8PFJetsCHSValueMap:pt"),
-        //     pat_topjet.userFloat("ak8PFJetsCHSValueMap:eta"),
-        //     pat_topjet.userFloat("ak8PFJetsCHSValueMap:phi"),
-        //     pat_topjet.userFloat("ak8PFJetsCHSValueMap:mass"));
-        //   //skip jets with incredibly high pT (99999 seems to be a default value in MINIAOD if the puppi jet is not defined)
-        //   if(puppi_v4.Pt()>=99999) continue;
-        //   if(puppi_v4.Pt() < ptmin) continue;
-        //   if(fabs(puppi_v4.Eta()) > etamax) continue;
-        // }
-        // else{
-          if(pat_topjet.pt() < ptmin) continue;
-          if(fabs(pat_topjet.eta()) > etamax) continue;
-        // }
-        
+        if(pat_topjet.pt() < ptmin) continue;
+        if(fabs(pat_topjet.eta()) > etamax) continue;
+
         topjets.emplace_back();
         TopJet & topjet = topjets.back();
         try{
           uhh2::NtupleWriterJets::fill_jet_info(pat_topjet, topjet, do_btagging, false, topjet_puppiSpecificProducer);
-          // if(subjet_src.find("CHS")!=string::npos){
-          //   TLorentzVector puppi_v4;
-          //   puppi_v4.SetPtEtaPhiM(pat_topjet.userFloat("ak8PFJetsCHSValueMap:pt"),
-          //                         pat_topjet.userFloat("ak8PFJetsCHSValueMap:eta"),
-          //                         pat_topjet.userFloat("ak8PFJetsCHSValueMap:phi"),
-          //                         pat_topjet.userFloat("ak8PFJetsCHSValueMap:mass"));
-          //   topjet.set_pt(puppi_v4.Pt());
-          //   topjet.set_eta(puppi_v4.Eta());
-          //   topjet.set_phi(puppi_v4.Phi());
-          //   topjet.set_energy(puppi_v4.E());
-          // }
-
         }catch(runtime_error &){
           throw cms::Exception("fill_jet_info error", "Error in fill_jet_info for topjets in NtupleWriterTopJets with src = " + src.label());
         }
-
 
         /*--- lepton keys ---*/
         if(save_lepton_keys_){
@@ -792,7 +782,7 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
                 drmin = dr;
               }
             }
-          }         
+          }
           else{
             for (size_t i_wc=0; i_wc < topjets_with_cands->size(); ++i_wc) {
               auto dr = reco::deltaR((*topjets_with_cands)[i_wc], pat_topjet);
@@ -841,7 +831,7 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
                 drmin = dr;
               }
             }
-          }         
+          }
           else{
             for (size_t i_wc=0; i_wc < topjets_groomed_with_cands->size(); ++i_wc) {
               auto dr = reco::deltaR((*topjets_groomed_with_cands)[i_wc], pat_topjet);
@@ -986,11 +976,11 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
         /*--- Higgs tagging ---*/
 
 	if(higgs_src!=""){
-	  
+
 	  edm::Handle<pat::JetCollection> higgs_pat_topjets;
 	  event.getByToken(src_higgs_token, higgs_pat_topjets);
 	  const vector<pat::Jet> & pat_higgsjets = *higgs_pat_topjets;
-	  
+
 	  //match a jet from "higgs" collection
 	  int i_pat_higgsjet = -1;
 	  double drmin = numeric_limits<double>::infinity();
@@ -1003,7 +993,7 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
 	    }
 	  }
 
-	  
+
 	  if (i_pat_higgsjet >= 0 && drmin < 1.0){
 	    const pat::Jet & higgs_jet = pat_higgsjets[i_pat_higgsjet];
 	    topjet.set_mvahiggsdiscr(higgs_jet.bDiscriminator(higgs_name.c_str()));
@@ -1021,7 +1011,7 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
 	if(higgstaginfo_src!=""){
 	  edm::Handle<std::vector<reco::BoostedDoubleSVTagInfo> > svTagInfos;
 	  event.getByToken(src_higgstaginfo_token, svTagInfos);
-	  
+
 	  //find taginfo belonging to a jet closest to the studied jet
 	  int i_svjet = -1;
 	  double drmin = numeric_limits<double>::infinity();
@@ -1034,10 +1024,10 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
 	      drmin = dr;
 	    }
 	  }
-	  
+
 	  if(i_svjet>=0 && drmin<1.0){
 	    const reco::BoostedDoubleSVTagInfo & svTagInfo = svTagInfos->at(i_svjet);
-	    const reco::JetBaseRef jet = svTagInfo.jet(); 
+	    const reco::JetBaseRef jet = svTagInfo.jet();
 
 	    topjet.set_tag(TopJet::tagname2tag("z_ratio"), svTagInfo.taggingVariables().get(reco::btau::TaggingVariableName::z_ratio));
 	    topjet.set_tag(TopJet::tagname2tag("trackSipdSig_3"), svTagInfo.taggingVariables().get(reco::btau::TaggingVariableName::trackSip3dSig_3));
@@ -1066,11 +1056,11 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
 	    topjet.set_tag(TopJet::tagname2tag("tau_flightDistance2dSig_1"), svTagInfo.taggingVariables().get(reco::btau::TaggingVariableName::tau2_flightDistance2dSig));
 	    topjet.set_tag(TopJet::tagname2tag("jetNTracks"), svTagInfo.taggingVariables().get(reco::btau::TaggingVariableName::jetNTracks));
 	    topjet.set_tag(TopJet::tagname2tag("nSV"), svTagInfo.taggingVariables().get(reco::btau::TaggingVariableName::jetNSecondaryVertices));
-	    
+
 	  }
 
 	}
-	  
+
         /*---------------------*/
 
         // loop over subjets to fill some more subjet info:

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -1080,6 +1080,19 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
     )
     task.add(process.packedPatJetsAk8CHSJets)
 
+    process.packedPatJetsAk8PuppiJets = cms.EDProducer("JetSubstructurePacker",
+        jetSrc = cms.InputTag("patJetsAk8PuppiJetsFat"),
+        distMax = cms.double(0.8),
+        algoTags = cms.VInputTag(
+            cms.InputTag("patJetsAk8PuppiJetsSoftDropPacked")
+        ),
+        algoLabels = cms.vstring(
+            'SoftDropPuppi'
+        ),
+        fixDaughters = cms.bool(False)
+    )
+    task.add(process.packedPatJetsAk8PuppiJets)
+
     # HOTVR & XCONE
     process.hotvrPuppi = cms.EDProducer("HOTVRProducer",
                                         src=cms.InputTag("puppi")
@@ -1692,6 +1705,21 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
                                             softdropmass_source=cms.string("patJetsAk8CHSJetsSoftDropPacked"),
                                             ecf_beta1_source=cms.string("ECFNbeta1Ak8SoftDropCHS"),
                                             ecf_beta2_source=cms.string("ECFNbeta2Ak8SoftDropCHS")
+                                        ),
+                                        cms.PSet(
+                                            topjet_source=cms.string("packedPatJetsAk8PuppiJets"),  # store ungroomed vars
+                                            subjet_source=cms.string("SoftDropPuppi"),
+                                            do_subjet_taginfo=cms.bool(True),
+                                            higgstag_source=cms.string("patJetsAk8PuppiJetsFat"),
+                                            higgstag_name=cms.string("pfBoostedDoubleSecondaryVertexAK8BJetTags"),
+                                            higgstaginfo_source=cms.string("pfBoostedDoubleSVTagInfos"),
+                                            njettiness_source=cms.string("NjettinessAk8Puppi"),
+                                            substructure_variables_source=cms.string("ak8PuppiJetsFat"),
+                                            njettiness_groomed_source=cms.string("NjettinessAk8SoftDropPuppi"),
+                                            substructure_groomed_variables_source=cms.string("ak8PuppiJetsSoftDropforsub"),
+                                            softdropmass_source=cms.string("patJetsAk8PuppiJetsSoftDropPacked"),
+                                            ecf_beta1_source=cms.string("ECFNbeta1Ak8SoftDropPuppi"),
+                                            ecf_beta2_source=cms.string("ECFNbeta2Ak8SoftDropPuppi")
                                         ),
                                         # cms.PSet(
                                         #     # The fat jets that HepTopTag produces are the Top jet candidates,

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -1649,8 +1649,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
                                             # If you include "CHS" in this string,
                                             # it will use the matched CHS 4-vector
                                             # for the *main* jet 4-vector.
-                                            subjet_source=cms.string(
-                                                "SoftDropPuppi"),
+                                            subjet_source=cms.string("SoftDropPuppi"),
                                             # Specify if you want to store b-tagging taginfos for subjet collection,
                                             # make sure to have included them with .addTagInfos = True
                                             # addTagInfos = True is currently true by default, however,
@@ -1663,15 +1662,13 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
                                             # from ungroomed jets
                                             higgstag_source=cms.string("patJetsAk8PuppiJetsFat"),
                                             higgstag_name=cms.string("pfBoostedDoubleSecondaryVertexAK8BJetTags"),
-                                            # Note: if empty, njettiness is directly taken from MINIAOD UserFloat and added to jets, otherwise taken from the provided source (for Run II CMSSW_74 ntuples)
+                                            # Note: if empty, njettiness is directly taken from MINIAOD UserFloat and added to jets, otherwise taken from the provided source
                                             #njettiness_source = cms.string(""),
                                             #substructure_variables_source = cms.string(""),
-                                            njettiness_groomed_source = cms.string(
-                                                "NjettinessAk8SoftDropPuppi"),
-                                            substructure_groomed_variables_source = cms.string(
-                                                "ak8PuppiJetsSoftDropforsub"),
-                                            softdropmass_source=cms.string(
-                                                "ak8PFJetsPuppiSoftDropMass"),
+                                            njettiness_groomed_source = cms.string("NjettinessAk8SoftDropPuppi"),
+                                            # substructure_groomed_variables_source should be the source as used in the module passed to njettiness_groomed_source
+                                            substructure_groomed_variables_source = cms.string("ak8PuppiJetsSoftDropforsub"),
+                                            softdropmass_source=cms.string("ak8PFJetsPuppiSoftDropMass"),
                                             # switch off qjets for now, as it takes a long time:
                                             #qjets_source = cms.string("QJetsCa8CHS")
                                             # Energy correlation functions, for beta=1 and beta=2
@@ -1682,30 +1679,19 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
                                             # ecf_beta2_source=cms.string("")
                                        ),
                                         cms.PSet(
-                                            topjet_source=cms.string(
-                                                "packedPatJetsAk8CHSJets"),  # store ungroomed vars
+                                            topjet_source=cms.string("packedPatJetsAk8CHSJets"),  # store ungroomed vars
                                             subjet_source=cms.string("SoftDropCHS"),
                                             do_subjet_taginfo=cms.bool(True),
-                                            higgstag_source=cms.string(
-                                                "patJetsAk8CHSJetsFat"),
-                                            higgstag_name=cms.string(
-                                                "pfBoostedDoubleSecondaryVertexAK8BJetTags"),
-                                            higgstaginfo_source=cms.string(
-                                                "pfBoostedDoubleSVTagInfos"),
-                                            njettiness_source=cms.string(
-                                                "NjettinessAk8CHS"),
-                                            substructure_variables_source=cms.string(
-                                                "ak8CHSJetsFat"),
-                                            njettiness_groomed_source=cms.string(
-                                                "NjettinessAk8SoftDropCHS"),
-                                            substructure_groomed_variables_source=cms.string(
-                                                "ak8CHSJetsSoftDropforsub"),
-                                            softdropmass_source=cms.string(
-                                                "patJetsAk8CHSJetsSoftDropPacked"),
-                                            ecf_beta1_source=cms.string(
-                                                "ECFNbeta1Ak8SoftDropCHS"),
-                                            ecf_beta2_source=cms.string(
-                                                "ECFNbeta2Ak8SoftDropCHS")
+                                            higgstag_source=cms.string("patJetsAk8CHSJetsFat"),
+                                            higgstag_name=cms.string("pfBoostedDoubleSecondaryVertexAK8BJetTags"),
+                                            higgstaginfo_source=cms.string("pfBoostedDoubleSVTagInfos"),
+                                            njettiness_source=cms.string("NjettinessAk8CHS"),
+                                            substructure_variables_source=cms.string("ak8CHSJetsFat"),
+                                            njettiness_groomed_source=cms.string("NjettinessAk8SoftDropCHS"),
+                                            substructure_groomed_variables_source=cms.string("ak8CHSJetsSoftDropforsub"),
+                                            softdropmass_source=cms.string("patJetsAk8CHSJetsSoftDropPacked"),
+                                            ecf_beta1_source=cms.string("ECFNbeta1Ak8SoftDropCHS"),
+                                            ecf_beta2_source=cms.string("ECFNbeta2Ak8SoftDropCHS")
                                         ),
                                         # cms.PSet(
                                         #     # The fat jets that HepTopTag produces are the Top jet candidates,
@@ -1787,8 +1773,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
                                     ),
 
                                     doTrigger=cms.bool(True),
-                                    trigger_bits=cms.InputTag(
-                                        "TriggerResults", "", "HLT"),
+                                    trigger_bits=cms.InputTag("TriggerResults", "", "HLT"),
                                     # MET filters (HBHE noise, CSC, etc.) are stored as trigger Bits in
                                     # MINIAOD produced in path "PAT"/"RECO" with prefix "Flag_"
                                     metfilter_bits=cms.InputTag("TriggerResults", "", metfilterpath),
@@ -1880,10 +1865,8 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
 
                                     # *** gen stuff:
                                     doGenInfo=cms.bool(not useData),
-                                    genparticle_source=cms.InputTag(
-                                        "prunedPrunedGenParticles"),
-                                    stablegenparticle_source=cms.InputTag(
-                                        "packedGenParticlesForJetsNoNu"),
+                                    genparticle_source=cms.InputTag("prunedPrunedGenParticles"),
+                                    stablegenparticle_source=cms.InputTag("packedGenParticlesForJetsNoNu"),
                                     # set to true if you want to store all gen particles, otherwise, only
                                     # prunedPrunedGenParticles are stored (see above)
                                     doAllGenParticles=cms.bool(False),

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -721,7 +721,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
     # add_fatjets_subjets(process, 'ca15CHSJets', 'ca15CHSJetsPruned',
     #                     jetcorr_label=None, jetcorr_label_subjets=None)  # we only use this to make packed collection for pruned mass
 
-    add_fatjets_subjets(process, 'ak8CHSJets', 'ak8CHSJetsSoftDrop',
+    add_fatjets_subjets(process, 'ak8CHSJetsFat', 'ak8CHSJetsSoftDrop',
                         genjets_name=lambda s: s.replace('CHS', 'Gen'))
 
     add_fatjets_subjets(process, 'ak8PuppiJetsFat', 'ak8PuppiJetsSoftDrop',
@@ -741,7 +741,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
     from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
     # AK8 CHS
     process.NjettinessAk8CHS = Njettiness.clone(
-        src=cms.InputTag("ak8CHSJets"),
+        src=cms.InputTag("ak8CHSJetsFat"),
         Njets=cms.vuint32(1, 2, 3, 4),  # compute 1-, 2-, 3-, 4- subjettiness
         # variables for measure definition :
         measureDefinition=cms.uint32(0),  # CMS default is normalized measure
@@ -1060,7 +1060,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
         trackPairV0Filter=cms.PSet(
            k0sMassWindow=cms.double(0.03)
         ),
-        svTagInfos=cms.InputTag("pfInclusiveSecondaryVertexFinderTagInfosAk8CHSJets")
+        svTagInfos=cms.InputTag("pfInclusiveSecondaryVertexFinderTagInfosAk8CHSJetsFat")  # This name is taken from the modules added by addJetcollection in add_fatjets_subjets
     )
     task.add(process.pfBoostedDoubleSVTagInfos)
 
@@ -1068,7 +1068,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
 
     # Add subjets from groomed fat jet to its corresponding ungroomed fatjet
     process.packedPatJetsAk8CHSJets = cms.EDProducer("JetSubstructurePacker",
-        jetSrc = cms.InputTag("patJetsAk8CHSJets"),
+        jetSrc = cms.InputTag("patJetsAk8CHSJetsFat"),
         distMax = cms.double(0.8),
         algoTags = cms.VInputTag(
             cms.InputTag("patJetsAk8CHSJetsSoftDropPacked")
@@ -1687,7 +1687,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
                                             subjet_source=cms.string("SoftDropCHS"),
                                             do_subjet_taginfo=cms.bool(True),
                                             higgstag_source=cms.string(
-                                                "patJetsAk8CHSJets"),
+                                                "patJetsAk8CHSJetsFat"),
                                             higgstag_name=cms.string(
                                                 "pfBoostedDoubleSecondaryVertexAK8BJetTags"),
                                             higgstaginfo_source=cms.string(
@@ -1695,7 +1695,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
                                             njettiness_source=cms.string(
                                                 "NjettinessAk8CHS"),
                                             substructure_variables_source=cms.string(
-                                                "ak8CHSJets"),
+                                                "ak8CHSJetsFat"),
                                             njettiness_groomed_source=cms.string(
                                                 "NjettinessAk8SoftDropCHS"),
                                             substructure_groomed_variables_source=cms.string(

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -834,28 +834,29 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
     # Add in Energy Correlation Functions for groomed jets only
     # The cut is taken from PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
     from RecoJets.JetProducers.ECF_cff import ecfNbeta1, ecfNbeta2
+    ecf_pt_min = 250
     process.ECFNbeta1Ak8SoftDropCHS = ecfNbeta1.clone(
         src=cms.InputTag("ak8CHSJetsSoftDropforsub"),
-        cuts=cms.vstring('', '', 'pt > 250')
+        cuts=cms.vstring('', '', 'pt > %f' % (ecf_pt_min))
     )
     task.add(process.ECFNbeta1Ak8SoftDropCHS)
 
     process.ECFNbeta2Ak8SoftDropCHS = ecfNbeta2.clone(
         src=cms.InputTag("ak8CHSJetsSoftDropforsub"),
-        cuts=cms.vstring('', '', 'pt > 250')
+        cuts=cms.vstring('', '', 'pt > %f' % (ecf_pt_min))
     )
     task.add(process.ECFNbeta2Ak8SoftDropCHS)
 
 
     process.ECFNbeta1Ak8SoftDropPuppi = ecfNbeta1.clone(
         src=cms.InputTag("ak8PuppiJetsSoftDropforsub"),
-        cuts=cms.vstring('', '', 'pt > 250')
+        cuts=cms.vstring('', '', 'pt > %f' % (ecf_pt_min))
     )
     task.add(process.ECFNbeta1Ak8SoftDropPuppi)
 
     process.ECFNbeta2Ak8SoftDropPuppi = ecfNbeta2.clone(
         src=cms.InputTag("ak8PuppiJetsSoftDropforsub"),
-        cuts=cms.vstring('', '', 'pt > 250')
+        cuts=cms.vstring('', '', 'pt > %f' % (ecf_pt_min))
     )
     task.add(process.ECFNbeta2Ak8SoftDropPuppi)
 

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -583,7 +583,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
             # add for ungroomed jets if not done yet (maybe never used in case
             # ungroomed are not added, but that's ok ..)
             ungroomed_jetproducer = getattr(process, fatjets_name)
-            assert ungroomed_jetproducer.type_() == 'FastjetJetProducer'
+            assert ungroomed_jetproducer.type_() == 'FastjetJetProducer', "ungroomed_jetproducer is not a FastjetJetProducer"
             ungroomed_genjets_name = genjets_name(fatjets_name)
             if verbose:
                 print "Adding ungroomed genjets", ungroomed_genjets_name
@@ -680,6 +680,8 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
         # add the merged jet collection which contains the links from fat jets to
         # subjets:
         groomed_packed_name = groomed_patname + 'Packed'
+        if verbose:
+            print "adding groomed jets + subjets packer", groomed_packed_name
         setattr(process,
                 groomed_packed_name,
                 cms.EDProducer("BoostedJetMerger",

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -599,8 +599,10 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
 
         jetcorr_list = ['L1FastJet', 'L2Relative', 'L3Absolute']
         if useData:
-            jetcorr_list = ['L1FastJet', 'L2Relative',
-                            'L3Absolute', 'L2L3Residual']
+            jetcorr_list.append('L2L3Residual')
+        if "puppi" in fatjets_name.lower():
+            jetcorr_list = jetcorr_list[1:]
+
         if jetcorr_label:
             jetcorr_arg = (jetcorr_label, cms.vstring(jetcorr_list), 'None')
         else:

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -563,7 +563,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
                                                    'CATopJetProducer'), "do not know how to construct genjet collection for %s" % repr(groomed_jetproducer)
             groomed_genjets_name = genjets_name(groomed_jets_name)
             if verbose:
-                print "Adding groomed genjets", groomed_genjets_name
+                print "  Adding groomed genjets:", groomed_genjets_name
             if not hasattr(process, groomed_genjets_name):
                 setattr(process,
                         groomed_genjets_name,
@@ -579,7 +579,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
             assert ungroomed_jetproducer.type_() == 'FastjetJetProducer', "ungroomed_jetproducer is not a FastjetJetProducer"
             ungroomed_genjets_name = genjets_name(fatjets_name)
             if verbose:
-                print "Adding ungroomed genjets", ungroomed_genjets_name
+                print "  Adding ungroomed genjets:", ungroomed_genjets_name
             if not hasattr(process, ungroomed_genjets_name):
                 setattr(process,
                         ungroomed_genjets_name,
@@ -606,7 +606,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
         add_ungroomed = not hasattr(process, ungroomed_patname)
         if add_ungroomed:
             if verbose:
-                print "Adding ungroomed jets", ungroomed_patname
+                print "  Adding ungroomed jets:", ungroomed_patname
             addJetCollection(process,
                              labelName=fatjets_name,
                              jetSource=cms.InputTag(fatjets_name),
@@ -623,7 +623,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
         # patify groomed fat jets, with b-tagging:
         groomed_patname = "patJets" + cap(groomed_jets_name)
         if verbose:
-            print "adding groomed jets", groomed_patname
+            print "  Adding groomed jets:", groomed_patname
         addJetCollection(process,
                          labelName=groomed_jets_name,
                          jetSource=cms.InputTag(groomed_jets_name),
@@ -646,7 +646,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
         # patify subjets, with subjet b-tagging:
         subjets_patname = "patJets" + cap(subjets_name)
         if verbose:
-            print "adding groomed jets' subjets", subjets_patname
+            print "  Adding groomed jets' subjets:", subjets_patname
         if jetcorr_label_subjets:
             jetcorr_arg = (jetcorr_label_subjets,
                            cms.vstring(jetcorr_list), 'None')
@@ -676,7 +676,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
         # fat jets to the subjets:
         groomed_packed_name = groomed_patname + 'Packed'
         if verbose:
-            print "adding groomed jets + subjets packer", groomed_packed_name
+            print "  Adding groomed jets + subjets packer:", groomed_packed_name
         setattr(process,
                 groomed_packed_name,
                 cms.EDProducer("BoostedJetMerger",
@@ -1121,7 +1121,9 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
 
     process.pfBoostedDoubleSVTagInfos.trackSelection.jetDeltaRMax = cms.double(0.8)
 
+    ###############################################
     # HOTVR & XCONE
+    #
     process.hotvrPuppi = cms.EDProducer("HOTVRProducer",
                                         src=cms.InputTag("puppi")
                                         )
@@ -1355,14 +1357,18 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
                                              )
     task.add(process.genXCone2jets08)
 
-    # LEPTON cfg
+    ###############################################
+    # LEPTON configuration
+    #
 
     # collections for lepton PF-isolation deposits
     process.load('UHH2.core.pfCandidatesByType_cff')
     process.load('CommonTools.ParticleFlow.deltaBetaWeights_cff')
 
-    # MUON # WILL BE IN MINIAOD OF 9_1_0 RELEASE
-
+    ###############################################
+    # MUONS
+    #
+    # mini-isolation
     mu_isovals = []
 
     load_muonPFMiniIso(process, 'muonPFMiniIsoSequenceSTAND', algo='STAND',
@@ -1390,11 +1396,11 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
                                               )
     task.add(process.slimmedMuonsUSER)
 
-    # ELECTRON
-
+    ###############################################
+    # ELECTRONS
+    #
     # mini-isolation
     # FIXME: should we use the already existing miniIsolatioin in pat::Lepton?
-
     el_isovals = []
 
     load_elecPFMiniIso(process,
@@ -1437,7 +1443,6 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
 
 
     # electron ID from VID
-
     switchOnVIDElectronIdProducer(process, DataFormat.MiniAOD)
 
     elecID_mod_ls = [
@@ -1528,7 +1533,9 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
     task.add(process.egmGsfElectronIDs)
     task.add(process.slimmedElectronsUSER)
 
+    ###############################################
     # L1 prefiring, only needed for simulation in 2016/7
+    #
     prefire_era_dict = {
         '2016v2': '2016BtoH',
         '2016v3': '2016BtoH',
@@ -1552,6 +1559,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
         )
         task.add(getattr(process, prefire_source))
 
+    ###############################################
     # Deal with bad ECAL endcap crystals
     # https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETOptionalFiltersRun2#How_to_run_ecal_BadCalibReducedM
     bad_ecal = year in ['2017', '2018'] and useData
@@ -1586,8 +1594,9 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
         )
         task.add(process.ecalBadCalibReducedMINIAODFilter)
 
-
+    ###############################################
     # NtupleWriter
+    #
 
     if useData:
         metfilterpath = "RECO"


### PR DESCRIPTION
Several things happen here:

- We now recluster our own AK8 PUPPI jets with all the melange of substructure and tagging. This replaces our reliance on slimmedJetsAK8, ensuring we have a consistent and flexible collection across all datasets, at the cost of extra runtime. It also means we don't have to worry about daughters really being subjets in some datasets. The new AK8 PUPPI mirrors the already existing AK8 CHS used for TopJets, with the extra deep* stuff

- Sorted out the DeepFlavour/Tagging + PUPPI PATPuppiJetSpecificProducer modules so that we only have one call to `updateJetCollection`, removing the extra jet collections. The trick is to do the PUPPI bit only for the very last `PATJetUpdater` module (since we use the collection name for userFloats) [Aside: the deepFlavour stuff cannot be added in with `addJetCollection`, only `updateJetCollection`]

- Added a crucial but totally undocumented fix to ensure the DeepBoostedJetTags are calculated properly for reclustered PUPPI jets

Minor stuff:

- Update the JEC levels in `add_fatjets_subjets` to ignore L1FastJet if PUPPI, and add L23Residual for data. Shouldn't be important as the user then applies JECs, but I thought I'd do it while tidying up.

- Lots of formatting & whitespace changes, plus more comments for future selves. Would recommend ignoring whitespace changes when looking at this PR diff (Diff settings in upper right -> Hide whitespace changes -> Apply)