### PR TITLE
[102X] Add missing variables for b-tagging

### DIFF
--- a/core/include/Jet.h
+++ b/core/include/Jet.h
@@ -100,12 +100,8 @@ class Jet : public FlavorParticle {
     m_btag_MassIndependentDeepDoubleCvLJet_probHcc=-2;
     m_btag_MassIndependentDeepDoubleCvLJet_probQCD=-2;
 
-    m_btag_DeepBoosted_bbvsLight=-2;
-    m_btag_DeepBoosted_ccvsLight=-2;
     m_btag_DeepBoosted_TvsQCD=-2;
-    m_btag_DeepBoosted_ZHccvsQCD=-2;
     m_btag_DeepBoosted_WvsQCD=-2;
-    m_btag_DeepBoosted_ZHbbvsQCD=-2;
     m_btag_DeepBoosted_ZvsQCD=-2;
     m_btag_DeepBoosted_ZbbvsQCD=-2;
     m_btag_DeepBoosted_HbbvsQCD=-2;
@@ -214,12 +210,8 @@ class Jet : public FlavorParticle {
   float btag_MassIndependentDeepDoubleCvLJet_probQCD() const{return m_btag_MassIndependentDeepDoubleCvLJet_probQCD;}
 
 
-  float btag_DeepBoosted_bbvsLight() const{return m_btag_DeepBoosted_bbvsLight;}
-  float btag_DeepBoosted_ccvsLight() const{return m_btag_DeepBoosted_ccvsLight;}
   float btag_DeepBoosted_TvsQCD() const{return m_btag_DeepBoosted_TvsQCD;}
-  float btag_DeepBoosted_ZHccvsQCD() const{return m_btag_DeepBoosted_ZHccvsQCD;}
   float btag_DeepBoosted_WvsQCD() const{return m_btag_DeepBoosted_WvsQCD;}
-  float btag_DeepBoosted_ZHbbvsQCD() const{return m_btag_DeepBoosted_ZHbbvsQCD;}
   float btag_DeepBoosted_ZvsQCD() const{return m_btag_DeepBoosted_ZvsQCD;}
   float btag_DeepBoosted_ZbbvsQCD() const{return m_btag_DeepBoosted_ZbbvsQCD;}
   float btag_DeepBoosted_HbbvsQCD() const{return m_btag_DeepBoosted_HbbvsQCD;}
@@ -330,12 +322,8 @@ class Jet : public FlavorParticle {
   void set_btag_MassIndependentDeepDoubleCvLJet_probHcc(float x) {  m_btag_MassIndependentDeepDoubleCvLJet_probHcc=x;}
   void set_btag_MassIndependentDeepDoubleCvLJet_probQCD(float x) {  m_btag_MassIndependentDeepDoubleCvLJet_probQCD=x;}
 
-  void set_btag_DeepBoosted_bbvsLight(float x){m_btag_DeepBoosted_bbvsLight=x;}
-  void set_btag_DeepBoosted_ccvsLight(float x){m_btag_DeepBoosted_ccvsLight=x;}
   void set_btag_DeepBoosted_TvsQCD(float x){m_btag_DeepBoosted_TvsQCD=x;}
-  void set_btag_DeepBoosted_ZHccvsQCD(float x){m_btag_DeepBoosted_ZHccvsQCD=x;}
   void set_btag_DeepBoosted_WvsQCD(float x){m_btag_DeepBoosted_WvsQCD=x;}
-  void set_btag_DeepBoosted_ZHbbvsQCD(float x){m_btag_DeepBoosted_ZHbbvsQCD=x;}
   void set_btag_DeepBoosted_ZvsQCD(float x) {m_btag_DeepBoosted_ZvsQCD=x;}
   void set_btag_DeepBoosted_ZbbvsQCD(float x) {m_btag_DeepBoosted_ZbbvsQCD=x;}
   void set_btag_DeepBoosted_HbbvsQCD(float x) {m_btag_DeepBoosted_HbbvsQCD=x;}
@@ -456,12 +444,8 @@ class Jet : public FlavorParticle {
   float m_btag_MassIndependentDeepDoubleCvLJet_probHcc;
   float m_btag_MassIndependentDeepDoubleCvLJet_probQCD;
 
-  float m_btag_DeepBoosted_bbvsLight;
-  float m_btag_DeepBoosted_ccvsLight;
   float m_btag_DeepBoosted_TvsQCD;
-  float m_btag_DeepBoosted_ZHccvsQCD;
   float m_btag_DeepBoosted_WvsQCD;
-  float m_btag_DeepBoosted_ZHbbvsQCD;
   float m_btag_DeepBoosted_probHbb;
   float m_btag_DeepBoosted_probQCDc;
   float m_btag_DeepBoosted_probQCDbb;

--- a/core/include/Jet.h
+++ b/core/include/Jet.h
@@ -64,6 +64,10 @@ class Jet : public FlavorParticle {
     m_btag_MassDecorrelatedDeepBoosted_ZHccvsQCD=-2;
     m_btag_MassDecorrelatedDeepBoosted_WvsQCD=-2;
     m_btag_MassDecorrelatedDeepBoosted_ZHbbvsQCD=-2;
+    m_btag_MassDecorrelatedDeepBoosted_ZvsQCD=-2;
+    m_btag_MassDecorrelatedDeepBoosted_ZbbvsQCD=-2;
+    m_btag_MassDecorrelatedDeepBoosted_HbbvsQCD=-2;
+    m_btag_MassDecorrelatedDeepBoosted_H4qvsQCD=-2;
     m_btag_MassDecorrelatedDeepBoosted_probHbb=-2;
     m_btag_MassDecorrelatedDeepBoosted_probQCDc=-2;
     m_btag_MassDecorrelatedDeepBoosted_probQCDbb=-2;
@@ -81,8 +85,31 @@ class Jet : public FlavorParticle {
     m_btag_MassDecorrelatedDeepBoosted_probZqq=-2;
     m_btag_MassDecorrelatedDeepBoosted_probHqqqq=-2;
     m_btag_MassDecorrelatedDeepBoosted_probZbb=-2;
-    m_btag_DeepDoubleB_probH=-2;
-    m_btag_DeepDoubleB_probQCD=-2;
+ 
+    m_btag_DeepDoubleBvLJet_probHbb=-2;
+    m_btag_DeepDoubleBvLJet_probQCD=-2;
+    m_btag_DeepDoubleCvBJet_probHbb=-2;
+    m_btag_DeepDoubleCvBJet_probHcc=-2;
+    m_btag_DeepDoubleCvLJet_probHcc=-2;
+    m_btag_DeepDoubleCvLJet_probQCD=-2;
+
+    m_btag_MassIndependentDeepDoubleBvLJet_probHbb=-2;
+    m_btag_MassIndependentDeepDoubleBvLJet_probQCD=-2;
+    m_btag_MassIndependentDeepDoubleCvBJet_probHbb=-2;
+    m_btag_MassIndependentDeepDoubleCvBJet_probHcc=-2;
+    m_btag_MassIndependentDeepDoubleCvLJet_probHcc=-2;
+    m_btag_MassIndependentDeepDoubleCvLJet_probQCD=-2;
+
+    m_btag_DeepBoosted_bbvsLight=-2;
+    m_btag_DeepBoosted_ccvsLight=-2;
+    m_btag_DeepBoosted_TvsQCD=-2;
+    m_btag_DeepBoosted_ZHccvsQCD=-2;
+    m_btag_DeepBoosted_WvsQCD=-2;
+    m_btag_DeepBoosted_ZHbbvsQCD=-2;
+    m_btag_DeepBoosted_ZvsQCD=-2;
+    m_btag_DeepBoosted_ZbbvsQCD=-2;
+    m_btag_DeepBoosted_HbbvsQCD=-2;
+    m_btag_DeepBoosted_H4qvsQCD=-2;
     m_btag_DeepBoosted_probHbb=-2;
     m_btag_DeepBoosted_probQCDc=-2;
     m_btag_DeepBoosted_probQCDbb=-2;
@@ -147,6 +174,13 @@ class Jet : public FlavorParticle {
   float btag_MassDecorrelatedDeepBoosted_ZHccvsQCD() const{return m_btag_MassDecorrelatedDeepBoosted_ZHccvsQCD;}
   float btag_MassDecorrelatedDeepBoosted_WvsQCD() const{return m_btag_MassDecorrelatedDeepBoosted_WvsQCD;}
   float btag_MassDecorrelatedDeepBoosted_ZHbbvsQCD() const{return m_btag_MassDecorrelatedDeepBoosted_ZHbbvsQCD;}
+
+  float btag_MassDecorrelatedDeepBoosted_ZvsQCD() const{return m_btag_MassDecorrelatedDeepBoosted_ZvsQCD;}
+  float btag_MassDecorrelatedDeepBoosted_ZbbvsQCD() const{return m_btag_MassDecorrelatedDeepBoosted_ZbbvsQCD;}
+  float btag_MassDecorrelatedDeepBoosted_HbbvsQCD() const{return m_btag_MassDecorrelatedDeepBoosted_HbbvsQCD;}
+  float btag_MassDecorrelatedDeepBoosted_H4qvsQCD() const{return m_btag_MassDecorrelatedDeepBoosted_H4qvsQCD;}
+
+
   float btag_MassDecorrelatedDeepBoosted_probHbb() const{return m_btag_MassDecorrelatedDeepBoosted_probHbb;}
   float btag_MassDecorrelatedDeepBoosted_probQCDc() const{return m_btag_MassDecorrelatedDeepBoosted_probQCDc;}
   float btag_MassDecorrelatedDeepBoosted_probQCDbb() const{return m_btag_MassDecorrelatedDeepBoosted_probQCDbb;}
@@ -164,8 +198,32 @@ class Jet : public FlavorParticle {
   float btag_MassDecorrelatedDeepBoosted_probZqq() const{return m_btag_MassDecorrelatedDeepBoosted_probZqq;}
   float btag_MassDecorrelatedDeepBoosted_probHqqqq() const{return m_btag_MassDecorrelatedDeepBoosted_probHqqqq;}
   float btag_MassDecorrelatedDeepBoosted_probZbb() const{return m_btag_MassDecorrelatedDeepBoosted_probZbb;}
-  float btag_DeepDoubleB_probH() const{return m_btag_DeepDoubleB_probH;}
-  float btag_DeepDoubleB_probQCD() const{return m_btag_DeepDoubleB_probQCD;}
+
+  float btag_DeepDoubleBvLJet_probHbb() const{return m_btag_DeepDoubleBvLJet_probHbb;}
+  float btag_DeepDoubleBvLJet_probQCD() const{return m_btag_DeepDoubleBvLJet_probQCD;}
+  float btag_DeepDoubleCvBJet_probHbb() const{return m_btag_DeepDoubleCvBJet_probHbb;}
+  float btag_DeepDoubleCvBJet_probHcc() const{return m_btag_DeepDoubleCvBJet_probHcc;}
+  float btag_DeepDoubleCvLJet_probHcc() const{return m_btag_DeepDoubleCvLJet_probHcc;}
+  float btag_DeepDoubleCvLJet_probQCD() const{return m_btag_DeepDoubleCvLJet_probQCD;}
+
+  float btag_MassIndependentDeepDoubleBvLJet_probHbb() const{return m_btag_MassIndependentDeepDoubleBvLJet_probHbb;}
+  float btag_MassIndependentDeepDoubleBvLJet_probQCD() const{return m_btag_MassIndependentDeepDoubleBvLJet_probQCD;}
+  float btag_MassIndependentDeepDoubleCvBJet_probHbb() const{return m_btag_MassIndependentDeepDoubleCvBJet_probHbb;}
+  float btag_MassIndependentDeepDoubleCvBJet_probHcc() const{return m_btag_MassIndependentDeepDoubleCvBJet_probHcc;}
+  float btag_MassIndependentDeepDoubleCvLJet_probHcc() const{return m_btag_MassIndependentDeepDoubleCvLJet_probHcc;}
+  float btag_MassIndependentDeepDoubleCvLJet_probQCD() const{return m_btag_MassIndependentDeepDoubleCvLJet_probQCD;}
+
+
+  float btag_DeepBoosted_bbvsLight() const{return m_btag_DeepBoosted_bbvsLight;}
+  float btag_DeepBoosted_ccvsLight() const{return m_btag_DeepBoosted_ccvsLight;}
+  float btag_DeepBoosted_TvsQCD() const{return m_btag_DeepBoosted_TvsQCD;}
+  float btag_DeepBoosted_ZHccvsQCD() const{return m_btag_DeepBoosted_ZHccvsQCD;}
+  float btag_DeepBoosted_WvsQCD() const{return m_btag_DeepBoosted_WvsQCD;}
+  float btag_DeepBoosted_ZHbbvsQCD() const{return m_btag_DeepBoosted_ZHbbvsQCD;}
+  float btag_DeepBoosted_ZvsQCD() const{return m_btag_DeepBoosted_ZvsQCD;}
+  float btag_DeepBoosted_ZbbvsQCD() const{return m_btag_DeepBoosted_ZbbvsQCD;}
+  float btag_DeepBoosted_HbbvsQCD() const{return m_btag_DeepBoosted_HbbvsQCD;}
+  float btag_DeepBoosted_H4qvsQCD() const{return m_btag_DeepBoosted_H4qvsQCD;}
   float btag_DeepBoosted_probHbb() const{return m_btag_DeepBoosted_probHbb;}
   float btag_DeepBoosted_probQCDc() const{return m_btag_DeepBoosted_probQCDc;}
   float btag_DeepBoosted_probQCDbb() const{return m_btag_DeepBoosted_probQCDbb;}
@@ -226,14 +284,22 @@ class Jet : public FlavorParticle {
   void set_btag_DeepFlavour_probc(float x){m_btag_DeepFlavour_probc=x;}
   void set_btag_DeepFlavour_probuds(float x){m_btag_DeepFlavour_probuds=x;}
   void set_btag_DeepFlavour_probg(float x){m_btag_DeepFlavour_probg=x;}
+
+
+
   void set_btag_MassDecorrelatedDeepBoosted_bbvsLight(float x){m_btag_MassDecorrelatedDeepBoosted_bbvsLight=x;}
   void set_btag_MassDecorrelatedDeepBoosted_ccvsLight(float x){m_btag_MassDecorrelatedDeepBoosted_ccvsLight=x;}
   void set_btag_MassDecorrelatedDeepBoosted_TvsQCD(float x){m_btag_MassDecorrelatedDeepBoosted_TvsQCD=x;}
   void set_btag_MassDecorrelatedDeepBoosted_ZHccvsQCD(float x){m_btag_MassDecorrelatedDeepBoosted_ZHccvsQCD=x;}
   void set_btag_MassDecorrelatedDeepBoosted_WvsQCD(float x){m_btag_MassDecorrelatedDeepBoosted_WvsQCD=x;}
   void set_btag_MassDecorrelatedDeepBoosted_ZHbbvsQCD(float x){m_btag_MassDecorrelatedDeepBoosted_ZHbbvsQCD=x;}
+  void set_btag_MassDecorrelatedDeepBoosted_ZvsQCD(float x) {m_btag_MassDecorrelatedDeepBoosted_ZvsQCD=x;}
+  void set_btag_MassDecorrelatedDeepBoosted_ZbbvsQCD(float x) {m_btag_MassDecorrelatedDeepBoosted_ZbbvsQCD=x;}
+  void set_btag_MassDecorrelatedDeepBoosted_HbbvsQCD(float x) {m_btag_MassDecorrelatedDeepBoosted_HbbvsQCD=x;}
+  void set_btag_MassDecorrelatedDeepBoosted_H4qvsQCD(float x) {m_btag_MassDecorrelatedDeepBoosted_H4qvsQCD=x;}
+
   void set_btag_MassDecorrelatedDeepBoosted_probHbb(float x){m_btag_MassDecorrelatedDeepBoosted_probHbb=x;}
-  void set_btag_MassDecorrelatedDeepBoosted_probQCD(float x) { m_btag_MassDecorrelatedDeepBoosted_probQCDc=x;}
+  void set_btag_MassDecorrelatedDeepBoosted_probQCDc(float x) { m_btag_MassDecorrelatedDeepBoosted_probQCDc=x;}
   void set_btag_MassDecorrelatedDeepBoosted_probQCDbb(float x) { m_btag_MassDecorrelatedDeepBoosted_probQCDbb=x;}
   void set_btag_MassDecorrelatedDeepBoosted_probTbqq(float x) { m_btag_MassDecorrelatedDeepBoosted_probTbqq=x;}
   void set_btag_MassDecorrelatedDeepBoosted_probTbcq(float x) { m_btag_MassDecorrelatedDeepBoosted_probTbcq=x;}
@@ -249,10 +315,34 @@ class Jet : public FlavorParticle {
   void set_btag_MassDecorrelatedDeepBoosted_probZqq(float x) { m_btag_MassDecorrelatedDeepBoosted_probZqq=x;}
   void set_btag_MassDecorrelatedDeepBoosted_probHqqqq(float x) { m_btag_MassDecorrelatedDeepBoosted_probHqqqq=x;}
   void set_btag_MassDecorrelatedDeepBoosted_probZbb(float x) { m_btag_MassDecorrelatedDeepBoosted_probZbb=x;}
-  void set_btag_DeepDoubleB_probH(float x) { m_btag_DeepDoubleB_probH=x;}
-  void set_btag_DeepDoubleB_probQCD(float x) { m_btag_DeepDoubleB_probQCD=x;}
+
+  void set_btag_DeepDoubleBvLJet_probHbb(float x) {  m_btag_DeepDoubleBvLJet_probHbb=x;}
+  void set_btag_DeepDoubleBvLJet_probQCD(float x) {  m_btag_DeepDoubleBvLJet_probQCD=x;}
+  void set_btag_DeepDoubleCvBJet_probHbb(float x) {  m_btag_DeepDoubleCvBJet_probHbb=x;}
+  void set_btag_DeepDoubleCvBJet_probHcc(float x) {  m_btag_DeepDoubleCvBJet_probHcc=x;}
+  void set_btag_DeepDoubleCvLJet_probHcc(float x) {  m_btag_DeepDoubleCvLJet_probHcc=x;}
+  void set_btag_DeepDoubleCvLJet_probQCD(float x) {  m_btag_DeepDoubleCvLJet_probQCD=x;}
+
+  void set_btag_MassIndependentDeepDoubleBvLJet_probHbb(float x) {  m_btag_MassIndependentDeepDoubleBvLJet_probHbb=x;}
+  void set_btag_MassIndependentDeepDoubleBvLJet_probQCD(float x) {  m_btag_MassIndependentDeepDoubleBvLJet_probQCD=x;}
+  void set_btag_MassIndependentDeepDoubleCvBJet_probHbb(float x) {  m_btag_MassIndependentDeepDoubleCvBJet_probHbb=x;}
+  void set_btag_MassIndependentDeepDoubleCvBJet_probHcc(float x) {  m_btag_MassIndependentDeepDoubleCvBJet_probHcc=x;}
+  void set_btag_MassIndependentDeepDoubleCvLJet_probHcc(float x) {  m_btag_MassIndependentDeepDoubleCvLJet_probHcc=x;}
+  void set_btag_MassIndependentDeepDoubleCvLJet_probQCD(float x) {  m_btag_MassIndependentDeepDoubleCvLJet_probQCD=x;}
+
+  void set_btag_DeepBoosted_bbvsLight(float x){m_btag_DeepBoosted_bbvsLight=x;}
+  void set_btag_DeepBoosted_ccvsLight(float x){m_btag_DeepBoosted_ccvsLight=x;}
+  void set_btag_DeepBoosted_TvsQCD(float x){m_btag_DeepBoosted_TvsQCD=x;}
+  void set_btag_DeepBoosted_ZHccvsQCD(float x){m_btag_DeepBoosted_ZHccvsQCD=x;}
+  void set_btag_DeepBoosted_WvsQCD(float x){m_btag_DeepBoosted_WvsQCD=x;}
+  void set_btag_DeepBoosted_ZHbbvsQCD(float x){m_btag_DeepBoosted_ZHbbvsQCD=x;}
+  void set_btag_DeepBoosted_ZvsQCD(float x) {m_btag_DeepBoosted_ZvsQCD=x;}
+  void set_btag_DeepBoosted_ZbbvsQCD(float x) {m_btag_DeepBoosted_ZbbvsQCD=x;}
+  void set_btag_DeepBoosted_HbbvsQCD(float x) {m_btag_DeepBoosted_HbbvsQCD=x;}
+  void set_btag_DeepBoosted_H4qvsQCD(float x) {m_btag_DeepBoosted_H4qvsQCD=x;}
+
   void set_btag_DeepBoosted_probHbb(float x){m_btag_DeepBoosted_probHbb=x;}
-  void set_btag_DeepBoosted_probQCD(float x) { m_btag_DeepBoosted_probQCDc=x;}
+  void set_btag_DeepBoosted_probQCDc(float x) { m_btag_DeepBoosted_probQCDc=x;}
   void set_btag_DeepBoosted_probQCDbb(float x) { m_btag_DeepBoosted_probQCDbb=x;}
   void set_btag_DeepBoosted_probTbqq(float x) { m_btag_DeepBoosted_probTbqq=x;}
   void set_btag_DeepBoosted_probTbcq(float x) { m_btag_DeepBoosted_probTbcq=x;}
@@ -268,7 +358,6 @@ class Jet : public FlavorParticle {
   void set_btag_DeepBoosted_probZqq(float x) { m_btag_DeepBoosted_probZqq=x;}
   void set_btag_DeepBoosted_probHqqqq(float x) { m_btag_DeepBoosted_probHqqqq=x;}
   void set_btag_DeepBoosted_probZbb(float x) { m_btag_DeepBoosted_probZbb=x;}
-
 
   void set_JEC_factor_raw(float x){m_JEC_factor_raw=x;}
   void set_JEC_L1factor_raw(float x){m_JEC_L1factor_raw=x;}
@@ -322,6 +411,19 @@ class Jet : public FlavorParticle {
   float m_btag_MassDecorrelatedDeepBoosted_ZHccvsQCD;
   float m_btag_MassDecorrelatedDeepBoosted_WvsQCD;
   float m_btag_MassDecorrelatedDeepBoosted_ZHbbvsQCD;
+
+  float m_btag_MassDecorrelatedDeepBoosted_ZvsQCD;
+  float m_btag_MassDecorrelatedDeepBoosted_ZbbvsQCD;
+  float m_btag_MassDecorrelatedDeepBoosted_HbbvsQCD;
+  float m_btag_MassDecorrelatedDeepBoosted_H4qvsQCD;
+
+  float m_btag_DeepBoosted_ZvsQCD;
+  float m_btag_DeepBoosted_ZbbvsQCD;
+  float m_btag_DeepBoosted_HbbvsQCD;
+  float m_btag_DeepBoosted_H4qvsQCD;
+
+
+
   float m_btag_MassDecorrelatedDeepBoosted_probHbb;
   float m_btag_MassDecorrelatedDeepBoosted_probQCDc;
   float m_btag_MassDecorrelatedDeepBoosted_probQCDbb;
@@ -339,8 +441,27 @@ class Jet : public FlavorParticle {
   float m_btag_MassDecorrelatedDeepBoosted_probZqq;
   float m_btag_MassDecorrelatedDeepBoosted_probHqqqq;
   float m_btag_MassDecorrelatedDeepBoosted_probZbb;
-  float m_btag_DeepDoubleB_probH;
-  float m_btag_DeepDoubleB_probQCD;
+
+  float m_btag_DeepDoubleBvLJet_probHbb;
+  float m_btag_DeepDoubleBvLJet_probQCD;
+  float m_btag_DeepDoubleCvBJet_probHbb;
+  float m_btag_DeepDoubleCvBJet_probHcc;
+  float m_btag_DeepDoubleCvLJet_probHcc;
+  float m_btag_DeepDoubleCvLJet_probQCD;
+
+  float m_btag_MassIndependentDeepDoubleBvLJet_probHbb;
+  float m_btag_MassIndependentDeepDoubleBvLJet_probQCD;
+  float m_btag_MassIndependentDeepDoubleCvBJet_probHbb;
+  float m_btag_MassIndependentDeepDoubleCvBJet_probHcc;
+  float m_btag_MassIndependentDeepDoubleCvLJet_probHcc;
+  float m_btag_MassIndependentDeepDoubleCvLJet_probQCD;
+
+  float m_btag_DeepBoosted_bbvsLight;
+  float m_btag_DeepBoosted_ccvsLight;
+  float m_btag_DeepBoosted_TvsQCD;
+  float m_btag_DeepBoosted_ZHccvsQCD;
+  float m_btag_DeepBoosted_WvsQCD;
+  float m_btag_DeepBoosted_ZHbbvsQCD;
   float m_btag_DeepBoosted_probHbb;
   float m_btag_DeepBoosted_probQCDc;
   float m_btag_DeepBoosted_probQCDbb;

--- a/core/plugins/NtupleWriterJets.cxx
+++ b/core/plugins/NtupleWriterJets.cxx
@@ -331,7 +331,15 @@ void NtupleWriterJets::fill_jet_info(uhh2::Event & uevent, const pat::Jet & pat_
   }//do taginfos
   if(do_btagging){
     const auto & bdisc = pat_jet.getPairDiscri();
-    bool csv = false, csvmva = false, doubleak8 = false, doubleca15 = false, deepcsv_b = false, deepcsv_bb = false, deepflavour_bb=false, deepflavour_b=false, deepflavour_lepb=false, deepflavour_c=false, deepflavour_uds=false, deepflavour_g=false, decorrmass_deepboosted_bbvsLight=false,decorrmass_deepboosted_ccvsLight=false,decorrmass_deepboosted_TvsQCD=false,decorrmass_deepboosted_ZHccvsQCD=false,decorrmass_deepboosted_WvsQCD=false,decorrmass_deepboosted_ZHbbvsQCD=false,deepboosted_probHbb=false,deepboosted_probQCDbb=false,deepboosted_probQCDc=false,deepboosted_probTbqq=false,deepboosted_probTbcq=false,deepboosted_probTbq=false,deepboosted_probQCDothers=false,deepboosted_probQCDb=false,deepboosted_probTbc=false,deepboosted_probWqq=false,deepboosted_probQCDcc=false,deepboosted_probHcc=false,deepboosted_probWcq=false,deepboosted_probZcc=false,deepboosted_probZqq=false,deepboosted_probHqqqq=false,deepboosted_probZbb=false,deepdouble_H=false,deepdouble_QCD=false,decorrmass_deepboosted_probHbb=false,decorrmass_deepboosted_probQCDbb=false,decorrmass_deepboosted_probQCDc=false,decorrmass_deepboosted_probTbqq=false,decorrmass_deepboosted_probTbcq=false,decorrmass_deepboosted_probTbq=false,decorrmass_deepboosted_probQCDothers=false,decorrmass_deepboosted_probQCDb=false,decorrmass_deepboosted_probTbc=false,decorrmass_deepboosted_probWqq=false,decorrmass_deepboosted_probQCDcc=false,decorrmass_deepboosted_probHcc=false,decorrmass_deepboosted_probWcq=false,decorrmass_deepboosted_probZcc=false,decorrmass_deepboosted_probZqq=false,decorrmass_deepboosted_probHqqqq=false,decorrmass_deepboosted_probZbb=false;
+    bool csv = false, csvmva = false, doubleak8 = false, doubleca15 = false, deepcsv_b = false, deepcsv_bb = false, deepflavour_bb=false, deepflavour_b=false, deepflavour_lepb=false, deepflavour_c=false, deepflavour_uds=false, deepflavour_g=false, 
+decorrmass_deepboosted_bbvsLight=false,decorrmass_deepboosted_ccvsLight=false,decorrmass_deepboosted_TvsQCD=false,decorrmass_deepboosted_ZHccvsQCD=false,decorrmass_deepboosted_WvsQCD=false,decorrmass_deepboosted_ZHbbvsQCD=false,
+decorrmass_deepboosted_ZvsQCD=false,decorrmass_deepboosted_ZbbvsQCD=false,decorrmass_deepboosted_HbbvsQCD=false,decorrmass_deepboosted_H4qvsQCD=false,
+deepboosted_bbvsLight=false,deepboosted_ccvsLight=false,deepboosted_TvsQCD=false,deepboosted_ZHccvsQCD=false,deepboosted_WvsQCD=false,deepboosted_ZHbbvsQCD=false,
+deepboosted_ZvsQCD=false,deepboosted_ZbbvsQCD=false,deepboosted_HbbvsQCD=false,deepboosted_H4qvsQCD=false,
+deepboosted_probHbb=false,deepboosted_probQCDbb=false,deepboosted_probQCDc=false,deepboosted_probTbqq=false,deepboosted_probTbcq=false,deepboosted_probTbq=false,deepboosted_probQCDothers=false,deepboosted_probQCDb=false,deepboosted_probTbc=false,deepboosted_probWqq=false,deepboosted_probQCDcc=false,deepboosted_probHcc=false,deepboosted_probWcq=false,deepboosted_probZcc=false,deepboosted_probZqq=false,deepboosted_probHqqqq=false,deepboosted_probZbb=false,
+deepdouble_H=false,deepdouble_QCD=false, deepdouble_cl_H=false,deepdouble_cl_QCD=false, deepdouble_cb_H=false,deepdouble_cb_QCD=false,
+massinddeepdouble_H=false,massinddeepdouble_QCD=false, massinddeepdouble_cl_H=false,massinddeepdouble_cl_QCD=false, massinddeepdouble_cb_H=false,massinddeepdouble_cb_QCD=false,
+decorrmass_deepboosted_probHbb=false,decorrmass_deepboosted_probQCDbb=false,decorrmass_deepboosted_probQCDc=false,decorrmass_deepboosted_probTbqq=false,decorrmass_deepboosted_probTbcq=false,decorrmass_deepboosted_probTbq=false,decorrmass_deepboosted_probQCDothers=false,decorrmass_deepboosted_probQCDb=false,decorrmass_deepboosted_probTbc=false,decorrmass_deepboosted_probWqq=false,decorrmass_deepboosted_probQCDcc=false,decorrmass_deepboosted_probHcc=false,decorrmass_deepboosted_probWcq=false,decorrmass_deepboosted_probZcc=false,decorrmass_deepboosted_probZqq=false,decorrmass_deepboosted_probHqqqq=false,decorrmass_deepboosted_probZbb=false;
     for(const auto & name_value : bdisc){
       const auto & name = name_value.first;
       const auto & value = name_value.second;
@@ -407,12 +415,28 @@ void NtupleWriterJets::fill_jet_info(uhh2::Event & uevent, const pat::Jet & pat_
         jet.set_btag_MassDecorrelatedDeepBoosted_ZHbbvsQCD(value);
         decorrmass_deepboosted_ZHbbvsQCD=true;
       }
+      else if(name == "pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:ZvsQCD"){
+        jet.set_btag_MassDecorrelatedDeepBoosted_ZvsQCD(value);
+        decorrmass_deepboosted_ZvsQCD=true;
+      }
+      else if(name == "pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:ZbbvsQCD"){
+        jet.set_btag_MassDecorrelatedDeepBoosted_ZbbvsQCD(value);
+        decorrmass_deepboosted_ZbbvsQCD=true;
+      }
+      else if(name == "pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:HbbvsQCD"){
+        jet.set_btag_MassDecorrelatedDeepBoosted_HbbvsQCD(value);
+        decorrmass_deepboosted_HbbvsQCD=true;
+      }
+      else if(name == "pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:H4qvsQCD"){
+        jet.set_btag_MassDecorrelatedDeepBoosted_H4qvsQCD(value);
+        decorrmass_deepboosted_H4qvsQCD=true;
+      }
       else if(name == "pfMassDecorrelatedDeepBoostedJetTags:probHbb"){
         jet.set_btag_MassDecorrelatedDeepBoosted_probHbb(value);
         decorrmass_deepboosted_probHbb=true;
       }
-      else if(name == "pfMassDecorrelatedDeepBoostedJetTags:probQCD"){
-        jet.set_btag_MassDecorrelatedDeepBoosted_probQCD(value);
+      else if(name == "pfMassDecorrelatedDeepBoostedJetTags:probQCDc"){
+        jet.set_btag_MassDecorrelatedDeepBoosted_probQCDc(value);
         decorrmass_deepboosted_probQCDc=true;
       }
       else if(name == "pfMassDecorrelatedDeepBoostedJetTags:probQCDbb"){
@@ -479,20 +503,100 @@ void NtupleWriterJets::fill_jet_info(uhh2::Event & uevent, const pat::Jet & pat_
         jet.set_btag_MassDecorrelatedDeepBoosted_probZbb(value);
         decorrmass_deepboosted_probZbb=true;
       }
-      else if(name=="pfDeepDoubleBJetTags:probH"){
-        jet.set_btag_DeepDoubleB_probH(value);
+      else if(name=="pfDeepDoubleBvLJetTags:probHbb"){
+        jet.set_btag_DeepDoubleBvLJet_probHbb(value);
         deepdouble_H = true;
       }
-      else if(name=="pfDeepDoubleBJetTags:probQCD"){
-        jet.set_btag_DeepDoubleB_probQCD(value);
+      else if(name=="pfDeepDoubleBvLJetTags:probQCD"){
+        jet.set_btag_DeepDoubleBvLJet_probQCD(value);
         deepdouble_QCD = true;
+      }
+      else if(name=="pfDeepDoubleCvBJetTags:probHbb"){
+        jet.set_btag_DeepDoubleCvBJet_probHbb(value);
+        deepdouble_cb_H = true;
+      }
+      else if(name=="pfDeepDoubleCvBJetTags:probHcc"){
+        jet.set_btag_DeepDoubleCvBJet_probHcc(value);
+        deepdouble_cb_QCD = true;
+      }
+      else if(name=="pfDeepDoubleCvLJetTags:probHcc"){
+        jet.set_btag_DeepDoubleCvLJet_probHcc(value);
+        deepdouble_cl_H = true;
+      }
+      else if(name=="pfDeepDoubleCvLJetTags:probQCD"){
+        jet.set_btag_DeepDoubleCvLJet_probQCD(value);
+        deepdouble_cl_QCD = true;
+      }
+      else if(name=="pfMassIndependentDeepDoubleBvLJetTags:probHbb"){
+        jet.set_btag_MassIndependentDeepDoubleBvLJet_probHbb(value);
+        massinddeepdouble_H = true;
+      }
+      else if(name=="pfMassIndependentDeepDoubleBvLJetTags:probQCD"){
+        jet.set_btag_MassIndependentDeepDoubleBvLJet_probQCD(value);
+        massinddeepdouble_QCD = true;
+      }
+      else if(name=="pfMassIndependentDeepDoubleCvBJetTags:probHbb"){
+        jet.set_btag_MassIndependentDeepDoubleCvBJet_probHbb(value);
+        massinddeepdouble_cb_H = true;
+      }
+      else if(name=="pfMassIndependentDeepDoubleCvBJetTags:probHcc"){
+        jet.set_btag_MassIndependentDeepDoubleCvBJet_probHcc(value);
+        massinddeepdouble_cb_QCD = true;
+      }
+      else if(name=="pfMassIndependentDeepDoubleCvLJetTags:probHcc"){
+        jet.set_btag_MassIndependentDeepDoubleCvLJet_probHcc(value);
+        massinddeepdouble_cl_H = true;
+      }
+      else if(name=="pfMassIndependentDeepDoubleCvLJetTags:probQCD"){
+        jet.set_btag_MassIndependentDeepDoubleCvLJet_probQCD(value);
+        massinddeepdouble_cl_QCD = true;
+      }
+      else if(name == "pfDeepBoostedDiscriminatorsJetTags:bbvsLight"){
+        jet.set_btag_DeepBoosted_bbvsLight(value);
+        deepboosted_bbvsLight=true;
+      }
+      else if(name == "pfDeepBoostedDiscriminatorsJetTags:ccvsLight"){
+        jet.set_btag_DeepBoosted_ccvsLight(value);
+        deepboosted_ccvsLight=true;
+      }
+      else if(name == "pfDeepBoostedDiscriminatorsJetTags:TvsQCD"){
+        jet.set_btag_DeepBoosted_TvsQCD(value);
+        deepboosted_TvsQCD=true;
+      }
+      else if(name == "pfDeepBoostedDiscriminatorsJetTags:ZHccvsQCD"){
+        jet.set_btag_DeepBoosted_ZHccvsQCD(value);
+        deepboosted_ZHccvsQCD=true;
+      }
+      else if(name == "pfDeepBoostedDiscriminatorsJetTags:WvsQCD"){
+        jet.set_btag_DeepBoosted_WvsQCD(value);
+        deepboosted_WvsQCD=true;
+      }
+      else if(name == "pfDeepBoostedDiscriminatorsJetTags:ZHbbvsQCD"){
+        jet.set_btag_DeepBoosted_ZHbbvsQCD(value);
+        deepboosted_ZHbbvsQCD=true;
+      }
+      else if(name == "pfDeepBoostedDiscriminatorsJetTags:ZvsQCD"){
+        jet.set_btag_DeepBoosted_ZvsQCD(value);
+        deepboosted_ZvsQCD=true;
+      }
+      else if(name == "pfDeepBoostedDiscriminatorsJetTags:ZbbvsQCD"){
+        jet.set_btag_DeepBoosted_ZbbvsQCD(value);
+        deepboosted_ZbbvsQCD=true;
+      }
+      else if(name == "pfDeepBoostedDiscriminatorsJetTags:HbbvsQCD"){
+        jet.set_btag_DeepBoosted_HbbvsQCD(value);
+        deepboosted_HbbvsQCD=true;
+      }
+      else if(name == "pfDeepBoostedDiscriminatorsJetTags:H4qvsQCD"){
+        jet.set_btag_DeepBoosted_H4qvsQCD(value);
+        deepboosted_H4qvsQCD=true;
       }
       else if(name == "pfDeepBoostedJetTags:probHbb"){
         jet.set_btag_DeepBoosted_probHbb(value);
         deepboosted_probHbb=true;
       }
-      else if(name == "pfDeepBoostedJetTags:probQCD"){
-        jet.set_btag_DeepBoosted_probQCD(value);
+      else if(name == "pfDeepBoostedJetTags:probQCDc"){
+        jet.set_btag_DeepBoosted_probQCDc(value);
         deepboosted_probQCDc=true;
       }
       else if(name == "pfDeepBoostedJetTags:probQCDbb"){
@@ -562,20 +666,26 @@ void NtupleWriterJets::fill_jet_info(uhh2::Event & uevent, const pat::Jet & pat_
 
     }
 
-
     if(!csv || !csvmva || !doubleak8 || !doubleca15 || !deepcsv_b || !deepcsv_bb
        || !deepflavour_bb || !deepflavour_b || !deepflavour_lepb
        || !deepflavour_uds || !deepflavour_c || !deepflavour_g
        || !decorrmass_deepboosted_bbvsLight || !decorrmass_deepboosted_ccvsLight
        || !decorrmass_deepboosted_TvsQCD || !decorrmass_deepboosted_ZHccvsQCD
        || !decorrmass_deepboosted_WvsQCD || !decorrmass_deepboosted_ZHbbvsQCD
+       || !decorrmass_deepboosted_ZvsQCD || !decorrmass_deepboosted_ZbbvsQCD || !decorrmass_deepboosted_HbbvsQCD || !decorrmass_deepboosted_H4qvsQCD
+       || !deepboosted_bbvsLight || !deepboosted_ccvsLight
+       || !deepboosted_TvsQCD || !deepboosted_ZHccvsQCD
+       || !deepboosted_WvsQCD || !deepboosted_ZHbbvsQCD
+       || !deepboosted_ZvsQCD || !deepboosted_ZbbvsQCD || !deepboosted_HbbvsQCD || !deepboosted_H4qvsQCD
        || !deepboosted_probHbb || !deepboosted_probQCDbb || !deepboosted_probQCDc
        || !deepboosted_probTbqq || !deepboosted_probTbcq || !deepboosted_probTbq
        || !deepboosted_probQCDothers || !deepboosted_probQCDb || !deepboosted_probTbc
        || !deepboosted_probWqq || !deepboosted_probQCDcc || !deepboosted_probHcc
        || !deepboosted_probWcq || !deepboosted_probZcc || !deepboosted_probZqq
-       || !deepboosted_probHqqqq || !deepboosted_probZbb || !deepdouble_H
-       || !deepdouble_QCD || !decorrmass_deepboosted_probHbb || !decorrmass_deepboosted_probQCDbb
+       || !deepboosted_probHqqqq || !deepboosted_probZbb 
+       || !deepdouble_H || !deepdouble_QCD || !deepdouble_cb_H || !deepdouble_cl_H || !deepdouble_cl_QCD  || !deepdouble_cb_QCD
+       || !massinddeepdouble_QCD || !massinddeepdouble_H || !massinddeepdouble_cb_H || !massinddeepdouble_cl_H || !massinddeepdouble_cl_QCD  || !massinddeepdouble_cb_QCD
+       || !decorrmass_deepboosted_probHbb || !decorrmass_deepboosted_probQCDbb
        || !decorrmass_deepboosted_probQCDc || !decorrmass_deepboosted_probTbqq
        || !decorrmass_deepboosted_probTbcq || !decorrmass_deepboosted_probTbq
        || !decorrmass_deepboosted_probQCDothers || !decorrmass_deepboosted_probQCDb

--- a/core/plugins/NtupleWriterJets.cxx
+++ b/core/plugins/NtupleWriterJets.cxx
@@ -551,30 +551,30 @@ decorrmass_deepboosted_probHbb=false,decorrmass_deepboosted_probQCDbb=false,deco
         jet.set_btag_MassIndependentDeepDoubleCvLJet_probQCD(value);
         massinddeepdouble_cl_QCD = true;
       }
-      else if(name == "pfDeepBoostedDiscriminatorsJetTags:bbvsLight"){
-        jet.set_btag_DeepBoosted_bbvsLight(value);
-        deepboosted_bbvsLight=true;
-      }
-      else if(name == "pfDeepBoostedDiscriminatorsJetTags:ccvsLight"){
-        jet.set_btag_DeepBoosted_ccvsLight(value);
-        deepboosted_ccvsLight=true;
-      }
+      // else if(name == "pfDeepBoostedDiscriminatorsJetTags:bbvsLight"){
+      //   jet.set_btag_DeepBoosted_bbvsLight(value);
+      //   deepboosted_bbvsLight=true;
+      // }
+      // else if(name == "pfDeepBoostedDiscriminatorsJetTags:ccvsLight"){
+      //   jet.set_btag_DeepBoosted_ccvsLight(value);
+      //   deepboosted_ccvsLight=true;
+      // }
       else if(name == "pfDeepBoostedDiscriminatorsJetTags:TvsQCD"){
         jet.set_btag_DeepBoosted_TvsQCD(value);
         deepboosted_TvsQCD=true;
       }
-      else if(name == "pfDeepBoostedDiscriminatorsJetTags:ZHccvsQCD"){
-        jet.set_btag_DeepBoosted_ZHccvsQCD(value);
-        deepboosted_ZHccvsQCD=true;
-      }
+      // else if(name == "pfDeepBoostedDiscriminatorsJetTags:ZHccvsQCD"){
+      //   jet.set_btag_DeepBoosted_ZHccvsQCD(value);
+      //   deepboosted_ZHccvsQCD=true;
+      // }
       else if(name == "pfDeepBoostedDiscriminatorsJetTags:WvsQCD"){
         jet.set_btag_DeepBoosted_WvsQCD(value);
         deepboosted_WvsQCD=true;
       }
-      else if(name == "pfDeepBoostedDiscriminatorsJetTags:ZHbbvsQCD"){
-        jet.set_btag_DeepBoosted_ZHbbvsQCD(value);
-        deepboosted_ZHbbvsQCD=true;
-      }
+      // else if(name == "pfDeepBoostedDiscriminatorsJetTags:ZHbbvsQCD"){
+      //   jet.set_btag_DeepBoosted_ZHbbvsQCD(value);
+      //   deepboosted_ZHbbvsQCD=true;
+      // }
       else if(name == "pfDeepBoostedDiscriminatorsJetTags:ZvsQCD"){
         jet.set_btag_DeepBoosted_ZvsQCD(value);
         deepboosted_ZvsQCD=true;

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -988,6 +988,20 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
         'pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:ZHccvsQCD',
         'pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:WvsQCD',
         'pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:ZHbbvsQCD',
+        'pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:H4qvsQCD',
+        'pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:HbbvsQCD',
+        'pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:ZbbvsQCD',
+        'pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:ZvsQCD',
+#        'pfDeepBoostedDiscriminatorsJetTags:bbvsLight',
+ #       'pfDeepBoostedDiscriminatorsJetTags:ccvsLight',
+        'pfDeepBoostedDiscriminatorsJetTags:TvsQCD',
+#        'pfDeepBoostedDiscriminatorsJetTags:ZHccvsQCD',
+        'pfDeepBoostedDiscriminatorsJetTags:WvsQCD',
+#        'pfDeepBoostedDiscriminatorsJetTags:ZHbbvsQCD',
+        'pfDeepBoostedDiscriminatorsJetTags:H4qvsQCD',
+        'pfDeepBoostedDiscriminatorsJetTags:HbbvsQCD',
+        'pfDeepBoostedDiscriminatorsJetTags:ZbbvsQCD',
+        'pfDeepBoostedDiscriminatorsJetTags:ZvsQCD',
 
         'pfMassDecorrelatedDeepBoostedJetTags:probHbb',
         'pfMassDecorrelatedDeepBoostedJetTags:probQCDc',
@@ -1006,10 +1020,18 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
         'pfMassDecorrelatedDeepBoostedJetTags:probZqq',
         'pfMassDecorrelatedDeepBoostedJetTags:probHqqqq',
         'pfMassDecorrelatedDeepBoostedJetTags:probZbb',
-
-        'pfDeepDoubleBJetTags:probH',
-        'pfDeepDoubleBJetTags:probQ',
-
+        'pfDeepDoubleBvLJetTags:probHbb',
+        'pfDeepDoubleBvLJetTags:probQCD',
+        'pfDeepDoubleCvBJetTags:probHbb',
+        'pfDeepDoubleCvBJetTags:probHcc',
+        'pfDeepDoubleCvLJetTags:probHcc',
+        'pfDeepDoubleCvLJetTags:probQCD',
+        'pfMassIndependentDeepDoubleBvLJetTags:probHbb',
+        'pfMassIndependentDeepDoubleBvLJetTags:probQCD',
+        'pfMassIndependentDeepDoubleCvBJetTags:probHbb',
+        'pfMassIndependentDeepDoubleCvBJetTags:probHcc',
+        'pfMassIndependentDeepDoubleCvLJetTags:probHcc',
+        'pfMassIndependentDeepDoubleCvLJetTags:probQCD',
         'pfDeepBoostedJetTags:probHbb',
         'pfDeepBoostedJetTags:probQCDc',
         'pfDeepBoostedJetTags:probQCDbb',
@@ -1059,10 +1081,13 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
 
         if is_ak8 and is_puppi:
             correction_tag = "AK8PFPuppi"
+        elif is_ak8 and not is_puppi:
+            correction_tag = "AK8PFchs"
         elif not is_ak8 and is_puppi:
             correction_tag = "AK4PFPuppi"
         elif not is_ak8 and not is_puppi:
             correction_tag = "AK4PFchs"
+
         else:
             raise RuntimeError("No idea which jet correction tag you need here")
 


### PR DESCRIPTION
Add missing variable for b-tagging as suggested in [1].
Also fixed DeepDoubleB_probQCD in DeepDoubleBJetTags 
Useful links:
- BTV Summary, Dec.2018
https://indico.cern.ch/event/777545/contributions/3234584/attachments/1766808/2869123/BTV_CMS_Week.pdf

- DeepDoubleBJetTags
https://cmssdt.cern.ch/lxr/source/PhysicsTools/PatAlgos/python/recoLayer0/bTagging_cff.py?%21v=CMSSW_10_2_0

- DeepBoostedJetTags
https://twiki.cern.ch/twiki/bin/view/CMS/DeepAKXTagging
https://cmssdt.cern.ch/lxr/source/RecoBTag/MXNet/plugins/DeepBoostedJetTagsProducer.cc

NB: DeepDoubleX and DeepBoostedJet seems to work only for AK8PUPPI, for CHS are not filled even if added to the "updateJetCollection" list.

[1] https://github.com/UHH2/UHH2/pull/1117#issuecomment-460931570