### PR TITLE
[102X] add storage of PF candidates for selected number of reconstructed jets

### DIFF
--- a/core/include/EventHelper.h
+++ b/core/include/EventHelper.h
@@ -61,6 +61,7 @@ public:
     void setup_genInfo(const std::string & bname);
     void setup_gentopjets(const std::string & bname);
     void setup_genparticles(const std::string & bname);
+    void setup_pfparticles(const std::string & bname);
     void setup_genjets(const std::string & bname);
     
     void setup_trigger();
@@ -85,6 +86,7 @@ private:
     
     bool pvs, electrons, muons, taus, photons, jets, topjets, toppuppijets, met, genmet;
     bool genInfo, gentopjets, genparticles, genjets;
+    bool pfparticles;
     bool trigger;
     bool first_event_read;
     
@@ -113,6 +115,7 @@ private:
     Event::Handle<GenInfo> h_genInfo;
     Event::Handle<std::vector<GenTopJet>> h_gentopjets;
     Event::Handle<std::vector<GenParticle>> h_genparticles;
+    Event::Handle<std::vector<PFParticle>> h_pfparticles;
     Event::Handle<std::vector<GenJet>> h_genjets;
     
     Event::Handle<std::vector<bool>> h_triggerResults;

--- a/core/include/Jet.h
+++ b/core/include/Jet.h
@@ -105,6 +105,7 @@ class Jet : public FlavorParticle {
     m_pileupID = -2;
 
     m_lepton_keys.clear();
+    m_pfcand_indexs.clear();
   }
 
   float jetArea() const{return m_jetArea;}
@@ -190,6 +191,7 @@ class Jet : public FlavorParticle {
   float pileupID() const {return m_pileupID;}
 
   const std::vector<long int>& lepton_keys() const { return m_lepton_keys; }
+  const std::vector<long int>& pfcand_indexs() const { return m_pfcand_indexs; }
 
   void set_jetArea(float x){m_jetArea=x;}
   void set_numberOfDaughters(int x){m_numberOfDaughters=x;} 
@@ -277,6 +279,9 @@ class Jet : public FlavorParticle {
   void set_lepton_keys(const std::vector<long int>& vlk){ m_lepton_keys = vlk; }
   void add_lepton_key (const long int k){ m_lepton_keys.push_back(k); }
 
+  void set_pfcand_indexs(const std::vector<long int>& vlk){ m_pfcand_indexs = vlk; }
+  void add_pfcand_index (const long int k){ m_pfcand_indexs.push_back(k); }
+
  private:
   float m_jetArea;
   int m_numberOfDaughters;
@@ -362,6 +367,6 @@ class Jet : public FlavorParticle {
   JetBTagInfo m_btaginfo;
 
   std::vector<long int> m_lepton_keys;
-
+  std::vector<long int> m_pfcand_indexs;
   Tags tags;
 };

--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -237,6 +237,7 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
   doGenJets = iConfig.getParameter<bool>("doGenJets");
   doGenTopJets = iConfig.getParameter<bool>("doGenTopJets");
   doGenJetConstituents = iConfig.getParameter<unsigned>("doGenJetConstituents");
+  doPFJetConstituents = iConfig.getParameter<unsigned>("doPFJetConstituents");
   doPhotons = iConfig.getParameter<bool>("doPhotons");
   doMET = iConfig.getParameter<bool>("doMET");
   doGenMET = iConfig.getParameter<bool>("doGenMET");
@@ -330,7 +331,7 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
         NtupleWriterJets::Config cfg(*context, consumesCollector(), jet_sources[i], jet_sources[i]);
         cfg.ptmin = jet_ptmin;
         cfg.etamax = jet_etamax;
-        writer_modules.emplace_back(new NtupleWriterJets(cfg, i==0, muon_sources, elec_sources));
+        writer_modules.emplace_back(new NtupleWriterJets(cfg, i==0, muon_sources, elec_sources,doPFJetConstituents));
       }
   }
   if(doTopJets){
@@ -435,7 +436,7 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
         std::string topbranch=topjet_source+"_"+subjet_source;
         cfg.dest_branchname = topbranch;
         cfg.dest = topbranch;
-        writer_modules.emplace_back(new NtupleWriterTopJets(cfg, j==0, muon_sources, elec_sources));
+        writer_modules.emplace_back(new NtupleWriterTopJets(cfg, j==0, muon_sources, elec_sources,doPFJetConstituents));
 
       }
     }

