### PR TITLE
[102X] add Photons 

### DIFF
--- a/core/include/Photon.h
+++ b/core/include/Photon.h
@@ -40,15 +40,25 @@ public:
   }
   
   Photon(){
-    m_vertex_x = 0; 
-    m_vertex_y = 0; 
-    m_vertex_z = 0; 
-    m_supercluster_eta = 0; 
-    m_supercluster_phi = 0; 
-    //    m_trackIso = 0;
-    m_puppiChargedHadronIso = 0;
-    m_puppiNeutralHadronIso = 0;
-    m_puppiPhotonIso = 0;
+    m_vertex_x = -1e4; 
+    m_vertex_y = -1e4; 
+    m_vertex_z = -1e4; 
+    m_supercluster_eta = -1e4; 
+    m_supercluster_phi = -1e4; 
+
+    m_puppiChargedHadronIso = -1;
+    m_puppiNeutralHadronIso = -1;
+    m_puppiPhotonIso = -1;
+    m_trackIso =-1;
+    m_ecalIso =-1;
+    m_hcalIso =-1;
+    m_caloIso =-1;
+    m_patParticleIso =-1;
+    m_chargedHadronIso =-1;
+    m_neutralHadronIso =-1;
+    m_photonIso =-1;
+    m_puChargedHadronIso =-1;
+
     m_source_candidates.clear();
   }
 
@@ -62,6 +72,16 @@ public:
   float puppiNeutralHadronIso() const{return m_puppiNeutralHadronIso;} 
   float puppiPhotonIso() const{return m_puppiPhotonIso;} 
 
+  float trackIso() const{return m_trackIso;}
+  float ecalIso() const{return m_ecalIso;}
+  float hcalIso() const{return m_hcalIso;}
+  float caloIso() const{return m_caloIso;}
+  float patParticleIso() const{return m_patParticleIso;}
+  float chargedHadronIso() const{return m_chargedHadronIso;}
+  float neutralHadronIso() const{return m_neutralHadronIso;}
+  float photonIso() const{return m_photonIso;}
+  float puChargedHadronIso() const{return m_puChargedHadronIso;}
+
   
   //  float get_tag(tag t) const{ return tags.get_tag(static_cast<int>(t));}
 
@@ -70,10 +90,20 @@ public:
   void set_vertex_z(float x){m_vertex_z=x;} 
   void set_supercluster_eta(float x){m_supercluster_eta=x;} 
   void set_supercluster_phi(float x){m_supercluster_phi=x;} 
-  //  void set_trackIso(float x){m_trackIso=x;} 
+
   void set_puppiChargedHadronIso(float x){m_puppiChargedHadronIso=x;} 
   void set_puppiNeutralHadronIso(float x){m_puppiNeutralHadronIso=x;} 
   void set_puppiPhotonIso(float x){m_puppiPhotonIso=x;} 
+
+  void set_trackIso(float x){m_trackIso =x;}
+  void set_ecalIso(float x){m_ecalIso =x;}
+  void set_hcalIso(float x){m_hcalIso =x;}
+  void set_caloIso(float x){m_caloIso =x;}
+  void set_patParticleIso(float x){m_patParticleIso =x;}
+  void set_chargedHadronIso(float x){m_chargedHadronIso =x;}
+  void set_neutralHadronIso(float x){m_neutralHadronIso =x;}
+  void set_photonIso(float x){m_photonIso =x;}
+  void set_puChargedHadronIso(float x){m_puChargedHadronIso =x;}
   
   //  void set_tag(tag t, float value){tags.set_tag(static_cast<int>(t), value);}
 
@@ -96,6 +126,15 @@ private:
   float m_puppiNeutralHadronIso;
   float m_puppiPhotonIso;
 
+  float m_trackIso;
+  float m_ecalIso;
+  float m_hcalIso;
+  float m_caloIso;
+  float m_patParticleIso;
+  float m_chargedHadronIso;
+  float m_neutralHadronIso;
+  float m_photonIso;
+  float m_puChargedHadronIso;
 
   std::vector<source_candidate> m_source_candidates;
 

--- a/core/include/Photon.h
+++ b/core/include/Photon.h
@@ -1,12 +1,43 @@
 #pragma once
 