--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -63,57 +63,45 @@ namespace{
    genp.set_mother2(-1);
    genp.set_daughter1(-1);
    genp.set_daughter2(-1);
-   /*  //fill mother and daughter info (assumes they are in the GenParticle list already). Does not look useful at the moment
-   int nm=jetgenp.numberOfMothers();
-   int nd=jetgenp.numberOfDaughters();
-   if(nm>0 || nd>0){
-     int mother1_i=-1;     int mother2_i=-1;
-     int daughter1_i=-1;     int daughter2_i=-1;
-     for(size_t j=0; j<genparts.size();j++){
-       const GenParticle & sgenpart = genparts[j];
-       if(nm>0){
-	 const reco::Candidate *reco_mother1 = jetgenp.mother(0);
-	 auto r = fabs(static_cast<float>(reco_mother1->eta()-sgenpart.eta()))+fabs(static_cast<float>(reco_mother1->phi()-sgenpart.phi()));
-	 auto dpt = fabs(static_cast<float>(reco_mother1->pt()-sgenpart.pt()));
-	 if (r == 0.0f && dpt == 0.0f){
-	   mother1_i=j;
-	 }
-       }
-       if(nm>1){
-	 const reco::Candidate *reco_mother2 = jetgenp.mother(1);
-	 auto r = fabs(static_cast<float>(reco_mother2->eta()-sgenpart.eta()))+fabs(static_cast<float>(reco_mother2->phi()-sgenpart.phi()));
-	 auto dpt = fabs(static_cast<float>(reco_mother2->pt()-sgenpart.pt()));
-	 if (r == 0.0f && dpt == 0.0f){
-	   mother2_i=j;
-	 }
-       }
-       if(nd>0){
-	 const reco::Candidate *reco_daughter1 = jetgenp.daughter(0);
-	 auto r = fabs(static_cast<float>(reco_daughter1->eta()-sgenpart.eta()))+fabs(static_cast<float>(reco_daughter1->phi()-sgenpart.phi()));
-	 auto dpt = fabs(static_cast<float>(reco_daughter1->pt()-sgenpart.pt()));
-	 if (r == 0.0f && dpt == 0.0f){
-	   daughter1_i=j;
-	 }
-       }
-       if(nd>1){
-	 const reco::Candidate *reco_daughter2 = jetgenp.daughter(1);
-	 auto r = fabs(static_cast<float>(reco_daughter2->eta()-sgenpart.eta()))+fabs(static_cast<float>(reco_daughter2->phi()-sgenpart.phi()));
-	 auto dpt = fabs(static_cast<float>(reco_daughter2->pt()-sgenpart.pt()));
-	 if (r == 0.0f && dpt == 0.0f){
-	   daughter2_i=j;
-	 }
-       }
-     }
-     genp.set_mother1(mother1_i);
-     genp.set_mother1(mother2_i);
-     genp.set_daughter1(daughter1_i);
-     genp.set_daughter1(daughter2_i);
-   }
-   */
+  
    genparts.push_back(genp);
    return genparts.size()-1;
 }
 
+
+size_t add_pfpart(const reco::Candidate & pf, vector<PFParticle> & pfparts){
+
+   for(size_t j=0; j<pfparts.size();j++){
+     const PFParticle & spfcandart = pfparts[j];
+     auto r = fabs(static_cast<float>(pf.eta()-spfcandart.eta()))+fabs(static_cast<float>(pf.phi()-spfcandart.phi()));
+     auto dpt = fabs(static_cast<float>(pf.pt()-spfcandart.pt()));
+     if (r == 0.0f && dpt == 0.0f){
+       return j;
+     }
+   }
+   PFParticle part;
+   part.set_pt(pf.pt());
+   part.set_eta(pf.eta());
+   part.set_phi(pf.phi());
+   part.set_energy(pf.energy());
+   part.set_charge(pf.charge());
+   PFParticle::EParticleID id = PFParticle::eX;
+   reco::PFCandidate reco_pf;
+   switch ( reco_pf.translatePdgIdToType(pf.pdgId()) ){
+   case reco::PFCandidate::X : id = PFParticle::eX; break;
+   case reco::PFCandidate::h : id = PFParticle::eH; break;
+   case reco::PFCandidate::e : id = PFParticle::eE; break;
+   case reco::PFCandidate::mu : id = PFParticle::eMu; break;
+   case reco::PFCandidate::gamma : id = PFParticle::eGamma; break;
+   case reco::PFCandidate::h0 : id = PFParticle::eH0; break;
+   case reco::PFCandidate::h_HF : id = PFParticle::eH_HF; break;
+   case reco::PFCandidate::egamma_HF : id = PFParticle::eEgamma_HF; break;
+   }
+   part.set_particleID(id);
+
+   pfparts.push_back(part);
+   return pfparts.size()-1;
+}
 
 template<typename T>
 void branch(TTree * tree, const char * bname, T t){
@@ -570,6 +558,11 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
     branch(tr, "genInfo","GenInfo", event->genInfo);
     branch(tr, "GenParticles","std::vector<GenParticle>", event->genparticles);
   }
+  if(doPFJetConstituents>0){
+    event->pfparticles = new vector<PFParticle>();
+    branch(tr, "PFParticles","std::vector<PFParticle>", event->pfparticles);
+  }
+
   if(doTrigger){
     trigger_prefixes = iConfig.getParameter<std::vector<std::string> >("trigger_prefixes");
     event->get_triggerResults() = new vector<bool>();
@@ -606,9 +599,11 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
     prefweightdown_token = consumes<double>(edm::InputTag(prefire_source, "nonPrefiringProbDown"));
   }
   if(doAllPFParticles){
-    event->pfparticles = new vector<PFParticle>;
     pf_collection_token = consumes<vector<pat::PackedCandidate>>(iConfig.getParameter<edm::InputTag>("pf_collection_source"));
-    branch(tr, "PFParticles", "std::vector<PFParticle>", &event->pfparticles);
+    if(doPFJetConstituents<1){
+      event->pfparticles = new vector<PFParticle>;
+      branch(tr, "PFParticles", "std::vector<PFParticle>", &event->pfparticles);
+    }
   }
 
   // HOTVR and XCone Jet Cluster - added by Alex and Dennis
@@ -709,6 +704,10 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
 
    print_times(timer, "rho");
+
+   if(doPFJetConstituents>0){
+     event->pfparticles->clear();
+   }
 
    // ------------- primary vertices and beamspot  -------------
 
@@ -1149,9 +1148,9 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
    print_times(timer, "met");
 
    // ------------- PF constituents --------------
-
+  
    if(doAllPFParticles){
-     event->pfparticles->clear();
+     if(!doPFJetConstituents) event->pfparticles->clear();
      edm::Handle<vector<pat::PackedCandidate> > pfColl_handle;
      iEvent.getByToken(pf_collection_token, pfColl_handle);
 
@@ -1186,6 +1185,9 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
      }
 
    }
+
+  
+
 
    // ------------- trigger -------------
 
@@ -1355,6 +1357,14 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 	}
 	thisJet.set_JEC_factor_raw(1.);
 	thisJet.set_JEC_L1factor_raw(1.);
+	if(hotvrJets[j].size()<doPFJetConstituents){
+	  const auto& jet_daughter_ptrs = patJet.daughterPtrVector();
+	  for(const auto & daughter_p : jet_daughter_ptrs){
+	    size_t pfparticles_index = add_pfpart(*daughter_p,*event->pfparticles);
+	    thisJet.add_pfcand_index(pfparticles_index);
+	  }
+	}
+
         for (const auto & subItr : patJet.subjets()) {
           Jet subjet;
           subjet.set_pt(subItr->p4().pt());
@@ -1381,6 +1391,13 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 	  }
 	  subjet.set_JEC_factor_raw(1.);
 	  subjet.set_JEC_L1factor_raw(1.);
+	  if(hotvrJets[j].size()<doPFJetConstituents){
+	    const auto& jet_daughter_ptrs = subItr->daughterPtrVector();
+	    for(const auto & daughter_p : jet_daughter_ptrs){
+	      size_t pfparticles_index = add_pfpart(*daughter_p,*event->pfparticles);
+	      subjet.add_pfcand_index(pfparticles_index);
+	    }
+	  }
           thisJet.add_subjet(subjet);
         }
 
@@ -1423,7 +1440,13 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 	}
 	thisJet.set_JEC_factor_raw(1.);
 	thisJet.set_JEC_L1factor_raw(1.);
-
+	if(xconeJets[j].size()<doPFJetConstituents){
+	  const auto& jet_daughter_ptrs = patJet.daughterPtrVector();
+	  for(const auto & daughter_p : jet_daughter_ptrs){
+	    size_t pfparticles_index = add_pfpart(*daughter_p,*event->pfparticles);
+	    thisJet.add_pfcand_index(pfparticles_index);
+	  }
+	}
 
         for (const auto & subItr : patJet.subjets()) {
           Jet subjet;
@@ -1451,6 +1474,13 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 	  }
 	  subjet.set_JEC_factor_raw(1.);
 	  subjet.set_JEC_L1factor_raw(1.);
+	  if(xconeJets[j].size()<doPFJetConstituents){
+	    const auto& jet_daughter_ptrs = subItr->daughterPtrVector();
+	    for(const auto & daughter_p : jet_daughter_ptrs){
+	      size_t pfparticles_index = add_pfpart(*daughter_p,*event->pfparticles);
+	      subjet.add_pfcand_index(pfparticles_index);
+	    }
+	  }
           thisJet.add_subjet(subjet);
         }
         xconeJets[j].push_back(thisJet);
@@ -1494,6 +1524,13 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 	thisJet.set_JEC_factor_raw(1.);
 	thisJet.set_JEC_L1factor_raw(1.);
 
+	if(xconeJets_dijet[j].size()<doPFJetConstituents){
+	  const auto& jet_daughter_ptrs = patJet.daughterPtrVector();
+	  for(const auto & daughter_p : jet_daughter_ptrs){
+	    size_t pfparticles_index = add_pfpart(*daughter_p,*event->pfparticles);
+	    thisJet.add_pfcand_index(pfparticles_index);
+	  }
+	}
 
         for (const auto & subItr : patJet.subjets()) {
           Jet subjet;
@@ -1521,8 +1558,16 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 	  }
 	  subjet.set_JEC_factor_raw(1.);
 	  subjet.set_JEC_L1factor_raw(1.);
+	  if(xconeJets_dijet[j].size()<doPFJetConstituents){
+	    const auto& jet_daughter_ptrs = subItr->daughterPtrVector();
+	    for(const auto & daughter_p : jet_daughter_ptrs){
+	      size_t pfparticles_index = add_pfpart(*daughter_p,*event->pfparticles);
+	      subjet.add_pfcand_index(pfparticles_index);
+	    }
+	  }
           thisJet.add_subjet(subjet);
         }
+
         xconeJets_dijet[j].push_back(thisJet);
       }
     }
@@ -1794,6 +1839,7 @@ void NtupleWriter::fill_geninfo_recocand(const reco::Candidate& sub_jet, GenJet&
   genjet.set_charge(jet_charge);
   // cout<<"N constituens ="<<pat_genjet.numberOfSourceCandidatePtrs()<<" with charge = "<<jet_charge<<endl;
 }
+
 
 
 //define this as a plug-in