-#include "Particle.h"
+#include "RecParticle.h"
 #include "Tags.h"
+#include "FlavorParticle.h"
+#include "source_candidate.h"
+#include <vector>
 
-class Photon: public Particle{
+
+class Photon : public RecParticle {
 public:
     
-  enum tag { /* for future use */};
+  enum tag {
+    // 2016
+    cutBasedPhotonID_Spring16_V2p2_loose,
+    cutBasedPhotonID_Spring16_V2p2_medium,
+    cutBasedPhotonID_Spring16_V2p2_tight,
+    mvaPhoID_Spring16_nonTrig_V1_wp90,
+    mvaPhoID_Spring16_nonTrig_V1_wp80,
+    // 2017 & 2018
+    cutBasedPhotonID_Fall17_94X_V2_loose,
+    cutBasedPhotonID_Fall17_94X_V2_medium,
+    cutBasedPhotonID_Fall17_94X_V2_tight,
+    mvaPhoID_Fall17_iso_V2_wp90,
+    mvaPhoID_Fall17_iso_V2_wp80
+  };
+
+  static tag tagname2tag(const std::string & tagname){
+    if(tagname == "cutBasedPhotonID_Spring16_V2p2_loose") return cutBasedPhotonID_Spring16_V2p2_loose;
+    if(tagname == "cutBasedPhotonID_Spring16_V2p2_medium") return cutBasedPhotonID_Spring16_V2p2_medium;
+    if(tagname == "cutBasedPhotonID_Spring16_V2p2_tight") return cutBasedPhotonID_Spring16_V2p2_tight;
+    if(tagname == "mvaPhoID_Spring16_nonTrig_V1_wp90") return mvaPhoID_Spring16_nonTrig_V1_wp90;
+    if(tagname == "mvaPhoID_Spring16_nonTrig_V1_wp80") return mvaPhoID_Spring16_nonTrig_V1_wp80;
+    if(tagname == "cutBasedPhotonID_Fall17_94X_V2_loose") return cutBasedPhotonID_Fall17_94X_V2_loose;
+    if(tagname == "cutBasedPhotonID_Fall17_94X_V2_medium") return cutBasedPhotonID_Fall17_94X_V2_medium;
+    if(tagname == "cutBasedPhotonID_Fall17_94X_V2_tight") return cutBasedPhotonID_Fall17_94X_V2_tight;
+    if(tagname == "mvaPhoID_Fall17_iso_V2_wp90") return mvaPhoID_Fall17_iso_V2_wp90;
+    if(tagname == "mvaPhoID_Fall17_iso_V2_wp80") return mvaPhoID_Fall17_iso_V2_wp80;
+    throw std::runtime_error("unknown Photon::tag '" + tagname + "'");
+  }
   
   Photon(){
     m_vertex_x = 0; 
@@ -14,7 +45,11 @@ public:
     m_vertex_z = 0; 
     m_supercluster_eta = 0; 
     m_supercluster_phi = 0; 
-    m_trackIso = 0;
+    //    m_trackIso = 0;
+    m_puppiChargedHadronIso = 0;
+    m_puppiNeutralHadronIso = 0;
+    m_puppiPhotonIso = 0;
+    m_source_candidates.clear();
   }
 
   float vertex_x() const{return m_vertex_x;} 
@@ -22,26 +57,47 @@ public:
   float vertex_z() const{return m_vertex_z;} 
   float supercluster_eta() const{return m_supercluster_eta;} 
   float supercluster_phi() const{return m_supercluster_phi;} 
-  float trackIso() const{return m_trackIso;} 
+  //  float trackIso() const{return m_trackIso;} 
+  float puppiChargedHadronIso() const{return m_puppiChargedHadronIso;} 
+  float puppiNeutralHadronIso() const{return m_puppiNeutralHadronIso;} 
+  float puppiPhotonIso() const{return m_puppiPhotonIso;} 
+
   
-  float get_tag(tag t) const{ return tags.get_tag(static_cast<int>(t));}
+  //  float get_tag(tag t) const{ return tags.get_tag(static_cast<int>(t));}
 
   void set_vertex_x(float x){m_vertex_x=x;} 
   void set_vertex_y(float x){m_vertex_y=x;} 
   void set_vertex_z(float x){m_vertex_z=x;} 
   void set_supercluster_eta(float x){m_supercluster_eta=x;} 
   void set_supercluster_phi(float x){m_supercluster_phi=x;} 
-  void set_trackIso(float x){m_trackIso=x;} 
+  //  void set_trackIso(float x){m_trackIso=x;} 
+  void set_puppiChargedHadronIso(float x){m_puppiChargedHadronIso=x;} 
+  void set_puppiNeutralHadronIso(float x){m_puppiNeutralHadronIso=x;} 
+  void set_puppiPhotonIso(float x){m_puppiPhotonIso=x;} 
   
-  void set_tag(tag t, float value){tags.set_tag(static_cast<int>(t), value);}
- 
+  //  void set_tag(tag t, float value){tags.set_tag(static_cast<int>(t), value);}
+
+  void set_source_candidates(const std::vector<source_candidate>& vsc){ m_source_candidates = vsc; }
+  void add_source_candidate (const source_candidate& sc){ m_source_candidates.push_back(sc); }
+
+  bool  has_tag(tag t) const { return tags.has_tag(static_cast<int>(t)); }
+  float get_tag(tag t) const { return tags.get_tag(static_cast<int>(t)); }
+  void  set_tag(tag t, float value) { tags.set_tag(static_cast<int>(t), value);}
+
 private:
   float m_vertex_x;
   float m_vertex_y;
   float m_vertex_z;
   float m_supercluster_eta;
   float m_supercluster_phi;
-  float m_trackIso;
-  
+  //  float m_trackIso;
+
+  float m_puppiChargedHadronIso;
+  float m_puppiNeutralHadronIso;
+  float m_puppiPhotonIso;
+
+
+  std::vector<source_candidate> m_source_candidates;
+
   Tags tags;
 };

--- a/core/plugins/NtupleWriterLeptons.cxx
+++ b/core/plugins/NtupleWriterLeptons.cxx
@@ -4,6 +4,7 @@
 #include "UHH2/core/include/AnalysisModule.h"
 
 #include "DataFormats/PatCandidates/interface/Electron.h"
+#include "DataFormats/PatCandidates/interface/Photon.h"
 #include "DataFormats/PatCandidates/interface/Muon.h"
 #include "DataFormats/PatCandidates/interface/Tau.h"
 
@@ -137,6 +138,77 @@ void NtupleWriterElectrons::process(const edm::Event & event, uhh2::Event & ueve
     }
 }
 