--- a/core/plugins/NtupleWriter.h
+++ b/core/plugins/NtupleWriter.h
@@ -49,6 +49,9 @@ class NtupleWriter : public edm::EDFilter {
       //For clustered reco::GenJet with subjets, which turn out to be reco::Jet with subjets reco::Candidate
       void fill_geninfo_recocand(const reco::Candidate& constituent, GenJet& genjet);
 
+      /* //Add pf candidate to event */
+      /* size_t add_pfpart(const reco::Candidate & pf, std::vector<PFParticle> & pfparts); */
+
       // ----------member data ---------------------------
       TFile *outfile;
       TTree *tr;

--- a/core/plugins/NtupleWriter.h
+++ b/core/plugins/NtupleWriter.h
@@ -63,6 +63,7 @@ class NtupleWriter : public edm::EDFilter {
       bool doAllGenParticles;
       bool doAllGenParticlesPythia8;
       unsigned doGenJetConstituents;
+      unsigned doPFJetConstituents;
       bool doPV;
       bool doTrigger;
       bool doEcalBadCalib;

--- a/core/plugins/NtupleWriterJets.cxx
+++ b/core/plugins/NtupleWriterJets.cxx
@@ -34,10 +34,8 @@ using namespace std;
 
 bool btag_warning;
 
-//size_t add_pfpart(const pat::PackedCandidate & pf, vector<PFParticle> & pfparts){
-//size_t add_pfpart(const reco::PFCandidate & pf, vector<PFParticle> & pfparts){
 size_t add_pfpart(const reco::Candidate & pf, vector<PFParticle> & pfparts){
-  cout<<"pfparts.size() = "<<pfparts.size()<<endl;
+
    for(size_t j=0; j<pfparts.size();j++){
      const PFParticle & spfcandart = pfparts[j];
      auto r = fabs(static_cast<float>(pf.eta()-spfcandart.eta()))+fabs(static_cast<float>(pf.phi()-spfcandart.phi()));
@@ -52,10 +50,7 @@ size_t add_pfpart(const reco::Candidate & pf, vector<PFParticle> & pfparts){
    part.set_phi(pf.phi());
    part.set_energy(pf.energy());
    part.set_charge(pf.charge());
-   //   part.set_puppiWeight(pf.puppiWeight());
-   //   part.set_puppiWeightNoLep(pf.puppiWeightNoLep());
-
-   /*   PFParticle::EParticleID id = PFParticle::eX;
+   PFParticle::EParticleID id = PFParticle::eX;
    reco::PFCandidate reco_pf;
    switch ( reco_pf.translatePdgIdToType(pf.pdgId()) ){
    case reco::PFCandidate::X : id = PFParticle::eX; break;
@@ -68,7 +63,7 @@ size_t add_pfpart(const reco::Candidate & pf, vector<PFParticle> & pfparts){
    case reco::PFCandidate::egamma_HF : id = PFParticle::eEgamma_HF; break;
    }
    part.set_particleID(id);
-   */
+
    pfparts.push_back(part);
    return pfparts.size()-1;
 }
@@ -95,6 +90,7 @@ std::string getPuppiJetSpecificProducer(const std::string & name){
 
 NtupleWriterJets::NtupleWriterJets(Config & cfg, bool set_jets_member, unsigned int NPFJetwConstituents){
     handle = cfg.ctx.declare_event_output<vector<Jet>>(cfg.dest_branchname, cfg.dest);
+    
     ptmin = cfg.ptmin;
     etamax = cfg.etamax;
     if(set_jets_member){
@@ -110,6 +106,7 @@ NtupleWriterJets::NtupleWriterJets(Config & cfg, bool set_jets_member, unsigned 
     h_muons.clear();
     h_elecs.clear();
     NPFJetwConstituents_ = NPFJetwConstituents;
+    //    auto h_pfcand = cfg.ctx.get_handle<vector<PFParticle>>("PFParticles"); h_pfcands.push_back(h_pfcand);
 }
 
 NtupleWriterJets::NtupleWriterJets(Config & cfg, bool set_jets_member, const std::vector<std::string>& muon_sources, const std::vector<std::string>& elec_sources, unsigned int NPFJetwConstituents):
@@ -119,7 +116,9 @@ NtupleWriterJets::NtupleWriterJets(Config & cfg, bool set_jets_member, const std
 
     for(const auto& muo_src : muon_sources){ auto h_muon = cfg.ctx.get_handle<std::vector<Muon>    >(muo_src); h_muons.push_back(h_muon); }
     for(const auto& ele_src : elec_sources){ auto h_elec = cfg.ctx.get_handle<std::vector<Electron>>(ele_src); h_elecs.push_back(h_elec); }
+    //    auto h_pfcand = cfg.ctx.get_handle<vector<PFParticle>>("pfparticles"); h_pfcands.push_back(h_pfcand);
     NPFJetwConstituents_ = NPFJetwConstituents;
+
 }
 
 NtupleWriterJets::~NtupleWriterJets(){}
@@ -167,6 +166,8 @@ void NtupleWriterJets::process(const edm::Event & event, uhh2::Event & uevent,  
         jets.emplace_back();
 
         Jet& jet = jets.back();
+
+
 	bool storePFcands = false;
 	if(i<NPFJetwConstituents_) storePFcands = true;
         try {
@@ -584,10 +585,8 @@ void NtupleWriterJets::fill_jet_info(uhh2::Event & uevent, const pat::Jet & pat_
   }
 
   if(fill_pfcand){//fill pf candidates list: add pf-candidate to the event list and store index in the jet container
-    //    const auto& jet_daughter_ptrs = pat_jet.getPFConstituents();
     const auto& jet_daughter_ptrs = pat_jet.daughterPtrVector();
     for(const auto & daughter_p : jet_daughter_ptrs){
-
       size_t pfparticles_index = add_pfpart(*daughter_p, *uevent.pfparticles);
       jet.add_pfcand_index(pfparticles_index);
     }

--- a/core/plugins/NtupleWriterJets.cxx
+++ b/core/plugins/NtupleWriterJets.cxx
@@ -34,6 +34,45 @@ using namespace std;
 
 bool btag_warning;
 
+//size_t add_pfpart(const pat::PackedCandidate & pf, vector<PFParticle> & pfparts){
+//size_t add_pfpart(const reco::PFCandidate & pf, vector<PFParticle> & pfparts){
+size_t add_pfpart(const reco::Candidate & pf, vector<PFParticle> & pfparts){
+  cout<<"pfparts.size() = "<<pfparts.size()<<endl;
+   for(size_t j=0; j<pfparts.size();j++){
+     const PFParticle & spfcandart = pfparts[j];
+     auto r = fabs(static_cast<float>(pf.eta()-spfcandart.eta()))+fabs(static_cast<float>(pf.phi()-spfcandart.phi()));
+     auto dpt = fabs(static_cast<float>(pf.pt()-spfcandart.pt()));
+     if (r == 0.0f && dpt == 0.0f){
+       return j;
+     }
+   }
+   PFParticle part;
+   part.set_pt(pf.pt());
+   part.set_eta(pf.eta());
+   part.set_phi(pf.phi());
+   part.set_energy(pf.energy());
+   part.set_charge(pf.charge());
+   //   part.set_puppiWeight(pf.puppiWeight());
+   //   part.set_puppiWeightNoLep(pf.puppiWeightNoLep());
+
+   /*   PFParticle::EParticleID id = PFParticle::eX;
+   reco::PFCandidate reco_pf;
+   switch ( reco_pf.translatePdgIdToType(pf.pdgId()) ){
+   case reco::PFCandidate::X : id = PFParticle::eX; break;
+   case reco::PFCandidate::h : id = PFParticle::eH; break;
+   case reco::PFCandidate::e : id = PFParticle::eE; break;
+   case reco::PFCandidate::mu : id = PFParticle::eMu; break;
+   case reco::PFCandidate::gamma : id = PFParticle::eGamma; break;
+   case reco::PFCandidate::h0 : id = PFParticle::eH0; break;
+   case reco::PFCandidate::h_HF : id = PFParticle::eH_HF; break;
+   case reco::PFCandidate::egamma_HF : id = PFParticle::eEgamma_HF; break;
+   }
+   part.set_particleID(id);
+   */
+   pfparts.push_back(part);
+   return pfparts.size()-1;
+}
+
 // Get userFloat entry, with some default return value if it doesn't exist
 // TODO: template this?
 float getPatJetUserFloat(const pat::Jet & jet, const std::string & key, float defaultValue=-9999.){
@@ -54,7 +93,7 @@ std::string getPuppiJetSpecificProducer(const std::string & name){
   return multiplicity_name;
 }
 
-NtupleWriterJets::NtupleWriterJets(Config & cfg, bool set_jets_member){
+NtupleWriterJets::NtupleWriterJets(Config & cfg, bool set_jets_member, unsigned int NPFJetwConstituents){
     handle = cfg.ctx.declare_event_output<vector<Jet>>(cfg.dest_branchname, cfg.dest);
     ptmin = cfg.ptmin;
     etamax = cfg.etamax;
@@ -70,15 +109,17 @@ NtupleWriterJets::NtupleWriterJets(Config & cfg, bool set_jets_member){
 
     h_muons.clear();
     h_elecs.clear();
+    NPFJetwConstituents_ = NPFJetwConstituents;
 }
 
-NtupleWriterJets::NtupleWriterJets(Config & cfg, bool set_jets_member, const std::vector<std::string>& muon_sources, const std::vector<std::string>& elec_sources):
-  NtupleWriterJets::NtupleWriterJets(cfg, set_jets_member) {
+NtupleWriterJets::NtupleWriterJets(Config & cfg, bool set_jets_member, const std::vector<std::string>& muon_sources, const std::vector<std::string>& elec_sources, unsigned int NPFJetwConstituents):
+  NtupleWriterJets::NtupleWriterJets(cfg, set_jets_member, NPFJetwConstituents) {
 
     save_lepton_keys_ = true;
 
     for(const auto& muo_src : muon_sources){ auto h_muon = cfg.ctx.get_handle<std::vector<Muon>    >(muo_src); h_muons.push_back(h_muon); }
     for(const auto& ele_src : elec_sources){ auto h_elec = cfg.ctx.get_handle<std::vector<Electron>>(ele_src); h_elecs.push_back(h_elec); }
+    NPFJetwConstituents_ = NPFJetwConstituents;
 }
 
 NtupleWriterJets::~NtupleWriterJets(){}
@@ -126,9 +167,10 @@ void NtupleWriterJets::process(const edm::Event & event, uhh2::Event & uevent,  
         jets.emplace_back();
 
         Jet& jet = jets.back();
-
+	bool storePFcands = false;
+	if(i<NPFJetwConstituents_) storePFcands = true;
         try {
-          fill_jet_info(pat_jet, jet, true, false, jet_puppiSpecificProducer);
+          fill_jet_info(uevent,pat_jet, jet, true, false, jet_puppiSpecificProducer,storePFcands);
         }
         catch(runtime_error & ex){
           throw cms::Exception("fill_jet_info error", "Error in fill_jet_info NtupleWriterJets::process for jets with src = " + src.label());
@@ -158,7 +200,7 @@ void NtupleWriterJets::process(const edm::Event & event, uhh2::Event & uevent,  
 }
 
 
-void NtupleWriterJets::fill_jet_info(const pat::Jet & pat_jet, Jet & jet, bool do_btagging, bool do_taginfo, const std::string & puppiJetSpecificProducer){
+void NtupleWriterJets::fill_jet_info(uhh2::Event & uevent, const pat::Jet & pat_jet, Jet & jet, bool do_btagging, bool do_taginfo, const std::string & puppiJetSpecificProducer, bool fill_pfcand){
   jet.set_charge(pat_jet.charge());
   jet.set_pt(pat_jet.pt());
   jet.set_eta(pat_jet.eta());
@@ -540,10 +582,20 @@ void NtupleWriterJets::fill_jet_info(const pat::Jet & pat_jet, Jet & jet, bool d
       // throw runtime_error("did not find all b-taggers; see output for details");
     }
   }
+
+  if(fill_pfcand){//fill pf candidates list: add pf-candidate to the event list and store index in the jet container
+    //    const auto& jet_daughter_ptrs = pat_jet.getPFConstituents();
+    const auto& jet_daughter_ptrs = pat_jet.daughterPtrVector();
+    for(const auto & daughter_p : jet_daughter_ptrs){
+
+      size_t pfparticles_index = add_pfpart(*daughter_p, *uevent.pfparticles);
+      jet.add_pfcand_index(pfparticles_index);
+    }
+  }
 }
 
 
-NtupleWriterTopJets::NtupleWriterTopJets(Config & cfg, bool set_jets_member): ptmin(cfg.ptmin), etamax(cfg.etamax) {
+NtupleWriterTopJets::NtupleWriterTopJets(Config & cfg, bool set_jets_member, unsigned int NPFJetwConstituents): ptmin(cfg.ptmin), etamax(cfg.etamax) {
     handle = cfg.ctx.declare_event_output<vector<TopJet>>(cfg.dest_branchname, cfg.dest);
     if(set_jets_member){
         topjets_handle = cfg.ctx.get_handle<vector<TopJet>>("topjets");
@@ -612,16 +664,17 @@ NtupleWriterTopJets::NtupleWriterTopJets(Config & cfg, bool set_jets_member): pt
 
     higgstaginfo_src = cfg.higgstaginfo_src;
     src_higgstaginfo_token =  cfg.cc.consumes<std::vector<reco::BoostedDoubleSVTagInfo> >(cfg.higgstaginfo_src);
+    NPFJetwConstituents_ = NPFJetwConstituents;
 }
 
-NtupleWriterTopJets::NtupleWriterTopJets(Config & cfg, bool set_jets_member, const std::vector<std::string>& muon_sources, const std::vector<std::string>& elec_sources):
-  NtupleWriterTopJets::NtupleWriterTopJets(cfg, set_jets_member) {
+NtupleWriterTopJets::NtupleWriterTopJets(Config & cfg, bool set_jets_member, const std::vector<std::string>& muon_sources, const std::vector<std::string>& elec_sources, unsigned int NPFJetwConstituents):
+  NtupleWriterTopJets::NtupleWriterTopJets(cfg, set_jets_member, NPFJetwConstituents) {
 
     save_lepton_keys_ = true;
 
     for(const auto& muo_src : muon_sources){ auto h_muon = cfg.ctx.get_handle<std::vector<Muon>    >(muo_src); h_muons.push_back(h_muon); }
     for(const auto& ele_src : elec_sources){ auto h_elec = cfg.ctx.get_handle<std::vector<Electron>>(ele_src); h_elecs.push_back(h_elec); }
-
+    NPFJetwConstituents_ = NPFJetwConstituents;
 }
 
 NtupleWriterTopJets::~NtupleWriterTopJets(){}
@@ -751,8 +804,10 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
         
         topjets.emplace_back();
         TopJet & topjet = topjets.back();
+	bool storePFcands = false;
+	if(i<NPFJetwConstituents_) storePFcands = true;
         try{
-          uhh2::NtupleWriterJets::fill_jet_info(pat_topjet, topjet, do_btagging, false, topjet_puppiSpecificProducer);
+          uhh2::NtupleWriterJets::fill_jet_info(uevent,pat_topjet, topjet, do_btagging, false, topjet_puppiSpecificProducer,storePFcands);
           // if(subjet_src.find("CHS")!=string::npos){
           //   TLorentzVector puppi_v4;
           //   puppi_v4.SetPtEtaPhiM(pat_topjet.userFloat("ak8PFJetsCHSValueMap:pt"),
@@ -1093,7 +1148,7 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
             auto patsubjetd = dynamic_cast<const pat::Jet *>(pat_topjet.daughter(k));
             if (patsubjetd) {
 	      try{
-		NtupleWriterJets::fill_jet_info(*patsubjetd, subjet, do_btagging_subjets, do_taginfo_subjets, "");
+		NtupleWriterJets::fill_jet_info(uevent,*patsubjetd, subjet, do_btagging_subjets, do_taginfo_subjets, "");
 	      }catch(runtime_error &){
                 throw cms::Exception("fill_jet_info error", "Error in fill_jet_info for daughters in NtupleWriterTopJets with src = " + src.label());
 	      }
@@ -1122,7 +1177,7 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
 	    auto tpatsubjet = dynamic_cast<const pat::Jet *>(tSubjets.at(sj).get());
             if (tpatsubjet) {
 	      try{
-		NtupleWriterJets::fill_jet_info(*tpatsubjet, subjet, do_btagging_subjets, do_taginfo_subjets, "");
+		NtupleWriterJets::fill_jet_info(uevent,*tpatsubjet, subjet, do_btagging_subjets, do_taginfo_subjets, "");
 	      }catch(runtime_error &){
                 throw cms::Exception("fill_jet_info error", "Error in fill_jet_info for subjets in NtupleWriterTopJets with src = " + src.label());
 	      }

--- a/core/plugins/NtupleWriterJets.cxx
+++ b/core/plugins/NtupleWriterJets.cxx
@@ -1142,7 +1142,7 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
 
         // loop over subjets to fill some more subjet info:
 	//	bool storePFcands = false;
-	if(i<NPFJetwConstituents_) storePFcands = true;
+	//	if(i<NPFJetwConstituents_) storePFcands = true;
 
 	if(subjet_src=="daughters"){
 	  for (unsigned int k = 0; k < pat_topjet.numberOfDaughters(); k++) {
@@ -1173,8 +1173,6 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
 	}//if label daughters
 	//taking subjets from existing miniAOD collection
 	else{
-	bool storePFcands = false;
-	if(i<NPFJetwConstituents_) storePFcands = true;
 	  auto tSubjets = pat_topjet.subjets(subjet_src);
 	  for( int sj = 0; sj < (int)tSubjets.size(); ++sj ){
 	    Jet subjet;

--- a/core/plugins/NtupleWriterJets.cxx
+++ b/core/plugins/NtupleWriterJets.cxx
@@ -1141,13 +1141,16 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
         /*---------------------*/
 
         // loop over subjets to fill some more subjet info:
+	//	bool storePFcands = false;
+	if(i<NPFJetwConstituents_) storePFcands = true;
+
 	if(subjet_src=="daughters"){
 	  for (unsigned int k = 0; k < pat_topjet.numberOfDaughters(); k++) {
             Jet subjet;
             auto patsubjetd = dynamic_cast<const pat::Jet *>(pat_topjet.daughter(k));
             if (patsubjetd) {
 	      try{
-		NtupleWriterJets::fill_jet_info(uevent,*patsubjetd, subjet, do_btagging_subjets, do_taginfo_subjets, "");
+		NtupleWriterJets::fill_jet_info(uevent,*patsubjetd, subjet, do_btagging_subjets, do_taginfo_subjets, "", storePFcands);
 	      }catch(runtime_error &){
                 throw cms::Exception("fill_jet_info error", "Error in fill_jet_info for daughters in NtupleWriterTopJets with src = " + src.label());
 	      }
@@ -1170,13 +1173,15 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
 	}//if label daughters
 	//taking subjets from existing miniAOD collection
 	else{
+	bool storePFcands = false;
+	if(i<NPFJetwConstituents_) storePFcands = true;
 	  auto tSubjets = pat_topjet.subjets(subjet_src);
 	  for( int sj = 0; sj < (int)tSubjets.size(); ++sj ){
 	    Jet subjet;
 	    auto tpatsubjet = dynamic_cast<const pat::Jet *>(tSubjets.at(sj).get());
             if (tpatsubjet) {
 	      try{
-		NtupleWriterJets::fill_jet_info(uevent,*tpatsubjet, subjet, do_btagging_subjets, do_taginfo_subjets, "");
+		NtupleWriterJets::fill_jet_info(uevent,*tpatsubjet, subjet, do_btagging_subjets, do_taginfo_subjets, "", storePFcands);
 	      }catch(runtime_error &){
                 throw cms::Exception("fill_jet_info error", "Error in fill_jet_info for subjets in NtupleWriterTopJets with src = " + src.label());
 	      }

--- a/core/plugins/NtupleWriterJets.h
+++ b/core/plugins/NtupleWriterJets.h
@@ -22,10 +22,10 @@ namespace uhh2 {
 
 class NtupleWriterJets: public NtupleWriterModule {
 public:
-    static void fill_jet_info(const pat::Jet & pat_jet, Jet & jet, bool do_btagging, bool do_taginfo, const std::string & puppiJetSpecificProducer="");
+    static void fill_jet_info(uhh2::Event & uevent, const pat::Jet & pat_jet, Jet & jet, bool do_btagging, bool do_taginfo, const std::string & puppiJetSpecificProducer="", bool fill_pfcand=false);
 
-    explicit NtupleWriterJets(Config & cfg, bool set_jets_member);
-    explicit NtupleWriterJets(Config & cfg, bool set_jets_member, const std::vector<std::string>&, const std::vector<std::string>&);
+    explicit NtupleWriterJets(Config & cfg, bool set_jets_member, unsigned int NPFJetwConstituents);
+    explicit NtupleWriterJets(Config & cfg, bool set_jets_member, const std::vector<std::string>&, const std::vector<std::string>&, unsigned int NPFJetwConstituents);
 
     virtual void process(const edm::Event &, uhh2::Event &,  const edm::EventSetup&);
 
@@ -42,6 +42,7 @@ private:
     bool save_lepton_keys_;
     std::vector<Event::Handle<std::vector<Muon>    >> h_muons;
     std::vector<Event::Handle<std::vector<Electron>>> h_elecs;
+    unsigned int NPFJetwConstituents_;
 };
 
 
@@ -69,8 +70,8 @@ public:
         std::string ecf_beta2_src;
     };
 
-    explicit NtupleWriterTopJets(Config & cfg, bool set_jets_member);
-    explicit NtupleWriterTopJets(Config & cfg, bool set_jets_member, const std::vector<std::string>&, const std::vector<std::string>&);
+    explicit NtupleWriterTopJets(Config & cfg, bool set_jets_member, unsigned int NPFJetwConstituents);
+    explicit NtupleWriterTopJets(Config & cfg, bool set_jets_member, const std::vector<std::string>&, const std::vector<std::string>&, unsigned int NPFJetwConstituents);
 
     virtual void process(const edm::Event &, uhh2::Event &,  const edm::EventSetup&);
 
@@ -92,6 +93,7 @@ private:
     std::vector<TopJet::tag> id_tags;
 
     bool save_lepton_keys_;
+    unsigned int NPFJetwConstituents_;
     std::vector<Event::Handle<std::vector<Muon>    >> h_muons;
     std::vector<Event::Handle<std::vector<Electron>>> h_elecs;
 };

--- a/core/plugins/NtupleWriterJets.h
+++ b/core/plugins/NtupleWriterJets.h
@@ -38,10 +38,13 @@ private:
     float ptmin, etamax;
     Event::Handle<std::vector<Jet>> handle; // main handle to write output to
     boost::optional<Event::Handle<std::vector<Jet>>> jets_handle; // handle of name "jets" in case set_jets_member is true
+    //    boost::optional<Event::Handle<std::vector<PFParticle>>> pfcand_handle;//handle to PF constituences of jets
     std::string jet_puppiSpecificProducer; // hold name of puppiJetSpecificProducer for userFloat access
     bool save_lepton_keys_;
     std::vector<Event::Handle<std::vector<Muon>    >> h_muons;
     std::vector<Event::Handle<std::vector<Electron>>> h_elecs;
+    std::vector<Event::Handle<std::vector<PFParticle>>> h_pfcands;
+
     unsigned int NPFJetwConstituents_;
 };
 
@@ -90,12 +93,14 @@ private:
     std::string njettiness_src, njettiness_groomed_src, qjets_src, ecf_beta1_src, ecf_beta2_src, subjet_src, higgs_src, higgs_name, higgstaginfo_src, softdrop_src, topjet_collection, topjet_puppiSpecificProducer;
     Event::Handle<std::vector<TopJet>> handle;
     boost::optional<Event::Handle<std::vector<TopJet>>> topjets_handle;
+    //    boost::optional<Event::Handle<std::vector<PFParticle>>> pfcand_handle;
     std::vector<TopJet::tag> id_tags;
 
     bool save_lepton_keys_;
     unsigned int NPFJetwConstituents_;
     std::vector<Event::Handle<std::vector<Muon>    >> h_muons;
     std::vector<Event::Handle<std::vector<Electron>>> h_elecs;
+    std::vector<Event::Handle<std::vector<PFParticle>>> h_pfcands;
 };
 
 }

--- a/core/plugins/XConeProducer.cc
+++ b/core/plugins/XConeProducer.cc
@@ -399,5 +399,7 @@ vector<reco::CandidatePtr> XConeProducer::getConstituents(const vector<fastjet::
   return result;
 }
 
+
+
 //define this as a plug-in
 DEFINE_FWK_MODULE(XConeProducer);

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -1906,6 +1906,8 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
                                     # prunedPrunedGenParticles are stored (see above)
                                     doAllGenParticles=cms.bool(False),
                                     doAllGenParticlesPythia8=cms.bool(False),
+#                                    doPFJetConstituents=cms.uint32(0),
+                                    doPFJetConstituents=cms.uint32(1),
                                     doGenJets=cms.bool(not useData),
                                     doGenJetConstituents=cms.uint32(0), #number of genjets with stored gen.constituents
                                     genjet_sources=cms.vstring(

--- a/core/src/EventHelper.cxx
+++ b/core/src/EventHelper.cxx
@@ -19,7 +19,8 @@ Event::Handle<T> declare_in_out(const std::string & branch_name, const std::stri
 }
 
 EventHelper::EventHelper(uhh2::Context & ctx_): ctx(ctx_), event(0), pvs(false), electrons(false), muons(false), taus(false), photons(false), jets(false),
-    topjets(false), toppuppijets(false), met(false),  genmet(false), genInfo(false), gentopjets(false), genparticles(false), genjets(false), trigger(false), first_event_read(true){
+						topjets(false), toppuppijets(false), met(false),  genmet(false), genInfo(false), gentopjets(false), 
+						genparticles(false), genjets(false), pfparticles(false), trigger(false), first_event_read(true){
     h_run = declare_in_out<int>("run", "run", ctx);
     h_lumi = declare_in_out<int>("luminosityBlock", "luminosityBlock", ctx);
     h_event = declare_in_out<int>("event", "event", ctx);
@@ -57,6 +58,7 @@ IMPL_SETUP(met, MET)
 IMPL_SETUP(genInfo, GenInfo)
 IMPL_SETUP(gentopjets, vector<GenTopJet>)
 IMPL_SETUP(genparticles, vector<GenParticle>)
+IMPL_SETUP(pfparticles, vector<PFParticle>)
 IMPL_SETUP(genjets, vector<GenJet>)
 IMPL_SETUP(genmet, MET)
 
@@ -135,6 +137,13 @@ void EventHelper::event_read(){
 	  std::cout<<"Problem with genparticles in EventHelper.cxx"<<std::endl;
 	  std::cout<<error.what();
 	}
+	try{
+        if(pfparticles) event->pfparticles = & event->get(h_pfparticles);}
+	catch(const std::runtime_error& error){
+	  std::cout<<"Problem with pfparticles in EventHelper.cxx"<<std::endl;
+	  std::cout<<error.what();
+	}
+
 	try{
         if(genjets) event->genjets = &event->get(h_genjets);}
 	catch(const std::runtime_error& error){


### PR DESCRIPTION
The feature is enabled by "doPFJetConstituents" flag (=number of jets for which PF candidates should be stored and linked to Jet).  At the moment one flag for all jet collections for simplicity. Might be useful for comparing leading jets between each other.