+
+
+
+// Photons ----------------
+NtupleWriterPhotons::NtupleWriterPhotons(Config & cfg, bool set_photons_member, const bool save_source_cands): save_source_candidates_(save_source_cands){
+  handle = cfg.ctx.declare_event_output<vector<Photon>>(cfg.dest_branchname, cfg.dest);
+  if(set_photons_member) photons_handle = cfg.ctx.get_handle<vector<Photon>>("photons");
+  src_token = cfg.cc.consumes<std::vector<pat::Photon>>(cfg.src);
+  pv_token = cfg.cc.consumes<std::vector<reco::Vertex>>(cfg.pv_src);
+  IDtag_keys = cfg.id_keys;
+}
+
+NtupleWriterPhotons::~NtupleWriterPhotons(){}
+
+void NtupleWriterPhotons::process(const edm::Event & event, uhh2::Event & uevent, const edm::EventSetup& iSetup){
+    edm::Handle< std::vector<pat::Photon> > pho_handle;
+    event.getByToken(src_token, pho_handle);
+
+   //  edm::Handle<std::vector<reco::Vertex>> pv_handle;
+   // event.getByToken(pv_token, pv_handle);
+   // if(pv_handle->empty()){
+   //     edm::LogWarning("NtupleWriterPhotons") << "No PVs found, not writing phoctrons!";
+   //     return;
+   // }
+   // const auto & PV = pv_handle->front();
+
+    std::vector<Photon> phos;
+    for (const pat::Photon & pat_pho : *pho_handle) {
+        phos.emplace_back();
+        Photon & pho = phos.back();
+        pho.set_charge( pat_pho.charge());
+        pho.set_pt( pat_pho.pt());
+        pho.set_eta( pat_pho.eta());
+        pho.set_phi( pat_pho.phi());
+        pho.set_energy( pat_pho.energy());
+	pho.set_vertex_x(pat_pho.vertex().x());
+	pho.set_vertex_y(pat_pho.vertex().y());
+	pho.set_vertex_z(pat_pho.vertex().z());
+	pho.set_puppiChargedHadronIso(pat_pho.puppiChargedHadronIso());
+	pho.set_puppiNeutralHadronIso(pat_pho.puppiNeutralHadronIso());
+	pho.set_puppiPhotonIso(pat_pho.puppiPhotonIso());
+        pho.set_supercluster_eta( pat_pho.superCluster()->eta() );
+        pho.set_supercluster_phi( pat_pho.superCluster()->phi() );
+        for(const auto& tag_str : IDtag_keys){
+          if(!pat_pho.hasUserInt(tag_str)) throw cms::Exception("Missing userInt label", "Label for pat::Photon::userInt not found: "+tag_str);
+          pho.set_tag(Photon::tagname2tag(tag_str), float(pat_pho.userInt(tag_str)));
+        }
+
+        /* source candidates */
+        if(save_source_candidates_){
+          for(unsigned int s=0; s<pat_pho.numberOfSourceCandidatePtrs(); ++s){
+            if(!pat_pho.sourceCandidatePtr(s).isAvailable()) continue;
+            source_candidate sc;
+            sc.key = pat_pho.sourceCandidatePtr(s).key();
+            sc.px  = pat_pho.sourceCandidatePtr(s)->px();
+            sc.py  = pat_pho.sourceCandidatePtr(s)->py();
+            sc.pz  = pat_pho.sourceCandidatePtr(s)->pz();
+            sc.E   = pat_pho.sourceCandidatePtr(s)->energy();
+            pho.add_source_candidate(std::move(sc));
+          }
+        }
+        /*-------------------*/
+    }
+
+    uevent.set(handle, move(phos));
+    if(photons_handle){
+        EventAccess_::set_unmanaged(uevent, *photons_handle, &uevent.get(handle));
+    }
+}
+
+//-------------------------
 
 NtupleWriterMuons::NtupleWriterMuons(Config & cfg, bool set_muons_member, const bool save_source_cands): save_source_candidates_(save_source_cands){
   handle = cfg.ctx.declare_event_output<vector<Muon>>(cfg.dest_branchname, cfg.dest);

--- a/core/plugins/NtupleWriterLeptons.cxx
+++ b/core/plugins/NtupleWriterLeptons.cxx
@@ -181,6 +181,18 @@ void NtupleWriterPhotons::process(const edm::Event & event, uhh2::Event & uevent
 	pho.set_puppiPhotonIso(pat_pho.puppiPhotonIso());
         pho.set_supercluster_eta( pat_pho.superCluster()->eta() );
         pho.set_supercluster_phi( pat_pho.superCluster()->phi() );
+
+	pho.set_trackIso(pat_pho.trackIso());
+	pho.set_ecalIso(pat_pho.ecalIso());
+	pho.set_hcalIso(pat_pho.hcalIso());
+	pho.set_caloIso(pat_pho.caloIso());
+
+	//	pho.set_patParticleIso(pat_pho.patParticleIso());
+	pho.set_chargedHadronIso(pat_pho.chargedHadronIso());
+	pho.set_neutralHadronIso(pat_pho.neutralHadronIso());
+	pho.set_photonIso(pat_pho.photonIso());
+	pho.set_puChargedHadronIso(pat_pho.puChargedHadronIso());
+
         for(const auto& tag_str : IDtag_keys){
           if(!pat_pho.hasUserInt(tag_str)) throw cms::Exception("Missing userInt label", "Label for pat::Photon::userInt not found: "+tag_str);
           pho.set_tag(Photon::tagname2tag(tag_str), float(pat_pho.userInt(tag_str)));

--- a/core/plugins/NtupleWriterLeptons.h
+++ b/core/plugins/NtupleWriterLeptons.h
@@ -33,6 +33,37 @@ private:
     bool save_source_candidates_;
 };
 
+class NtupleWriterPhotons: public NtupleWriterModule {
+public:
+    
+    struct Config: public NtupleWriterModule::Config {     
+      edm::InputTag pv_src;
+      std::vector<std::string> id_keys;
+
+      // inherit constructor does not work yet :-(
+      Config(uhh2::Context & ctx_, edm::ConsumesCollector && cc_, const edm::InputTag & src_,
+             const std::string & dest_, const std::string & dest_branchname_ = ""):
+        NtupleWriterModule::Config(ctx_, std::move(cc_), src_, dest_, dest_branchname_) {}
+    };
+
+    explicit NtupleWriterPhotons(Config & cfg, bool set_electrons_member, const bool save_source_cands=0);
+
+    virtual void process(const edm::Event &, uhh2::Event &, const edm::EventSetup& iSetup);
+
+    virtual ~NtupleWriterPhotons();
+private:
+    edm::EDGetToken src_token;
+    edm::EDGetToken pv_token;
+    std::vector<std::string> IDtag_keys;
+    Event::Handle<std::vector<Photon>> handle; // main handle to write output to
+    boost::optional<Event::Handle<std::vector<Photon>>> photons_handle; // handle of name "electrons" in case set_electrons_member is true
+
+    bool save_source_candidates_;
+};
+
+
+
+
 class NtupleWriterMuons: public NtupleWriterModule {
 public:
     

--- a/core/plugins/PATPhotonUserData.cc
+++ b/core/plugins/PATPhotonUserData.cc
@@ -1,0 +1,146 @@
+#include <memory>
+#include <vector>
+#include <string>
+
+#include <FWCore/Framework/interface/Frameworkfwd.h>
+#include <FWCore/Framework/interface/EDProducer.h>
+#include <FWCore/Framework/interface/Event.h>
+#include <FWCore/Framework/interface/MakerMacros.h>
+#include <FWCore/ParameterSet/interface/ParameterSet.h>
+
+#include <DataFormats/PatCandidates/interface/Photon.h>
+
+#include <RecoEgamma/EgammaTools/interface/EffectiveAreas.h>
+
+class PATPhotonUserData : public edm::EDProducer {
+ public:
+  explicit PATPhotonUserData(const edm::ParameterSet&);
+  virtual ~PATPhotonUserData() {}
+
+ private:
+  virtual void produce(edm::Event&, const edm::EventSetup&);
+
+  edm::EDGetTokenT< edm::View<pat::Photon> > src_;
+  edm::EDGetTokenT< edm::View<reco::Vertex> > vertices_;
+
+  struct vmap_link {
+    std::string     vname;
+    edm::EDGetToken token;
+  };
+
+  edm::ParameterSet      vmaps_bool_;
+  std::vector<vmap_link> vmaps_bool_links_;
+
+  edm::ParameterSet      vmaps_float_;
+  std::vector<vmap_link> vmaps_float_links_;
+
+  std::vector<std::string> vmaps_double_;
+  std::vector<edm::EDGetToken> vmaps_token_;
+
+};
+
+PATPhotonUserData::PATPhotonUserData(const edm::ParameterSet& iConfig){
+
+  src_ = consumes< edm::View<pat::Photon> >(iConfig.getParameter<edm::InputTag>("src"));
+
+  if(iConfig.exists("vmaps_bool")) vmaps_bool_ = iConfig.getParameter<edm::ParameterSet>("vmaps_bool");
+  for(unsigned int i=0; i<vmaps_bool_.getParameterNames().size(); ++i){
+
+    vmap_link link;
+    link.vname = vmaps_bool_.getParameterNames().at(i);
+    link.token = consumes< edm::ValueMap<bool> >(vmaps_bool_.getParameter<edm::InputTag>(link.vname));
+
+    vmaps_bool_links_.push_back(link);
+  }
+
+  if(iConfig.exists("vmaps_float")) vmaps_float_ = iConfig.getParameter<edm::ParameterSet>("vmaps_float");
+  for(unsigned int i=0; i<vmaps_float_.getParameterNames().size(); ++i){
+
+    vmap_link link;
+    link.vname = vmaps_float_.getParameterNames().at(i);
+    link.token = consumes< edm::ValueMap<float> >(vmaps_float_.getParameter<edm::InputTag>(link.vname));
+
+    vmaps_float_links_.push_back(link);
+  }
+
+  if(iConfig.exists("vmaps_double")) {
+    vmaps_double_ = iConfig.getParameter<std::vector<std::string>>("vmaps_double");
+    for(unsigned int i=0; i<vmaps_double_.size(); i++){
+      vmaps_token_.push_back(consumes<edm::ValueMap<double> >(edm::InputTag(vmaps_double_.at(i))));
+    }
+  }
+
+  produces< pat::PhotonCollection >();
+}
+
+void PATPhotonUserData::produce(edm::Event& iEvent, const edm::EventSetup& iSetup){
+
+  edm::Handle< edm::View<pat::Photon> > patPhons;
+  iEvent.getByToken(src_, patPhons);
+
+  std::vector< edm::Handle< edm::ValueMap<bool> > > vmapBs;
+  for(unsigned int i=0; i<vmaps_bool_links_.size(); ++i){
+
+    edm::Handle< edm::ValueMap<bool> > vmapB;
+    iEvent.getByToken(vmaps_bool_links_.at(i).token, vmapB);
+    vmapBs.push_back(vmapB);
+  }
+
+  std::vector< edm::Handle< edm::ValueMap<float> > > vmapFs;
+  for(unsigned int i=0; i<vmaps_float_links_.size(); ++i){
+
+    edm::Handle< edm::ValueMap<float> > vmapF;
+    iEvent.getByToken(vmaps_float_links_.at(i).token, vmapF);
+    vmapFs.push_back(vmapF);
+  }
+
+  std::vector< edm::Handle< edm::ValueMap<double> > > vmapDs;
+  for(unsigned int i=0; i<vmaps_token_.size(); ++i){
+
+    edm::Handle< edm::ValueMap<double> > vmapD;
+    iEvent.getByToken(vmaps_token_.at(i), vmapD);
+    vmapDs.push_back(vmapD);
+  }
+
+  std::unique_ptr< pat::PhotonCollection > newPhons(new pat::PhotonCollection);
+  newPhons->reserve(patPhons->size());
+
+  for(unsigned int i=0; i<patPhons->size(); ++i){
+
+    newPhons->push_back(patPhons->at(i));
+    pat::Photon& pho = newPhons->back();
+
+    for(unsigned int j=0; j<vmapBs.size(); ++j){
+
+      if(pho.hasUserInt(vmaps_bool_links_.at(j).vname))
+        throw cms::Exception("InputError") << "@@@ PATPhotonUserData::produce -- PAT user-int label already exists: " << vmaps_bool_links_.at(j).vname;
+
+      const bool& val = (*(vmapBs.at(j)))[patPhons->refAt(i)];
+      pho.addUserInt(vmaps_bool_links_.at(j).vname, int(val));
+    }
+
+    for(unsigned int j=0; j<vmapFs.size(); ++j){
+
+      if(pho.hasUserFloat(vmaps_float_links_.at(j).vname))
+        throw cms::Exception("InputError") << "@@@ PATPhotonUserData::produce -- PAT user-float label already exists: " << vmaps_float_links_.at(j).vname;
+
+      const float& val = (*(vmapFs.at(j)))[patPhons->refAt(i)];
+      pho.addUserFloat(vmaps_float_links_.at(j).vname, float(val));
+    }
+
+    for(unsigned int j=0; j<vmapDs.size(); ++j){
+
+      if(pho.hasUserFloat(vmaps_double_.at(j)))
+        throw cms::Exception("InputError") << "@@@ PATPhotonUserData::produce -- PAT user-float label already exists: " << vmaps_double_.at(j);
+
+      const double& val = (*(vmapDs.at(j)))[patPhons->refAt(i)];
+      pho.addUserFloat(vmaps_double_.at(j), float(val));
+    }
+  }
+
+  iEvent.put(std::move(newPhons));
+
+  return;
+}
+
+DEFINE_FWK_MODULE(PATPhotonUserData);


### PR DESCRIPTION
Add photons to ntuples in similar fashion as muons and electrons. Photon class is updated to store PhotonID tags for RunII. Isolation variables are copied from slimmedPhotons miniAOD collection.
For updates in immediate future might be useful:
https://cmssdt.cern.ch/lxr/source/DataFormats/PatCandidates/interface/Photon.h?%21v=CMSSW_10_2_0


