### PR TITLE
[102X] add DeepBoosted info to AK8CHS jets

### DIFF
--- a/core/include/Jet.h
+++ b/core/include/Jet.h
@@ -50,80 +50,13 @@ class Jet : public FlavorParticle {
     m_btag_combinedSecondaryVertexMVA = -2;
     m_btag_DeepCSV_probb = -2;
     m_btag_DeepCSV_probbb = -2;
-    m_btag_BoostedDoubleSecondaryVertexAK8 = -2;
-    m_btag_BoostedDoubleSecondaryVertexCA15 = -2;
     m_btag_DeepFlavour_probbb=-2;
     m_btag_DeepFlavour_probb=-2;
     m_btag_DeepFlavour_problepb=-2;
     m_btag_DeepFlavour_probc=-2;
     m_btag_DeepFlavour_probuds=-2;
     m_btag_DeepFlavour_probg=-2;
-    m_btag_MassDecorrelatedDeepBoosted_bbvsLight=-2;
-    m_btag_MassDecorrelatedDeepBoosted_ccvsLight=-2;
-    m_btag_MassDecorrelatedDeepBoosted_TvsQCD=-2;
-    m_btag_MassDecorrelatedDeepBoosted_ZHccvsQCD=-2;
-    m_btag_MassDecorrelatedDeepBoosted_WvsQCD=-2;
-    m_btag_MassDecorrelatedDeepBoosted_ZHbbvsQCD=-2;
-    m_btag_MassDecorrelatedDeepBoosted_ZvsQCD=-2;
-    m_btag_MassDecorrelatedDeepBoosted_ZbbvsQCD=-2;
-    m_btag_MassDecorrelatedDeepBoosted_HbbvsQCD=-2;
-    m_btag_MassDecorrelatedDeepBoosted_H4qvsQCD=-2;
-    m_btag_MassDecorrelatedDeepBoosted_probHbb=-2;
-    m_btag_MassDecorrelatedDeepBoosted_probQCDc=-2;
-    m_btag_MassDecorrelatedDeepBoosted_probQCDbb=-2;
-    m_btag_MassDecorrelatedDeepBoosted_probTbqq=-2;
-    m_btag_MassDecorrelatedDeepBoosted_probTbcq=-2;
-    m_btag_MassDecorrelatedDeepBoosted_probTbq=-2;
-    m_btag_MassDecorrelatedDeepBoosted_probQCDothers=-2;
-    m_btag_MassDecorrelatedDeepBoosted_probQCDb=-2;
-    m_btag_MassDecorrelatedDeepBoosted_probTbc=-2;
-    m_btag_MassDecorrelatedDeepBoosted_probWqq=-2;
-    m_btag_MassDecorrelatedDeepBoosted_probQCDcc=-2;
-    m_btag_MassDecorrelatedDeepBoosted_probHcc=-2;
-    m_btag_MassDecorrelatedDeepBoosted_probWcq=-2;
-    m_btag_MassDecorrelatedDeepBoosted_probZcc=-2;
-    m_btag_MassDecorrelatedDeepBoosted_probZqq=-2;
-    m_btag_MassDecorrelatedDeepBoosted_probHqqqq=-2;
-    m_btag_MassDecorrelatedDeepBoosted_probZbb=-2;
- 
-    m_btag_DeepDoubleBvLJet_probHbb=-2;
-    m_btag_DeepDoubleBvLJet_probQCD=-2;
-    m_btag_DeepDoubleCvBJet_probHbb=-2;
-    m_btag_DeepDoubleCvBJet_probHcc=-2;
-    m_btag_DeepDoubleCvLJet_probHcc=-2;
-    m_btag_DeepDoubleCvLJet_probQCD=-2;
-
-    m_btag_MassIndependentDeepDoubleBvLJet_probHbb=-2;
-    m_btag_MassIndependentDeepDoubleBvLJet_probQCD=-2;
-    m_btag_MassIndependentDeepDoubleCvBJet_probHbb=-2;
-    m_btag_MassIndependentDeepDoubleCvBJet_probHcc=-2;
-    m_btag_MassIndependentDeepDoubleCvLJet_probHcc=-2;
-    m_btag_MassIndependentDeepDoubleCvLJet_probQCD=-2;
-
-    m_btag_DeepBoosted_TvsQCD=-2;
-    m_btag_DeepBoosted_WvsQCD=-2;
-    m_btag_DeepBoosted_ZvsQCD=-2;
-    m_btag_DeepBoosted_ZbbvsQCD=-2;
-    m_btag_DeepBoosted_HbbvsQCD=-2;
-    m_btag_DeepBoosted_H4qvsQCD=-2;
-    m_btag_DeepBoosted_probHbb=-2;
-    m_btag_DeepBoosted_probQCDc=-2;
-    m_btag_DeepBoosted_probQCDbb=-2;
-    m_btag_DeepBoosted_probTbqq=-2;
-    m_btag_DeepBoosted_probTbcq=-2;
-    m_btag_DeepBoosted_probTbq=-2;
-    m_btag_DeepBoosted_probQCDothers=-2;
-    m_btag_DeepBoosted_probQCDb=-2;
-    m_btag_DeepBoosted_probTbc=-2;
-    m_btag_DeepBoosted_probWqq=-2;
-    m_btag_DeepBoosted_probQCDcc=-2;
-    m_btag_DeepBoosted_probHcc=-2;
-    m_btag_DeepBoosted_probWcq=-2;
-    m_btag_DeepBoosted_probZcc=-2;
-    m_btag_DeepBoosted_probZqq=-2;
-    m_btag_DeepBoosted_probHqqqq=-2;
-    m_btag_DeepBoosted_probZbb=-2;
-
+   
     m_JEC_factor_raw = 0;
     m_JEC_L1factor_raw = 0;
     m_genjet_index = -1; // not default of 0, as 0 is a valid index
@@ -155,8 +88,6 @@ class Jet : public FlavorParticle {
   float btag_combinedSecondaryVertex() const{return m_btag_combinedSecondaryVertex;} // combinedInclusiveSecondaryVertexV2BJetTags
   float btag_combinedSecondaryVertexMVA() const{return m_btag_combinedSecondaryVertexMVA;}
   float btag_DeepCSV() const{return m_btag_DeepCSV_probb + m_btag_DeepCSV_probbb;} // pfDeepCSVJetTags:probb + pfDeepCSVJetTags:probbb
-  float btag_BoostedDoubleSecondaryVertexAK8() const{return m_btag_BoostedDoubleSecondaryVertexAK8;}
-  float btag_BoostedDoubleSecondaryVertexCA15() const{return m_btag_BoostedDoubleSecondaryVertexCA15;}
   float btag_DeepFlavour_bb() const{return m_btag_DeepFlavour_probbb;}
   float btag_DeepFlavour_b() const{return m_btag_DeepFlavour_probb;}
   float btag_DeepFlavour_lepb() const{return m_btag_DeepFlavour_problepb;}
@@ -164,75 +95,7 @@ class Jet : public FlavorParticle {
   float btag_DeepFlavour_g() const{return m_btag_DeepFlavour_probg;}
   float btag_DeepFlavour_c() const{return m_btag_DeepFlavour_probc;}
   float btag_DeepFlavour() const{return m_btag_DeepFlavour_probbb+m_btag_DeepFlavour_probb+m_btag_DeepFlavour_problepb;}
-  float btag_MassDecorrelatedDeepBoosted_bbvsLight() const{return m_btag_MassDecorrelatedDeepBoosted_bbvsLight;}
-  float btag_MassDecorrelatedDeepBoosted_ccvsLight() const{return m_btag_MassDecorrelatedDeepBoosted_ccvsLight;}
-  float btag_MassDecorrelatedDeepBoosted_TvsQCD() const{return m_btag_MassDecorrelatedDeepBoosted_TvsQCD;}
-  float btag_MassDecorrelatedDeepBoosted_ZHccvsQCD() const{return m_btag_MassDecorrelatedDeepBoosted_ZHccvsQCD;}
-  float btag_MassDecorrelatedDeepBoosted_WvsQCD() const{return m_btag_MassDecorrelatedDeepBoosted_WvsQCD;}
-  float btag_MassDecorrelatedDeepBoosted_ZHbbvsQCD() const{return m_btag_MassDecorrelatedDeepBoosted_ZHbbvsQCD;}
-
-  float btag_MassDecorrelatedDeepBoosted_ZvsQCD() const{return m_btag_MassDecorrelatedDeepBoosted_ZvsQCD;}
-  float btag_MassDecorrelatedDeepBoosted_ZbbvsQCD() const{return m_btag_MassDecorrelatedDeepBoosted_ZbbvsQCD;}
-  float btag_MassDecorrelatedDeepBoosted_HbbvsQCD() const{return m_btag_MassDecorrelatedDeepBoosted_HbbvsQCD;}
-  float btag_MassDecorrelatedDeepBoosted_H4qvsQCD() const{return m_btag_MassDecorrelatedDeepBoosted_H4qvsQCD;}
-
-
-  float btag_MassDecorrelatedDeepBoosted_probHbb() const{return m_btag_MassDecorrelatedDeepBoosted_probHbb;}
-  float btag_MassDecorrelatedDeepBoosted_probQCDc() const{return m_btag_MassDecorrelatedDeepBoosted_probQCDc;}
-  float btag_MassDecorrelatedDeepBoosted_probQCDbb() const{return m_btag_MassDecorrelatedDeepBoosted_probQCDbb;}
-  float btag_MassDecorrelatedDeepBoosted_probTbqq() const{return m_btag_MassDecorrelatedDeepBoosted_probTbqq;}
-  float btag_MassDecorrelatedDeepBoosted_probTbcq() const{return m_btag_MassDecorrelatedDeepBoosted_probTbcq;}
-  float btag_MassDecorrelatedDeepBoosted_probTbq() const{return m_btag_MassDecorrelatedDeepBoosted_probTbq;}
-  float btag_MassDecorrelatedDeepBoosted_probQCDothers() const{return m_btag_MassDecorrelatedDeepBoosted_probQCDothers;}
-  float btag_MassDecorrelatedDeepBoosted_probQCDb() const{return m_btag_MassDecorrelatedDeepBoosted_probQCDb;}
-  float btag_MassDecorrelatedDeepBoosted_probTbc() const{return m_btag_MassDecorrelatedDeepBoosted_probTbc;}
-  float btag_MassDecorrelatedDeepBoosted_probWqq() const{return m_btag_MassDecorrelatedDeepBoosted_probWqq;}
-  float btag_MassDecorrelatedDeepBoosted_probQCDcc() const{return m_btag_MassDecorrelatedDeepBoosted_probQCDcc;}
-  float btag_MassDecorrelatedDeepBoosted_probHcc() const{return m_btag_MassDecorrelatedDeepBoosted_probHcc;}
-  float btag_MassDecorrelatedDeepBoosted_probZcc() const{return m_btag_MassDecorrelatedDeepBoosted_probZcc;}
-  float btag_MassDecorrelatedDeepBoosted_proWcq() const{return m_btag_MassDecorrelatedDeepBoosted_probWcq;}
-  float btag_MassDecorrelatedDeepBoosted_probZqq() const{return m_btag_MassDecorrelatedDeepBoosted_probZqq;}
-  float btag_MassDecorrelatedDeepBoosted_probHqqqq() const{return m_btag_MassDecorrelatedDeepBoosted_probHqqqq;}
-  float btag_MassDecorrelatedDeepBoosted_probZbb() const{return m_btag_MassDecorrelatedDeepBoosted_probZbb;}
-
-  float btag_DeepDoubleBvLJet_probHbb() const{return m_btag_DeepDoubleBvLJet_probHbb;}
-  float btag_DeepDoubleBvLJet_probQCD() const{return m_btag_DeepDoubleBvLJet_probQCD;}
-  float btag_DeepDoubleCvBJet_probHbb() const{return m_btag_DeepDoubleCvBJet_probHbb;}
-  float btag_DeepDoubleCvBJet_probHcc() const{return m_btag_DeepDoubleCvBJet_probHcc;}
-  float btag_DeepDoubleCvLJet_probHcc() const{return m_btag_DeepDoubleCvLJet_probHcc;}
-  float btag_DeepDoubleCvLJet_probQCD() const{return m_btag_DeepDoubleCvLJet_probQCD;}
-
-  float btag_MassIndependentDeepDoubleBvLJet_probHbb() const{return m_btag_MassIndependentDeepDoubleBvLJet_probHbb;}
-  float btag_MassIndependentDeepDoubleBvLJet_probQCD() const{return m_btag_MassIndependentDeepDoubleBvLJet_probQCD;}
-  float btag_MassIndependentDeepDoubleCvBJet_probHbb() const{return m_btag_MassIndependentDeepDoubleCvBJet_probHbb;}
-  float btag_MassIndependentDeepDoubleCvBJet_probHcc() const{return m_btag_MassIndependentDeepDoubleCvBJet_probHcc;}
-  float btag_MassIndependentDeepDoubleCvLJet_probHcc() const{return m_btag_MassIndependentDeepDoubleCvLJet_probHcc;}
-  float btag_MassIndependentDeepDoubleCvLJet_probQCD() const{return m_btag_MassIndependentDeepDoubleCvLJet_probQCD;}
-
-
-  float btag_DeepBoosted_TvsQCD() const{return m_btag_DeepBoosted_TvsQCD;}
-  float btag_DeepBoosted_WvsQCD() const{return m_btag_DeepBoosted_WvsQCD;}
-  float btag_DeepBoosted_ZvsQCD() const{return m_btag_DeepBoosted_ZvsQCD;}
-  float btag_DeepBoosted_ZbbvsQCD() const{return m_btag_DeepBoosted_ZbbvsQCD;}
-  float btag_DeepBoosted_HbbvsQCD() const{return m_btag_DeepBoosted_HbbvsQCD;}
-  float btag_DeepBoosted_H4qvsQCD() const{return m_btag_DeepBoosted_H4qvsQCD;}
-  float btag_DeepBoosted_probHbb() const{return m_btag_DeepBoosted_probHbb;}
-  float btag_DeepBoosted_probQCDc() const{return m_btag_DeepBoosted_probQCDc;}
-  float btag_DeepBoosted_probQCDbb() const{return m_btag_DeepBoosted_probQCDbb;}
-  float btag_DeepBoosted_probTbqq() const{return m_btag_DeepBoosted_probTbqq;}
-  float btag_DeepBoosted_probTbcq() const{return m_btag_DeepBoosted_probTbcq;}
-  float btag_DeepBoosted_probTbq() const{return m_btag_DeepBoosted_probTbq;}
-  float btag_DeepBoosted_probQCDothers() const{return m_btag_DeepBoosted_probQCDothers;}
-  float btag_DeepBoosted_probQCDb() const{return m_btag_DeepBoosted_probQCDb;}
-  float btag_DeepBoosted_probTbc() const{return m_btag_DeepBoosted_probTbc;}
-  float btag_DeepBoosted_probWqq() const{return m_btag_DeepBoosted_probWqq;}
-  float btag_DeepBoosted_probQCDcc() const{return m_btag_DeepBoosted_probQCDcc;}
-  float btag_DeepBoosted_probHcc() const{return m_btag_DeepBoosted_probHcc;}
-  float btag_DeepBoosted_probZcc() const{return m_btag_DeepBoosted_probZcc;}
-  float btag_DeepBoosted_proWcq() const{return m_btag_DeepBoosted_probWcq;}
-  float btag_DeepBoosted_probZqq() const{return m_btag_DeepBoosted_probZqq;}
-  float btag_DeepBoosted_probHqqqq() const{return m_btag_DeepBoosted_probHqqqq;}
-  float btag_DeepBoosted_probZbb() const{return m_btag_DeepBoosted_probZbb;}
+ 
 
   float JEC_factor_raw() const{return m_JEC_factor_raw;}
   float JEC_L1factor_raw() const{return m_JEC_L1factor_raw;}
@@ -268,84 +131,12 @@ class Jet : public FlavorParticle {
   void set_btag_combinedSecondaryVertexMVA(float x){m_btag_combinedSecondaryVertexMVA=x;}
   void set_btag_DeepCSV_probb(float x){m_btag_DeepCSV_probb=x;} // pfDeepCSVJetTags:probb
   void set_btag_DeepCSV_probbb(float x){m_btag_DeepCSV_probbb=x;} // pfDeepCSVJetTags:probbb
-  void set_btag_BoostedDoubleSecondaryVertexAK8(float x){m_btag_BoostedDoubleSecondaryVertexAK8=x;}
-  void set_btag_BoostedDoubleSecondaryVertexCA15(float x){m_btag_BoostedDoubleSecondaryVertexCA15=x;}
   void set_btag_DeepFlavour_probbb(float x){m_btag_DeepFlavour_probbb=x;}
   void set_btag_DeepFlavour_probb(float x){m_btag_DeepFlavour_probb=x;}
   void set_btag_DeepFlavour_problepb(float x){m_btag_DeepFlavour_problepb=x;}
   void set_btag_DeepFlavour_probc(float x){m_btag_DeepFlavour_probc=x;}
   void set_btag_DeepFlavour_probuds(float x){m_btag_DeepFlavour_probuds=x;}
   void set_btag_DeepFlavour_probg(float x){m_btag_DeepFlavour_probg=x;}
-
-
-
-  void set_btag_MassDecorrelatedDeepBoosted_bbvsLight(float x){m_btag_MassDecorrelatedDeepBoosted_bbvsLight=x;}
-  void set_btag_MassDecorrelatedDeepBoosted_ccvsLight(float x){m_btag_MassDecorrelatedDeepBoosted_ccvsLight=x;}
-  void set_btag_MassDecorrelatedDeepBoosted_TvsQCD(float x){m_btag_MassDecorrelatedDeepBoosted_TvsQCD=x;}
-  void set_btag_MassDecorrelatedDeepBoosted_ZHccvsQCD(float x){m_btag_MassDecorrelatedDeepBoosted_ZHccvsQCD=x;}
-  void set_btag_MassDecorrelatedDeepBoosted_WvsQCD(float x){m_btag_MassDecorrelatedDeepBoosted_WvsQCD=x;}
-  void set_btag_MassDecorrelatedDeepBoosted_ZHbbvsQCD(float x){m_btag_MassDecorrelatedDeepBoosted_ZHbbvsQCD=x;}
-  void set_btag_MassDecorrelatedDeepBoosted_ZvsQCD(float x) {m_btag_MassDecorrelatedDeepBoosted_ZvsQCD=x;}
-  void set_btag_MassDecorrelatedDeepBoosted_ZbbvsQCD(float x) {m_btag_MassDecorrelatedDeepBoosted_ZbbvsQCD=x;}
-  void set_btag_MassDecorrelatedDeepBoosted_HbbvsQCD(float x) {m_btag_MassDecorrelatedDeepBoosted_HbbvsQCD=x;}
-  void set_btag_MassDecorrelatedDeepBoosted_H4qvsQCD(float x) {m_btag_MassDecorrelatedDeepBoosted_H4qvsQCD=x;}
-
-  void set_btag_MassDecorrelatedDeepBoosted_probHbb(float x){m_btag_MassDecorrelatedDeepBoosted_probHbb=x;}
-  void set_btag_MassDecorrelatedDeepBoosted_probQCDc(float x) { m_btag_MassDecorrelatedDeepBoosted_probQCDc=x;}
-  void set_btag_MassDecorrelatedDeepBoosted_probQCDbb(float x) { m_btag_MassDecorrelatedDeepBoosted_probQCDbb=x;}
-  void set_btag_MassDecorrelatedDeepBoosted_probTbqq(float x) { m_btag_MassDecorrelatedDeepBoosted_probTbqq=x;}
-  void set_btag_MassDecorrelatedDeepBoosted_probTbcq(float x) { m_btag_MassDecorrelatedDeepBoosted_probTbcq=x;}
-  void set_btag_MassDecorrelatedDeepBoosted_probTbq(float x) { m_btag_MassDecorrelatedDeepBoosted_probTbq=x;}
-  void set_btag_MassDecorrelatedDeepBoosted_probQCDothers(float x) { m_btag_MassDecorrelatedDeepBoosted_probQCDothers=x;}
-  void set_btag_MassDecorrelatedDeepBoosted_probQCDb(float x) { m_btag_MassDecorrelatedDeepBoosted_probQCDb=x;}
-  void set_btag_MassDecorrelatedDeepBoosted_probTbc(float x) { m_btag_MassDecorrelatedDeepBoosted_probTbc=x;}
-  void set_btag_MassDecorrelatedDeepBoosted_probWqq(float x) { m_btag_MassDecorrelatedDeepBoosted_probWqq=x;}
-  void set_btag_MassDecorrelatedDeepBoosted_probQCDcc(float x) { m_btag_MassDecorrelatedDeepBoosted_probQCDcc=x;}
-  void set_btag_MassDecorrelatedDeepBoosted_probHcc(float x) { m_btag_MassDecorrelatedDeepBoosted_probHcc=x;}
-  void set_btag_MassDecorrelatedDeepBoosted_probZcc(float x) { m_btag_MassDecorrelatedDeepBoosted_probZcc=x;}
-  void set_btag_MassDecorrelatedDeepBoosted_probWcq(float x) { m_btag_MassDecorrelatedDeepBoosted_probWcq=x;}
-  void set_btag_MassDecorrelatedDeepBoosted_probZqq(float x) { m_btag_MassDecorrelatedDeepBoosted_probZqq=x;}
-  void set_btag_MassDecorrelatedDeepBoosted_probHqqqq(float x) { m_btag_MassDecorrelatedDeepBoosted_probHqqqq=x;}
-  void set_btag_MassDecorrelatedDeepBoosted_probZbb(float x) { m_btag_MassDecorrelatedDeepBoosted_probZbb=x;}
-
-  void set_btag_DeepDoubleBvLJet_probHbb(float x) {  m_btag_DeepDoubleBvLJet_probHbb=x;}
-  void set_btag_DeepDoubleBvLJet_probQCD(float x) {  m_btag_DeepDoubleBvLJet_probQCD=x;}
-  void set_btag_DeepDoubleCvBJet_probHbb(float x) {  m_btag_DeepDoubleCvBJet_probHbb=x;}
-  void set_btag_DeepDoubleCvBJet_probHcc(float x) {  m_btag_DeepDoubleCvBJet_probHcc=x;}
-  void set_btag_DeepDoubleCvLJet_probHcc(float x) {  m_btag_DeepDoubleCvLJet_probHcc=x;}
-  void set_btag_DeepDoubleCvLJet_probQCD(float x) {  m_btag_DeepDoubleCvLJet_probQCD=x;}
-
-  void set_btag_MassIndependentDeepDoubleBvLJet_probHbb(float x) {  m_btag_MassIndependentDeepDoubleBvLJet_probHbb=x;}
-  void set_btag_MassIndependentDeepDoubleBvLJet_probQCD(float x) {  m_btag_MassIndependentDeepDoubleBvLJet_probQCD=x;}
-  void set_btag_MassIndependentDeepDoubleCvBJet_probHbb(float x) {  m_btag_MassIndependentDeepDoubleCvBJet_probHbb=x;}
-  void set_btag_MassIndependentDeepDoubleCvBJet_probHcc(float x) {  m_btag_MassIndependentDeepDoubleCvBJet_probHcc=x;}
-  void set_btag_MassIndependentDeepDoubleCvLJet_probHcc(float x) {  m_btag_MassIndependentDeepDoubleCvLJet_probHcc=x;}
-  void set_btag_MassIndependentDeepDoubleCvLJet_probQCD(float x) {  m_btag_MassIndependentDeepDoubleCvLJet_probQCD=x;}
-
-  void set_btag_DeepBoosted_TvsQCD(float x){m_btag_DeepBoosted_TvsQCD=x;}
-  void set_btag_DeepBoosted_WvsQCD(float x){m_btag_DeepBoosted_WvsQCD=x;}
-  void set_btag_DeepBoosted_ZvsQCD(float x) {m_btag_DeepBoosted_ZvsQCD=x;}
-  void set_btag_DeepBoosted_ZbbvsQCD(float x) {m_btag_DeepBoosted_ZbbvsQCD=x;}
-  void set_btag_DeepBoosted_HbbvsQCD(float x) {m_btag_DeepBoosted_HbbvsQCD=x;}
-  void set_btag_DeepBoosted_H4qvsQCD(float x) {m_btag_DeepBoosted_H4qvsQCD=x;}
-
-  void set_btag_DeepBoosted_probHbb(float x){m_btag_DeepBoosted_probHbb=x;}
-  void set_btag_DeepBoosted_probQCDc(float x) { m_btag_DeepBoosted_probQCDc=x;}
-  void set_btag_DeepBoosted_probQCDbb(float x) { m_btag_DeepBoosted_probQCDbb=x;}
-  void set_btag_DeepBoosted_probTbqq(float x) { m_btag_DeepBoosted_probTbqq=x;}
-  void set_btag_DeepBoosted_probTbcq(float x) { m_btag_DeepBoosted_probTbcq=x;}
-  void set_btag_DeepBoosted_probTbq(float x) { m_btag_DeepBoosted_probTbq=x;}
-  void set_btag_DeepBoosted_probQCDothers(float x) { m_btag_DeepBoosted_probQCDothers=x;}
-  void set_btag_DeepBoosted_probQCDb(float x) { m_btag_DeepBoosted_probQCDb=x;}
-  void set_btag_DeepBoosted_probTbc(float x) { m_btag_DeepBoosted_probTbc=x;}
-  void set_btag_DeepBoosted_probWqq(float x) { m_btag_DeepBoosted_probWqq=x;}
-  void set_btag_DeepBoosted_probQCDcc(float x) { m_btag_DeepBoosted_probQCDcc=x;}
-  void set_btag_DeepBoosted_probHcc(float x) { m_btag_DeepBoosted_probHcc=x;}
-  void set_btag_DeepBoosted_probZcc(float x) { m_btag_DeepBoosted_probZcc=x;}
-  void set_btag_DeepBoosted_probWcq(float x) { m_btag_DeepBoosted_probWcq=x;}
-  void set_btag_DeepBoosted_probZqq(float x) { m_btag_DeepBoosted_probZqq=x;}
-  void set_btag_DeepBoosted_probHqqqq(float x) { m_btag_DeepBoosted_probHqqqq=x;}
-  void set_btag_DeepBoosted_probZbb(float x) { m_btag_DeepBoosted_probZbb=x;}
 
   void set_JEC_factor_raw(float x){m_JEC_factor_raw=x;}
   void set_JEC_L1factor_raw(float x){m_JEC_L1factor_raw=x;}
@@ -381,90 +172,18 @@ class Jet : public FlavorParticle {
   float m_photonPuppiMultiplicity;
   float m_HFHadronPuppiMultiplicity;
   float m_HFEMPuppiMultiplicity;
+
   float m_btag_combinedSecondaryVertex;
   float m_btag_combinedSecondaryVertexMVA;
   float m_btag_DeepCSV_probb;
   float m_btag_DeepCSV_probbb;
-  float m_btag_BoostedDoubleSecondaryVertexAK8;
-  float m_btag_BoostedDoubleSecondaryVertexCA15;
   float m_btag_DeepFlavour_probbb;
   float m_btag_DeepFlavour_probb;
   float m_btag_DeepFlavour_problepb;
   float m_btag_DeepFlavour_probuds;
   float m_btag_DeepFlavour_probc;
   float m_btag_DeepFlavour_probg;
-  float m_btag_MassDecorrelatedDeepBoosted_bbvsLight;
-  float m_btag_MassDecorrelatedDeepBoosted_ccvsLight;
-  float m_btag_MassDecorrelatedDeepBoosted_TvsQCD;
-  float m_btag_MassDecorrelatedDeepBoosted_ZHccvsQCD;
-  float m_btag_MassDecorrelatedDeepBoosted_WvsQCD;
-  float m_btag_MassDecorrelatedDeepBoosted_ZHbbvsQCD;
-
-  float m_btag_MassDecorrelatedDeepBoosted_ZvsQCD;
-  float m_btag_MassDecorrelatedDeepBoosted_ZbbvsQCD;
-  float m_btag_MassDecorrelatedDeepBoosted_HbbvsQCD;
-  float m_btag_MassDecorrelatedDeepBoosted_H4qvsQCD;
-
-  float m_btag_DeepBoosted_ZvsQCD;
-  float m_btag_DeepBoosted_ZbbvsQCD;
-  float m_btag_DeepBoosted_HbbvsQCD;
-  float m_btag_DeepBoosted_H4qvsQCD;
-
-
-
-  float m_btag_MassDecorrelatedDeepBoosted_probHbb;
-  float m_btag_MassDecorrelatedDeepBoosted_probQCDc;
-  float m_btag_MassDecorrelatedDeepBoosted_probQCDbb;
-  float m_btag_MassDecorrelatedDeepBoosted_probTbqq;
-  float m_btag_MassDecorrelatedDeepBoosted_probTbcq;
-  float m_btag_MassDecorrelatedDeepBoosted_probTbq;
-  float m_btag_MassDecorrelatedDeepBoosted_probQCDothers;
-  float m_btag_MassDecorrelatedDeepBoosted_probQCDb;
-  float m_btag_MassDecorrelatedDeepBoosted_probTbc;
-  float m_btag_MassDecorrelatedDeepBoosted_probWqq;
-  float m_btag_MassDecorrelatedDeepBoosted_probQCDcc;
-  float m_btag_MassDecorrelatedDeepBoosted_probHcc;
-  float m_btag_MassDecorrelatedDeepBoosted_probWcq;
-  float m_btag_MassDecorrelatedDeepBoosted_probZcc;
-  float m_btag_MassDecorrelatedDeepBoosted_probZqq;
-  float m_btag_MassDecorrelatedDeepBoosted_probHqqqq;
-  float m_btag_MassDecorrelatedDeepBoosted_probZbb;
-
-  float m_btag_DeepDoubleBvLJet_probHbb;
-  float m_btag_DeepDoubleBvLJet_probQCD;
-  float m_btag_DeepDoubleCvBJet_probHbb;
-  float m_btag_DeepDoubleCvBJet_probHcc;
-  float m_btag_DeepDoubleCvLJet_probHcc;
-  float m_btag_DeepDoubleCvLJet_probQCD;
-
-  float m_btag_MassIndependentDeepDoubleBvLJet_probHbb;
-  float m_btag_MassIndependentDeepDoubleBvLJet_probQCD;
-  float m_btag_MassIndependentDeepDoubleCvBJet_probHbb;
-  float m_btag_MassIndependentDeepDoubleCvBJet_probHcc;
-  float m_btag_MassIndependentDeepDoubleCvLJet_probHcc;
-  float m_btag_MassIndependentDeepDoubleCvLJet_probQCD;
-
-  float m_btag_DeepBoosted_TvsQCD;
-  float m_btag_DeepBoosted_WvsQCD;
-  float m_btag_DeepBoosted_probHbb;
-  float m_btag_DeepBoosted_probQCDc;
-  float m_btag_DeepBoosted_probQCDbb;
-  float m_btag_DeepBoosted_probTbqq;
-  float m_btag_DeepBoosted_probTbcq;
-  float m_btag_DeepBoosted_probTbq;
-  float m_btag_DeepBoosted_probQCDothers;
-  float m_btag_DeepBoosted_probQCDb;
-  float m_btag_DeepBoosted_probTbc;
-  float m_btag_DeepBoosted_probWqq;
-  float m_btag_DeepBoosted_probQCDcc;
-  float m_btag_DeepBoosted_probHcc;
-  float m_btag_DeepBoosted_probWcq;
-  float m_btag_DeepBoosted_probZcc;
-  float m_btag_DeepBoosted_probZqq;
-  float m_btag_DeepBoosted_probHqqqq;
-  float m_btag_DeepBoosted_probZbb;
-
-
+  
   float m_JEC_factor_raw;
   float m_JEC_L1factor_raw;
   int m_genjet_index;

--- a/core/include/TopJet.h
+++ b/core/include/TopJet.h
@@ -82,6 +82,74 @@ public:
 
   TopJet(){
       m_qjets_volatility = m_tau1 = m_tau2 = m_tau3 = m_tau4 = m_mvahiggsdiscr = m_softdropmass = m_tau1_groomed = m_tau2_groomed = m_tau3_groomed = m_tau4_groomed = m_ecfN2_beta1 = m_ecfN2_beta2 = m_ecfN3_beta1 = m_ecfN3_beta2 = -1.0f;
+      m_btag_BoostedDoubleSecondaryVertexAK8 = -2;
+      m_btag_BoostedDoubleSecondaryVertexCA15 = -2;
+      m_btag_MassDecorrelatedDeepBoosted_bbvsLight=-2;
+      m_btag_MassDecorrelatedDeepBoosted_ccvsLight=-2;
+      m_btag_MassDecorrelatedDeepBoosted_TvsQCD=-2;
+      m_btag_MassDecorrelatedDeepBoosted_ZHccvsQCD=-2;
+      m_btag_MassDecorrelatedDeepBoosted_WvsQCD=-2;
+      m_btag_MassDecorrelatedDeepBoosted_ZHbbvsQCD=-2;
+      m_btag_MassDecorrelatedDeepBoosted_ZvsQCD=-2;
+      m_btag_MassDecorrelatedDeepBoosted_ZbbvsQCD=-2;
+      m_btag_MassDecorrelatedDeepBoosted_HbbvsQCD=-2;
+      m_btag_MassDecorrelatedDeepBoosted_H4qvsQCD=-2;
+      m_btag_MassDecorrelatedDeepBoosted_probHbb=-2;
+      m_btag_MassDecorrelatedDeepBoosted_probQCDc=-2;
+      m_btag_MassDecorrelatedDeepBoosted_probQCDbb=-2;
+      m_btag_MassDecorrelatedDeepBoosted_probTbqq=-2;
+      m_btag_MassDecorrelatedDeepBoosted_probTbcq=-2;
+      m_btag_MassDecorrelatedDeepBoosted_probTbq=-2;
+      m_btag_MassDecorrelatedDeepBoosted_probQCDothers=-2;
+      m_btag_MassDecorrelatedDeepBoosted_probQCDb=-2;
+      m_btag_MassDecorrelatedDeepBoosted_probTbc=-2;
+      m_btag_MassDecorrelatedDeepBoosted_probWqq=-2;
+      m_btag_MassDecorrelatedDeepBoosted_probQCDcc=-2;
+      m_btag_MassDecorrelatedDeepBoosted_probHcc=-2;
+      m_btag_MassDecorrelatedDeepBoosted_probWcq=-2;
+      m_btag_MassDecorrelatedDeepBoosted_probZcc=-2;
+      m_btag_MassDecorrelatedDeepBoosted_probZqq=-2;
+      m_btag_MassDecorrelatedDeepBoosted_probHqqqq=-2;
+      m_btag_MassDecorrelatedDeepBoosted_probZbb=-2;
+      
+      m_btag_DeepDoubleBvLJet_probHbb=-2;
+      m_btag_DeepDoubleBvLJet_probQCD=-2;
+      m_btag_DeepDoubleCvBJet_probHbb=-2;
+      m_btag_DeepDoubleCvBJet_probHcc=-2;
+      m_btag_DeepDoubleCvLJet_probHcc=-2;
+      m_btag_DeepDoubleCvLJet_probQCD=-2;
+
+      m_btag_MassIndependentDeepDoubleBvLJet_probHbb=-2;
+      m_btag_MassIndependentDeepDoubleBvLJet_probQCD=-2;
+      m_btag_MassIndependentDeepDoubleCvBJet_probHbb=-2;
+      m_btag_MassIndependentDeepDoubleCvBJet_probHcc=-2;
+      m_btag_MassIndependentDeepDoubleCvLJet_probHcc=-2;
+      m_btag_MassIndependentDeepDoubleCvLJet_probQCD=-2;
+
+      m_btag_DeepBoosted_TvsQCD=-2;
+      m_btag_DeepBoosted_WvsQCD=-2;
+      m_btag_DeepBoosted_ZvsQCD=-2;
+      m_btag_DeepBoosted_ZbbvsQCD=-2;
+      m_btag_DeepBoosted_HbbvsQCD=-2;
+      m_btag_DeepBoosted_H4qvsQCD=-2;
+      m_btag_DeepBoosted_probHbb=-2;
+      m_btag_DeepBoosted_probQCDc=-2;
+      m_btag_DeepBoosted_probQCDbb=-2;
+      m_btag_DeepBoosted_probTbqq=-2;
+      m_btag_DeepBoosted_probTbcq=-2;
+      m_btag_DeepBoosted_probTbq=-2;
+      m_btag_DeepBoosted_probQCDothers=-2;
+      m_btag_DeepBoosted_probQCDb=-2;
+      m_btag_DeepBoosted_probTbc=-2;
+      m_btag_DeepBoosted_probWqq=-2;
+      m_btag_DeepBoosted_probQCDcc=-2;
+      m_btag_DeepBoosted_probHcc=-2;
+      m_btag_DeepBoosted_probWcq=-2;
+      m_btag_DeepBoosted_probZcc=-2;
+      m_btag_DeepBoosted_probZqq=-2;
+      m_btag_DeepBoosted_probHqqqq=-2;
+      m_btag_DeepBoosted_probZbb=-2;
+
   }
 
   // getters
@@ -110,7 +178,72 @@ public:
   
   float get_tag(tag t) const{ return tags.get_tag(static_cast<int>(t)); }
   float has_tag(tag t) const{ return tags.has_tag(static_cast<int>(t)); }
- 
+
+  //b-taggers for fat jets
+  float btag_BoostedDoubleSecondaryVertexAK8() const{return m_btag_BoostedDoubleSecondaryVertexAK8;}
+  float btag_BoostedDoubleSecondaryVertexCA15() const{return m_btag_BoostedDoubleSecondaryVertexCA15;}
+  float btag_MassDecorrelatedDeepBoosted_bbvsLight() const{return m_btag_MassDecorrelatedDeepBoosted_bbvsLight;}
+  float btag_MassDecorrelatedDeepBoosted_ccvsLight() const{return m_btag_MassDecorrelatedDeepBoosted_ccvsLight;}
+  float btag_MassDecorrelatedDeepBoosted_TvsQCD() const{return m_btag_MassDecorrelatedDeepBoosted_TvsQCD;}
+  float btag_MassDecorrelatedDeepBoosted_ZHccvsQCD() const{return m_btag_MassDecorrelatedDeepBoosted_ZHccvsQCD;}
+  float btag_MassDecorrelatedDeepBoosted_WvsQCD() const{return m_btag_MassDecorrelatedDeepBoosted_WvsQCD;}
+  float btag_MassDecorrelatedDeepBoosted_ZHbbvsQCD() const{return m_btag_MassDecorrelatedDeepBoosted_ZHbbvsQCD;}
+  float btag_MassDecorrelatedDeepBoosted_ZvsQCD() const{return m_btag_MassDecorrelatedDeepBoosted_ZvsQCD;}
+  float btag_MassDecorrelatedDeepBoosted_ZbbvsQCD() const{return m_btag_MassDecorrelatedDeepBoosted_ZbbvsQCD;}
+  float btag_MassDecorrelatedDeepBoosted_HbbvsQCD() const{return m_btag_MassDecorrelatedDeepBoosted_HbbvsQCD;}
+  float btag_MassDecorrelatedDeepBoosted_H4qvsQCD() const{return m_btag_MassDecorrelatedDeepBoosted_H4qvsQCD;}
+  float btag_MassDecorrelatedDeepBoosted_probHbb() const{return m_btag_MassDecorrelatedDeepBoosted_probHbb;}
+  float btag_MassDecorrelatedDeepBoosted_probQCDc() const{return m_btag_MassDecorrelatedDeepBoosted_probQCDc;}
+  float btag_MassDecorrelatedDeepBoosted_probQCDbb() const{return m_btag_MassDecorrelatedDeepBoosted_probQCDbb;}
+  float btag_MassDecorrelatedDeepBoosted_probTbqq() const{return m_btag_MassDecorrelatedDeepBoosted_probTbqq;}
+  float btag_MassDecorrelatedDeepBoosted_probTbcq() const{return m_btag_MassDecorrelatedDeepBoosted_probTbcq;}
+  float btag_MassDecorrelatedDeepBoosted_probTbq() const{return m_btag_MassDecorrelatedDeepBoosted_probTbq;}
+  float btag_MassDecorrelatedDeepBoosted_probQCDothers() const{return m_btag_MassDecorrelatedDeepBoosted_probQCDothers;}
+  float btag_MassDecorrelatedDeepBoosted_probQCDb() const{return m_btag_MassDecorrelatedDeepBoosted_probQCDb;}
+  float btag_MassDecorrelatedDeepBoosted_probTbc() const{return m_btag_MassDecorrelatedDeepBoosted_probTbc;}
+  float btag_MassDecorrelatedDeepBoosted_probWqq() const{return m_btag_MassDecorrelatedDeepBoosted_probWqq;}
+  float btag_MassDecorrelatedDeepBoosted_probQCDcc() const{return m_btag_MassDecorrelatedDeepBoosted_probQCDcc;}
+  float btag_MassDecorrelatedDeepBoosted_probHcc() const{return m_btag_MassDecorrelatedDeepBoosted_probHcc;}
+  float btag_MassDecorrelatedDeepBoosted_probZcc() const{return m_btag_MassDecorrelatedDeepBoosted_probZcc;}
+  float btag_MassDecorrelatedDeepBoosted_proWcq() const{return m_btag_MassDecorrelatedDeepBoosted_probWcq;}
+  float btag_MassDecorrelatedDeepBoosted_probZqq() const{return m_btag_MassDecorrelatedDeepBoosted_probZqq;}
+  float btag_MassDecorrelatedDeepBoosted_probHqqqq() const{return m_btag_MassDecorrelatedDeepBoosted_probHqqqq;}
+  float btag_MassDecorrelatedDeepBoosted_probZbb() const{return m_btag_MassDecorrelatedDeepBoosted_probZbb;}
+  float btag_DeepDoubleBvLJet_probHbb() const{return m_btag_DeepDoubleBvLJet_probHbb;}
+  float btag_DeepDoubleBvLJet_probQCD() const{return m_btag_DeepDoubleBvLJet_probQCD;}
+  float btag_DeepDoubleCvBJet_probHbb() const{return m_btag_DeepDoubleCvBJet_probHbb;}
+  float btag_DeepDoubleCvBJet_probHcc() const{return m_btag_DeepDoubleCvBJet_probHcc;}
+  float btag_DeepDoubleCvLJet_probHcc() const{return m_btag_DeepDoubleCvLJet_probHcc;}
+  float btag_DeepDoubleCvLJet_probQCD() const{return m_btag_DeepDoubleCvLJet_probQCD;}
+  float btag_MassIndependentDeepDoubleBvLJet_probHbb() const{return m_btag_MassIndependentDeepDoubleBvLJet_probHbb;}
+  float btag_MassIndependentDeepDoubleBvLJet_probQCD() const{return m_btag_MassIndependentDeepDoubleBvLJet_probQCD;}
+  float btag_MassIndependentDeepDoubleCvBJet_probHbb() const{return m_btag_MassIndependentDeepDoubleCvBJet_probHbb;}
+  float btag_MassIndependentDeepDoubleCvBJet_probHcc() const{return m_btag_MassIndependentDeepDoubleCvBJet_probHcc;}
+  float btag_MassIndependentDeepDoubleCvLJet_probHcc() const{return m_btag_MassIndependentDeepDoubleCvLJet_probHcc;}
+  float btag_MassIndependentDeepDoubleCvLJet_probQCD() const{return m_btag_MassIndependentDeepDoubleCvLJet_probQCD;}
+  float btag_DeepBoosted_TvsQCD() const{return m_btag_DeepBoosted_TvsQCD;}
+  float btag_DeepBoosted_WvsQCD() const{return m_btag_DeepBoosted_WvsQCD;}
+  float btag_DeepBoosted_ZvsQCD() const{return m_btag_DeepBoosted_ZvsQCD;}
+  float btag_DeepBoosted_ZbbvsQCD() const{return m_btag_DeepBoosted_ZbbvsQCD;}
+  float btag_DeepBoosted_HbbvsQCD() const{return m_btag_DeepBoosted_HbbvsQCD;}
+  float btag_DeepBoosted_H4qvsQCD() const{return m_btag_DeepBoosted_H4qvsQCD;}
+  float btag_DeepBoosted_probHbb() const{return m_btag_DeepBoosted_probHbb;}
+  float btag_DeepBoosted_probQCDc() const{return m_btag_DeepBoosted_probQCDc;}
+  float btag_DeepBoosted_probQCDbb() const{return m_btag_DeepBoosted_probQCDbb;}
+  float btag_DeepBoosted_probTbqq() const{return m_btag_DeepBoosted_probTbqq;}
+  float btag_DeepBoosted_probTbcq() const{return m_btag_DeepBoosted_probTbcq;}
+  float btag_DeepBoosted_probTbq() const{return m_btag_DeepBoosted_probTbq;}
+  float btag_DeepBoosted_probQCDothers() const{return m_btag_DeepBoosted_probQCDothers;}
+  float btag_DeepBoosted_probQCDb() const{return m_btag_DeepBoosted_probQCDb;}
+  float btag_DeepBoosted_probTbc() const{return m_btag_DeepBoosted_probTbc;}
+  float btag_DeepBoosted_probWqq() const{return m_btag_DeepBoosted_probWqq;}
+  float btag_DeepBoosted_probQCDcc() const{return m_btag_DeepBoosted_probQCDcc;}
+  float btag_DeepBoosted_probHcc() const{return m_btag_DeepBoosted_probHcc;}
+  float btag_DeepBoosted_probZcc() const{return m_btag_DeepBoosted_probZcc;}
+  float btag_DeepBoosted_proWcq() const{return m_btag_DeepBoosted_probWcq;}
+  float btag_DeepBoosted_probZqq() const{return m_btag_DeepBoosted_probZqq;}
+  float btag_DeepBoosted_probHqqqq() const{return m_btag_DeepBoosted_probHqqqq;}
+  float btag_DeepBoosted_probZbb() const{return m_btag_DeepBoosted_probZbb;}
 
   // setters
   void set_qjets_volatility(float x){m_qjets_volatility = x;}
@@ -138,6 +271,77 @@ public:
   
   void set_tag(tag t, float value){ tags.set_tag(static_cast<int>(t), value);}
 
+  void set_btag_BoostedDoubleSecondaryVertexAK8(float x){m_btag_BoostedDoubleSecondaryVertexAK8=x;}
+  void set_btag_BoostedDoubleSecondaryVertexCA15(float x){m_btag_BoostedDoubleSecondaryVertexCA15=x;}
+
+ void set_btag_MassDecorrelatedDeepBoosted_bbvsLight(float x){m_btag_MassDecorrelatedDeepBoosted_bbvsLight=x;}
+  void set_btag_MassDecorrelatedDeepBoosted_ccvsLight(float x){m_btag_MassDecorrelatedDeepBoosted_ccvsLight=x;}
+  void set_btag_MassDecorrelatedDeepBoosted_TvsQCD(float x){m_btag_MassDecorrelatedDeepBoosted_TvsQCD=x;}
+  void set_btag_MassDecorrelatedDeepBoosted_ZHccvsQCD(float x){m_btag_MassDecorrelatedDeepBoosted_ZHccvsQCD=x;}
+  void set_btag_MassDecorrelatedDeepBoosted_WvsQCD(float x){m_btag_MassDecorrelatedDeepBoosted_WvsQCD=x;}
+  void set_btag_MassDecorrelatedDeepBoosted_ZHbbvsQCD(float x){m_btag_MassDecorrelatedDeepBoosted_ZHbbvsQCD=x;}
+  void set_btag_MassDecorrelatedDeepBoosted_ZvsQCD(float x) {m_btag_MassDecorrelatedDeepBoosted_ZvsQCD=x;}
+  void set_btag_MassDecorrelatedDeepBoosted_ZbbvsQCD(float x) {m_btag_MassDecorrelatedDeepBoosted_ZbbvsQCD=x;}
+  void set_btag_MassDecorrelatedDeepBoosted_HbbvsQCD(float x) {m_btag_MassDecorrelatedDeepBoosted_HbbvsQCD=x;}
+  void set_btag_MassDecorrelatedDeepBoosted_H4qvsQCD(float x) {m_btag_MassDecorrelatedDeepBoosted_H4qvsQCD=x;}
+
+  void set_btag_MassDecorrelatedDeepBoosted_probHbb(float x){m_btag_MassDecorrelatedDeepBoosted_probHbb=x;}
+  void set_btag_MassDecorrelatedDeepBoosted_probQCDc(float x) { m_btag_MassDecorrelatedDeepBoosted_probQCDc=x;}
+  void set_btag_MassDecorrelatedDeepBoosted_probQCDbb(float x) { m_btag_MassDecorrelatedDeepBoosted_probQCDbb=x;}
+  void set_btag_MassDecorrelatedDeepBoosted_probTbqq(float x) { m_btag_MassDecorrelatedDeepBoosted_probTbqq=x;}
+  void set_btag_MassDecorrelatedDeepBoosted_probTbcq(float x) { m_btag_MassDecorrelatedDeepBoosted_probTbcq=x;}
+  void set_btag_MassDecorrelatedDeepBoosted_probTbq(float x) { m_btag_MassDecorrelatedDeepBoosted_probTbq=x;}
+  void set_btag_MassDecorrelatedDeepBoosted_probQCDothers(float x) { m_btag_MassDecorrelatedDeepBoosted_probQCDothers=x;}
+  void set_btag_MassDecorrelatedDeepBoosted_probQCDb(float x) { m_btag_MassDecorrelatedDeepBoosted_probQCDb=x;}
+  void set_btag_MassDecorrelatedDeepBoosted_probTbc(float x) { m_btag_MassDecorrelatedDeepBoosted_probTbc=x;}
+  void set_btag_MassDecorrelatedDeepBoosted_probWqq(float x) { m_btag_MassDecorrelatedDeepBoosted_probWqq=x;}
+  void set_btag_MassDecorrelatedDeepBoosted_probQCDcc(float x) { m_btag_MassDecorrelatedDeepBoosted_probQCDcc=x;}
+  void set_btag_MassDecorrelatedDeepBoosted_probHcc(float x) { m_btag_MassDecorrelatedDeepBoosted_probHcc=x;}
+  void set_btag_MassDecorrelatedDeepBoosted_probZcc(float x) { m_btag_MassDecorrelatedDeepBoosted_probZcc=x;}
+  void set_btag_MassDecorrelatedDeepBoosted_probWcq(float x) { m_btag_MassDecorrelatedDeepBoosted_probWcq=x;}
+  void set_btag_MassDecorrelatedDeepBoosted_probZqq(float x) { m_btag_MassDecorrelatedDeepBoosted_probZqq=x;}
+  void set_btag_MassDecorrelatedDeepBoosted_probHqqqq(float x) { m_btag_MassDecorrelatedDeepBoosted_probHqqqq=x;}
+  void set_btag_MassDecorrelatedDeepBoosted_probZbb(float x) { m_btag_MassDecorrelatedDeepBoosted_probZbb=x;}
+
+  void set_btag_DeepDoubleBvLJet_probHbb(float x) {  m_btag_DeepDoubleBvLJet_probHbb=x;}
+  void set_btag_DeepDoubleBvLJet_probQCD(float x) {  m_btag_DeepDoubleBvLJet_probQCD=x;}
+  void set_btag_DeepDoubleCvBJet_probHbb(float x) {  m_btag_DeepDoubleCvBJet_probHbb=x;}
+  void set_btag_DeepDoubleCvBJet_probHcc(float x) {  m_btag_DeepDoubleCvBJet_probHcc=x;}
+  void set_btag_DeepDoubleCvLJet_probHcc(float x) {  m_btag_DeepDoubleCvLJet_probHcc=x;}
+  void set_btag_DeepDoubleCvLJet_probQCD(float x) {  m_btag_DeepDoubleCvLJet_probQCD=x;}
+
+  void set_btag_MassIndependentDeepDoubleBvLJet_probHbb(float x) {  m_btag_MassIndependentDeepDoubleBvLJet_probHbb=x;}
+  void set_btag_MassIndependentDeepDoubleBvLJet_probQCD(float x) {  m_btag_MassIndependentDeepDoubleBvLJet_probQCD=x;}
+  void set_btag_MassIndependentDeepDoubleCvBJet_probHbb(float x) {  m_btag_MassIndependentDeepDoubleCvBJet_probHbb=x;}
+  void set_btag_MassIndependentDeepDoubleCvBJet_probHcc(float x) {  m_btag_MassIndependentDeepDoubleCvBJet_probHcc=x;}
+  void set_btag_MassIndependentDeepDoubleCvLJet_probHcc(float x) {  m_btag_MassIndependentDeepDoubleCvLJet_probHcc=x;}
+  void set_btag_MassIndependentDeepDoubleCvLJet_probQCD(float x) {  m_btag_MassIndependentDeepDoubleCvLJet_probQCD=x;}
+
+  void set_btag_DeepBoosted_TvsQCD(float x){m_btag_DeepBoosted_TvsQCD=x;}
+  void set_btag_DeepBoosted_WvsQCD(float x){m_btag_DeepBoosted_WvsQCD=x;}
+  void set_btag_DeepBoosted_ZvsQCD(float x) {m_btag_DeepBoosted_ZvsQCD=x;}
+  void set_btag_DeepBoosted_ZbbvsQCD(float x) {m_btag_DeepBoosted_ZbbvsQCD=x;}
+  void set_btag_DeepBoosted_HbbvsQCD(float x) {m_btag_DeepBoosted_HbbvsQCD=x;}
+  void set_btag_DeepBoosted_H4qvsQCD(float x) {m_btag_DeepBoosted_H4qvsQCD=x;}
+
+  void set_btag_DeepBoosted_probHbb(float x){m_btag_DeepBoosted_probHbb=x;}
+  void set_btag_DeepBoosted_probQCDc(float x) { m_btag_DeepBoosted_probQCDc=x;}
+  void set_btag_DeepBoosted_probQCDbb(float x) { m_btag_DeepBoosted_probQCDbb=x;}
+  void set_btag_DeepBoosted_probTbqq(float x) { m_btag_DeepBoosted_probTbqq=x;}
+  void set_btag_DeepBoosted_probTbcq(float x) { m_btag_DeepBoosted_probTbcq=x;}
+  void set_btag_DeepBoosted_probTbq(float x) { m_btag_DeepBoosted_probTbq=x;}
+  void set_btag_DeepBoosted_probQCDothers(float x) { m_btag_DeepBoosted_probQCDothers=x;}
+  void set_btag_DeepBoosted_probQCDb(float x) { m_btag_DeepBoosted_probQCDb=x;}
+  void set_btag_DeepBoosted_probTbc(float x) { m_btag_DeepBoosted_probTbc=x;}
+  void set_btag_DeepBoosted_probWqq(float x) { m_btag_DeepBoosted_probWqq=x;}
+  void set_btag_DeepBoosted_probQCDcc(float x) { m_btag_DeepBoosted_probQCDcc=x;}
+  void set_btag_DeepBoosted_probHcc(float x) { m_btag_DeepBoosted_probHcc=x;}
+  void set_btag_DeepBoosted_probZcc(float x) { m_btag_DeepBoosted_probZcc=x;}
+  void set_btag_DeepBoosted_probWcq(float x) { m_btag_DeepBoosted_probWcq=x;}
+  void set_btag_DeepBoosted_probZqq(float x) { m_btag_DeepBoosted_probZqq=x;}
+  void set_btag_DeepBoosted_probHqqqq(float x) { m_btag_DeepBoosted_probHqqqq=x;}
+  void set_btag_DeepBoosted_probZbb(float x) { m_btag_DeepBoosted_probZbb=x;}
+
 private:
   std::vector<Jet> m_subjets;
 
@@ -158,8 +362,72 @@ private:
   float m_ecfN3_beta2;
 
   float m_mvahiggsdiscr;
-
   float m_softdropmass;
+
+  float m_btag_BoostedDoubleSecondaryVertexAK8;
+  float m_btag_BoostedDoubleSecondaryVertexCA15;
+  float m_btag_MassDecorrelatedDeepBoosted_bbvsLight;
+  float m_btag_MassDecorrelatedDeepBoosted_ccvsLight;
+  float m_btag_MassDecorrelatedDeepBoosted_TvsQCD;
+  float m_btag_MassDecorrelatedDeepBoosted_ZHccvsQCD;
+  float m_btag_MassDecorrelatedDeepBoosted_WvsQCD;
+  float m_btag_MassDecorrelatedDeepBoosted_ZHbbvsQCD;
+  float m_btag_MassDecorrelatedDeepBoosted_ZvsQCD;
+  float m_btag_MassDecorrelatedDeepBoosted_ZbbvsQCD;
+  float m_btag_MassDecorrelatedDeepBoosted_HbbvsQCD;
+  float m_btag_MassDecorrelatedDeepBoosted_H4qvsQCD;
+  float m_btag_DeepBoosted_ZvsQCD;
+  float m_btag_DeepBoosted_ZbbvsQCD;
+  float m_btag_DeepBoosted_HbbvsQCD;
+  float m_btag_DeepBoosted_H4qvsQCD;
+  float m_btag_MassDecorrelatedDeepBoosted_probHbb;
+  float m_btag_MassDecorrelatedDeepBoosted_probQCDc;
+  float m_btag_MassDecorrelatedDeepBoosted_probQCDbb;
+  float m_btag_MassDecorrelatedDeepBoosted_probTbqq;
+  float m_btag_MassDecorrelatedDeepBoosted_probTbcq;
+  float m_btag_MassDecorrelatedDeepBoosted_probTbq;
+  float m_btag_MassDecorrelatedDeepBoosted_probQCDothers;
+  float m_btag_MassDecorrelatedDeepBoosted_probQCDb;
+  float m_btag_MassDecorrelatedDeepBoosted_probTbc;
+  float m_btag_MassDecorrelatedDeepBoosted_probWqq;
+  float m_btag_MassDecorrelatedDeepBoosted_probQCDcc;
+  float m_btag_MassDecorrelatedDeepBoosted_probHcc;
+  float m_btag_MassDecorrelatedDeepBoosted_probWcq;
+  float m_btag_MassDecorrelatedDeepBoosted_probZcc;
+  float m_btag_MassDecorrelatedDeepBoosted_probZqq;
+  float m_btag_MassDecorrelatedDeepBoosted_probHqqqq;
+  float m_btag_MassDecorrelatedDeepBoosted_probZbb;
+  float m_btag_DeepDoubleBvLJet_probHbb;
+  float m_btag_DeepDoubleBvLJet_probQCD;
+  float m_btag_DeepDoubleCvBJet_probHbb;
+  float m_btag_DeepDoubleCvBJet_probHcc;
+  float m_btag_DeepDoubleCvLJet_probHcc;
+  float m_btag_DeepDoubleCvLJet_probQCD;
+  float m_btag_MassIndependentDeepDoubleBvLJet_probHbb;
+  float m_btag_MassIndependentDeepDoubleBvLJet_probQCD;
+  float m_btag_MassIndependentDeepDoubleCvBJet_probHbb;
+  float m_btag_MassIndependentDeepDoubleCvBJet_probHcc;
+  float m_btag_MassIndependentDeepDoubleCvLJet_probHcc;
+  float m_btag_MassIndependentDeepDoubleCvLJet_probQCD;
+  float m_btag_DeepBoosted_TvsQCD;
+  float m_btag_DeepBoosted_WvsQCD;
+  float m_btag_DeepBoosted_probHbb;
+  float m_btag_DeepBoosted_probQCDc;
+  float m_btag_DeepBoosted_probQCDbb;
+  float m_btag_DeepBoosted_probTbqq;
+  float m_btag_DeepBoosted_probTbcq;
+  float m_btag_DeepBoosted_probTbq;
+  float m_btag_DeepBoosted_probQCDothers;
+  float m_btag_DeepBoosted_probQCDb;
+  float m_btag_DeepBoosted_probTbc;
+  float m_btag_DeepBoosted_probWqq;
+  float m_btag_DeepBoosted_probQCDcc;
+  float m_btag_DeepBoosted_probHcc;
+  float m_btag_DeepBoosted_probWcq;
+  float m_btag_DeepBoosted_probZcc;
+  float m_btag_DeepBoosted_probZqq;
+  float m_btag_DeepBoosted_probHqqqq;
+  float m_btag_DeepBoosted_probZbb;
 
   Tags tags;
 };

--- a/core/plugins/NtupleWriterJets.cxx
+++ b/core/plugins/NtupleWriterJets.cxx
@@ -164,7 +164,7 @@ void NtupleWriterJets::process(const edm::Event & event, uhh2::Event & uevent,  
 	bool storePFcands = false;
 	if(i<NPFJetwConstituents_) storePFcands = true;
         try {
-          fill_jet_info(uevent,pat_jet, jet, true, false, jet_puppiSpecificProducer,storePFcands,false);
+          fill_jet_info(uevent,pat_jet, jet, true, false, jet_puppiSpecificProducer,storePFcands);
         }
         catch(runtime_error & ex){
           throw cms::Exception("fill_jet_info error", "Error in fill_jet_info NtupleWriterJets::process for jets with src = " + src.label());
@@ -194,7 +194,7 @@ void NtupleWriterJets::process(const edm::Event & event, uhh2::Event & uevent,  
 }
 
 
-void NtupleWriterJets::fill_jet_info(uhh2::Event & uevent, const pat::Jet & pat_jet, Jet & jet, bool do_btagging, bool do_taginfo, const std::string & puppiJetSpecificProducer, bool fill_pfcand, bool isTopJet){
+void NtupleWriterJets::fill_jet_info(uhh2::Event & uevent, const pat::Jet & pat_jet, Jet & jet, bool do_btagging, bool do_taginfo, const std::string & puppiJetSpecificProducer, bool fill_pfcand){
   jet.set_charge(pat_jet.charge());
   jet.set_pt(pat_jet.pt());
   jet.set_eta(pat_jet.eta());
@@ -331,43 +331,8 @@ void NtupleWriterJets::fill_jet_info(uhh2::Event & uevent, const pat::Jet & pat_
   }//do taginfos
   if(do_btagging){
     const auto & bdisc = pat_jet.getPairDiscri();
-    bool csv = false, csvmva = false, doubleak8 = false, doubleca15 = false, deepcsv_b = false, deepcsv_bb = false, deepflavour_bb=false, deepflavour_b=false, deepflavour_lepb=false, deepflavour_c=false, deepflavour_uds=false, deepflavour_g=false, 
-decorrmass_deepboosted_bbvsLight=false,decorrmass_deepboosted_ccvsLight=false,decorrmass_deepboosted_TvsQCD=false,decorrmass_deepboosted_ZHccvsQCD=false,decorrmass_deepboosted_WvsQCD=false,decorrmass_deepboosted_ZHbbvsQCD=false,
-decorrmass_deepboosted_ZvsQCD=false,decorrmass_deepboosted_ZbbvsQCD=false,decorrmass_deepboosted_HbbvsQCD=false,decorrmass_deepboosted_H4qvsQCD=false,
-deepboosted_bbvsLight=false,deepboosted_ccvsLight=false,deepboosted_TvsQCD=false,deepboosted_ZHccvsQCD=false,deepboosted_WvsQCD=false,deepboosted_ZHbbvsQCD=false,
-deepboosted_ZvsQCD=false,deepboosted_ZbbvsQCD=false,deepboosted_HbbvsQCD=false,deepboosted_H4qvsQCD=false,
-deepboosted_probHbb=false,deepboosted_probQCDbb=false,deepboosted_probQCDc=false,deepboosted_probTbqq=false,deepboosted_probTbcq=false,deepboosted_probTbq=false,deepboosted_probQCDothers=false,deepboosted_probQCDb=false,deepboosted_probTbc=false,deepboosted_probWqq=false,deepboosted_probQCDcc=false,deepboosted_probHcc=false,deepboosted_probWcq=false,deepboosted_probZcc=false,deepboosted_probZqq=false,deepboosted_probHqqqq=false,deepboosted_probZbb=false,
-deepdouble_H=false,deepdouble_QCD=false, deepdouble_cl_H=false,deepdouble_cl_QCD=false, deepdouble_cb_H=false,deepdouble_cb_QCD=false,
-massinddeepdouble_H=false,massinddeepdouble_QCD=false, massinddeepdouble_cl_H=false,massinddeepdouble_cl_QCD=false, massinddeepdouble_cb_H=false,massinddeepdouble_cb_QCD=false,
-decorrmass_deepboosted_probHbb=false,decorrmass_deepboosted_probQCDbb=false,decorrmass_deepboosted_probQCDc=false,decorrmass_deepboosted_probTbqq=false,decorrmass_deepboosted_probTbcq=false,decorrmass_deepboosted_probTbq=false,decorrmass_deepboosted_probQCDothers=false,decorrmass_deepboosted_probQCDb=false,decorrmass_deepboosted_probTbc=false,decorrmass_deepboosted_probWqq=false,decorrmass_deepboosted_probQCDcc=false,decorrmass_deepboosted_probHcc=false,decorrmass_deepboosted_probWcq=false,decorrmass_deepboosted_probZcc=false,decorrmass_deepboosted_probZqq=false,decorrmass_deepboosted_probHqqqq=false,decorrmass_deepboosted_probZbb=false;
-    if(!isTopJet){
-      //slim (= not fat) jets don't have DeepBoosted info, etc
-      // set booleans to 'true' to avoid warnings in b-taggers check
-      doubleak8 = true; doubleca15 = true;
-      decorrmass_deepboosted_bbvsLight=true; decorrmass_deepboosted_ccvsLight=true; 
-      decorrmass_deepboosted_TvsQCD=true; decorrmass_deepboosted_ZHccvsQCD=true; 
-      decorrmass_deepboosted_WvsQCD=true; decorrmass_deepboosted_ZHbbvsQCD=true;
-      decorrmass_deepboosted_ZvsQCD=true; decorrmass_deepboosted_ZbbvsQCD=true;
-      decorrmass_deepboosted_HbbvsQCD=true; decorrmass_deepboosted_H4qvsQCD=true;
-      deepboosted_bbvsLight=true; deepboosted_ccvsLight=true; deepboosted_TvsQCD=true;
-      deepboosted_ZHccvsQCD=true; deepboosted_WvsQCD=true; deepboosted_ZHbbvsQCD=true;
-      deepboosted_ZvsQCD=true; deepboosted_ZbbvsQCD=true; deepboosted_HbbvsQCD=true;
-      deepboosted_H4qvsQCD=true; deepboosted_probHbb=true; deepboosted_probQCDbb=true; deepboosted_probQCDc=true;
-      deepboosted_probTbqq=true; deepboosted_probTbcq=true; deepboosted_probTbq=true; deepboosted_probQCDothers=true;
-      deepboosted_probQCDb=true; deepboosted_probTbc=true; deepboosted_probWqq=true; deepboosted_probQCDcc=true;
-      deepboosted_probHcc=true; deepboosted_probWcq=true; deepboosted_probZcc=true; deepboosted_probZqq=true; deepboosted_probHqqqq=true;
-      deepboosted_probZbb=true; deepdouble_H=true; deepdouble_QCD=true; deepdouble_cl_H=true;
-      deepdouble_cl_QCD=true; deepdouble_cb_H=true; deepdouble_cb_QCD=true;
-      massinddeepdouble_H=true; massinddeepdouble_QCD=true; massinddeepdouble_cl_H=true;
-      massinddeepdouble_cl_QCD=true; massinddeepdouble_cb_H=true; massinddeepdouble_cb_QCD=true;
-      decorrmass_deepboosted_probHbb=true; decorrmass_deepboosted_probQCDbb=true; 
-      decorrmass_deepboosted_probQCDc=true; decorrmass_deepboosted_probTbqq=true;
-      decorrmass_deepboosted_probTbcq=true; decorrmass_deepboosted_probTbq=true; decorrmass_deepboosted_probQCDothers=true;
-      decorrmass_deepboosted_probQCDb=true; decorrmass_deepboosted_probTbc=true; decorrmass_deepboosted_probWqq=true;
-      decorrmass_deepboosted_probQCDcc=true; decorrmass_deepboosted_probHcc=true; decorrmass_deepboosted_probWcq=true;
-      decorrmass_deepboosted_probZcc=true; decorrmass_deepboosted_probZqq=true; decorrmass_deepboosted_probHqqqq=true;
-      decorrmass_deepboosted_probZbb=true;
-    }
+    bool csv = false, csvmva = false,  deepcsv_b = false, deepcsv_bb = false;
+    bool deepflavour_bb=false, deepflavour_b=false, deepflavour_lepb=false, deepflavour_c=false, deepflavour_uds=false, deepflavour_g=false;
     for(const auto & name_value : bdisc){
       const auto & name = name_value.first;
       const auto & value = name_value.second;
@@ -386,14 +351,6 @@ decorrmass_deepboosted_probHbb=false,decorrmass_deepboosted_probQCDbb=false,deco
       else if(name == "pfDeepCSVJetTags:probbb"){
         jet.set_btag_DeepCSV_probbb(value);
         deepcsv_bb = true;
-      }
-      else if(name == "pfBoostedDoubleSecondaryVertexAK8BJetTags"){
-        jet.set_btag_BoostedDoubleSecondaryVertexAK8(value);
-        doubleak8 = true;
-      }
-      else if(name == "pfBoostedDoubleSecondaryVertexCA15BJetTags"){
-        jet.set_btag_BoostedDoubleSecondaryVertexCA15(value);
-        doubleca15 = true;
       }
       else if(name=="pfDeepFlavourJetTags:probbb"){
         jet.set_btag_DeepFlavour_probbb(value);
@@ -418,6 +375,156 @@ decorrmass_deepboosted_probHbb=false,decorrmass_deepboosted_probQCDbb=false,deco
       else if(name=="pfDeepFlavourJetTags:probg"){
         jet.set_btag_DeepFlavour_probg(value);
         deepflavour_g =true;
+      }
+    }
+   
+
+
+    if(!csv || !csvmva || !deepcsv_b || !deepcsv_bb
+       || !deepflavour_bb || !deepflavour_b || !deepflavour_lepb
+       || !deepflavour_uds || !deepflavour_c || !deepflavour_g){
+      if(btag_warning){
+        std::string btag_list = "";
+        for(const auto & name_value : bdisc){
+          btag_list += name_value.first;
+          btag_list += " ";
+        }
+        edm::LogWarning("NtupleWriterJets") << "Did not find all b-taggers! Available btaggers: " << btag_list;
+        btag_warning = false;
+      }
+      // throw runtime_error("did not find all b-taggers; see output for details");
+    }
+  }
+
+  if(fill_pfcand){//fill pf candidates list: add pf-candidate to the event list and store index in the jet container
+    const auto& jet_daughter_ptrs = pat_jet.daughterPtrVector();
+    for(const auto & daughter_p : jet_daughter_ptrs){
+      size_t pfparticles_index = add_pfpart(*daughter_p, *uevent.pfparticles);
+      jet.add_pfcand_index(pfparticles_index);
+    }
+  }
+}
+
+
+NtupleWriterTopJets::NtupleWriterTopJets(Config & cfg, bool set_jets_member, unsigned int NPFJetwConstituents): ptmin(cfg.ptmin), etamax(cfg.etamax) {
+    handle = cfg.ctx.declare_event_output<vector<TopJet>>(cfg.dest_branchname, cfg.dest);
+    if(set_jets_member){
+        topjets_handle = cfg.ctx.get_handle<vector<TopJet>>("topjets");
+    }
+    src_token = cfg.cc.consumes<std::vector<pat::Jet>>(cfg.src);
+    njettiness_src = cfg.njettiness_src;
+    src_njettiness1_token = cfg.cc.consumes<edm::ValueMap<float> >(edm::InputTag(njettiness_src, "tau1"));
+    src_njettiness2_token = cfg.cc.consumes<edm::ValueMap<float> >(edm::InputTag(njettiness_src, "tau2"));
+    src_njettiness3_token = cfg.cc.consumes<edm::ValueMap<float> >(edm::InputTag(njettiness_src, "tau3"));
+    src_njettiness4_token = cfg.cc.consumes<edm::ValueMap<float> >(edm::InputTag(njettiness_src, "tau4"));
+
+    njettiness_groomed_src = cfg.njettiness_groomed_src;
+    src_njettiness1_groomed_token = cfg.cc.consumes<edm::ValueMap<float> >(edm::InputTag(njettiness_groomed_src, "tau1"));
+    src_njettiness2_groomed_token = cfg.cc.consumes<edm::ValueMap<float> >(edm::InputTag(njettiness_groomed_src, "tau2"));
+    src_njettiness3_groomed_token = cfg.cc.consumes<edm::ValueMap<float> >(edm::InputTag(njettiness_groomed_src, "tau3"));
+    src_njettiness4_groomed_token = cfg.cc.consumes<edm::ValueMap<float> >(edm::InputTag(njettiness_groomed_src, "tau4"));
+
+    qjets_src = cfg.qjets_src;
+    src_qjets_token = cfg.cc.consumes<edm::ValueMap<float> >(edm::InputTag(qjets_src, "QjetsVolatility"));
+
+    ecf_beta1_src = cfg.ecf_beta1_src;
+    src_ecf_beta1_N2_token = cfg.cc.consumes<edm::ValueMap<float> >(edm::InputTag(ecf_beta1_src, "ecfN2"));
+    src_ecf_beta1_N3_token = cfg.cc.consumes<edm::ValueMap<float> >(edm::InputTag(ecf_beta1_src, "ecfN3"));
+    ecf_beta2_src = cfg.ecf_beta2_src;
+    src_ecf_beta2_N2_token = cfg.cc.consumes<edm::ValueMap<float> >(edm::InputTag(ecf_beta2_src, "ecfN2"));
+    src_ecf_beta2_N3_token = cfg.cc.consumes<edm::ValueMap<float> >(edm::InputTag(ecf_beta2_src, "ecfN3"));
+
+    subjet_src = cfg.subjet_src;
+    higgs_src= cfg.higgs_src;
+
+    if (cfg.toptagging_src == "") {
+      do_toptagging = false;
+    } else {
+      do_toptagging = true;
+      src_hepTopTag_token = cfg.cc.consumes<edm::View<reco::HTTTopJetTagInfo> >(edm::InputTag(cfg.toptagging_src));
+    }
+
+    softdrop_src = cfg.softdrop_src;
+    if(softdrop_src.find("Mass")==string::npos){
+      src_softdrop_token = cfg.cc.consumes<std::vector<pat::Jet>>(cfg.softdrop_src);
+    }
+
+    src_higgs_token = cfg.cc.consumes<std::vector<pat::Jet>>(cfg.higgs_src);
+    higgs_name=cfg.higgs_name;
+    do_taginfo_subjets = cfg.do_taginfo_subjets;
+    src = cfg.src;
+    do_btagging = cfg.do_btagging;
+    do_btagging_subjets = cfg.do_btagging_subjets;
+    if(!njettiness_src.empty() || !qjets_src.empty()){
+        substructure_variables_src_token = cfg.cc.consumes<reco::BasicJetCollection>(cfg.substructure_variables_src);
+	substructure_variables_src_tokenreco = cfg.cc.consumes<reco::PFJetCollection>(cfg.substructure_variables_src);
+    }
+    if(!njettiness_groomed_src.empty()){
+        substructure_groomed_variables_src_token = cfg.cc.consumes<reco::BasicJetCollection>(cfg.substructure_groomed_variables_src);
+	substructure_groomed_variables_src_tokenreco = cfg.cc.consumes<reco::PFJetCollection>(cfg.substructure_groomed_variables_src);
+    }
+    btag_warning=true;
+    topjet_collection = cfg.dest_branchname;
+
+    topjet_puppiSpecificProducer = getPuppiJetSpecificProducer(src.label());
+
+    save_lepton_keys_ = false;
+
+    h_muons.clear();
+    h_elecs.clear();
+
+    higgstaginfo_src = cfg.higgstaginfo_src;
+    src_higgstaginfo_token =  cfg.cc.consumes<std::vector<reco::BoostedDoubleSVTagInfo> >(cfg.higgstaginfo_src);
+    NPFJetwConstituents_ = NPFJetwConstituents;
+}
+
+NtupleWriterTopJets::NtupleWriterTopJets(Config & cfg, bool set_jets_member, const std::vector<std::string>& muon_sources, const std::vector<std::string>& elec_sources, unsigned int NPFJetwConstituents):
+  NtupleWriterTopJets::NtupleWriterTopJets(cfg, set_jets_member, NPFJetwConstituents) {
+
+    save_lepton_keys_ = true;
+
+    for(const auto& muo_src : muon_sources){ auto h_muon = cfg.ctx.get_handle<std::vector<Muon>    >(muo_src); h_muons.push_back(h_muon); }
+    for(const auto& ele_src : elec_sources){ auto h_elec = cfg.ctx.get_handle<std::vector<Electron>>(ele_src); h_elecs.push_back(h_elec); }
+    NPFJetwConstituents_ = NPFJetwConstituents;
+}
+
+NtupleWriterTopJets::~NtupleWriterTopJets(){}
+
+
+void NtupleWriterTopJets::fill_btag_info(uhh2::Event & uevent, const pat::Jet & pat_jet, TopJet & jet){
+  const auto & bdisc = pat_jet.getPairDiscri();
+  bool doubleak8 = false, doubleca15 = false,
+    decorrmass_deepboosted_bbvsLight=false,decorrmass_deepboosted_ccvsLight=false,decorrmass_deepboosted_TvsQCD=false,
+    decorrmass_deepboosted_ZHccvsQCD=false,decorrmass_deepboosted_WvsQCD=false,decorrmass_deepboosted_ZHbbvsQCD=false,
+    decorrmass_deepboosted_ZvsQCD=false,decorrmass_deepboosted_ZbbvsQCD=false,decorrmass_deepboosted_HbbvsQCD=false,
+    decorrmass_deepboosted_H4qvsQCD=false,deepboosted_bbvsLight=false,deepboosted_ccvsLight=false,deepboosted_TvsQCD=false,
+    deepboosted_ZHccvsQCD=false,deepboosted_WvsQCD=false,deepboosted_ZHbbvsQCD=false,
+    deepboosted_ZvsQCD=false,deepboosted_ZbbvsQCD=false,deepboosted_HbbvsQCD=false,deepboosted_H4qvsQCD=false,
+    deepboosted_probHbb=false,deepboosted_probQCDbb=false,deepboosted_probQCDc=false,deepboosted_probTbqq=false,
+    deepboosted_probTbcq=false,deepboosted_probTbq=false,deepboosted_probQCDothers=false,deepboosted_probQCDb=false,
+    deepboosted_probTbc=false,deepboosted_probWqq=false,deepboosted_probQCDcc=false,deepboosted_probHcc=false,
+    deepboosted_probWcq=false,deepboosted_probZcc=false,deepboosted_probZqq=false,deepboosted_probHqqqq=false,
+    deepboosted_probZbb=false, deepdouble_H=false,deepdouble_QCD=false, deepdouble_cl_H=false,deepdouble_cl_QCD=false, 
+    deepdouble_cb_H=false,deepdouble_cb_QCD=false, massinddeepdouble_H=false,massinddeepdouble_QCD=false, 
+    massinddeepdouble_cl_H=false,massinddeepdouble_cl_QCD=false, massinddeepdouble_cb_H=false,massinddeepdouble_cb_QCD=false,
+    decorrmass_deepboosted_probHbb=false,decorrmass_deepboosted_probQCDbb=false,decorrmass_deepboosted_probQCDc=false,
+    decorrmass_deepboosted_probTbqq=false,decorrmass_deepboosted_probTbcq=false,decorrmass_deepboosted_probTbq=false,
+    decorrmass_deepboosted_probQCDothers=false,decorrmass_deepboosted_probQCDb=false,decorrmass_deepboosted_probTbc=false,
+    decorrmass_deepboosted_probWqq=false,decorrmass_deepboosted_probQCDcc=false,decorrmass_deepboosted_probHcc=false,
+    decorrmass_deepboosted_probWcq=false,decorrmass_deepboosted_probZcc=false,decorrmass_deepboosted_probZqq=false,
+    decorrmass_deepboosted_probHqqqq=false,decorrmass_deepboosted_probZbb=false;
+
+   
+    for(const auto & name_value : bdisc){
+      const auto & name = name_value.first;
+      const auto & value = name_value.second;
+      if(name == "pfBoostedDoubleSecondaryVertexAK8BJetTags"){
+        jet.set_btag_BoostedDoubleSecondaryVertexAK8(value);
+        doubleak8 = true;
+      }
+      else if(name == "pfBoostedDoubleSecondaryVertexCA15BJetTags"){
+        jet.set_btag_BoostedDoubleSecondaryVertexCA15(value);
+        doubleca15 = true;
       }
       else if(name == "pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:bbvsLight"){
         jet.set_btag_MassDecorrelatedDeepBoosted_bbvsLight(value);
@@ -678,13 +785,7 @@ decorrmass_deepboosted_probHbb=false,decorrmass_deepboosted_probQCDbb=false,deco
 
     }
    
-
-
-
-    if(!csv || !csvmva || !doubleak8 || !doubleca15 || !deepcsv_b || !deepcsv_bb
-       || !deepflavour_bb || !deepflavour_b || !deepflavour_lepb
-       || !deepflavour_uds || !deepflavour_c || !deepflavour_g
-       || !decorrmass_deepboosted_bbvsLight || !decorrmass_deepboosted_ccvsLight
+    if(!doubleak8 || !doubleca15 || !decorrmass_deepboosted_bbvsLight || !decorrmass_deepboosted_ccvsLight
        || !decorrmass_deepboosted_TvsQCD || !decorrmass_deepboosted_ZHccvsQCD
        || !decorrmass_deepboosted_WvsQCD || !decorrmass_deepboosted_ZHbbvsQCD
        || !decorrmass_deepboosted_ZvsQCD || !decorrmass_deepboosted_ZbbvsQCD || !decorrmass_deepboosted_HbbvsQCD || !decorrmass_deepboosted_H4qvsQCD
@@ -715,152 +816,13 @@ decorrmass_deepboosted_probHbb=false,decorrmass_deepboosted_probQCDbb=false,deco
           btag_list += name_value.first;
           btag_list += " ";
         }
-        edm::LogWarning("NtupleWriterJets") << "Did not find all b-taggers! Available btaggers: " << btag_list;
-	/*	cout<<"Didn't find these: "<<endl;
-	if(!csv) cout<<"!csv"; 
-	if(!doubleak8) cout<<"!doubleak8"; 
-	if(!doubleca15) cout<<"!doubleca15"; if(!deepcsv_b) cout<<"!deepcsv_b";
-	if(!deepcsv_bb) cout<<"!deepcsv_bb"; if(!csvmva) cout<<"!csvmva";
-	if(!deepflavour_bb) cout<<"!deepflavour_bb"; if(!deepflavour_b) cout<<"!deepflavour_b "; if(!deepflavour_lepb) cout<<"!deepflavour_lepb";
-	if(!deepflavour_uds) cout<<"!deepflavour_uds "; if(!deepflavour_c) cout<<"!deepflavour_c "; if(!deepflavour_g) cout<<"!deepflavour_g";
-	if(!decorrmass_deepboosted_bbvsLight) cout<<"!decorrmass_deepboosted_bbvsLight"; if(!decorrmass_deepboosted_ccvsLight) cout<<"!decorrmass_deepboosted_ccvsLight";
-	if(!decorrmass_deepboosted_TvsQCD) cout<<"!decorrmass_deepboosted_TvsQCD"; if(!decorrmass_deepboosted_ZHccvsQCD) cout<<"!decorrmass_deepboosted_ZHccvsQCD";
-	if(!decorrmass_deepboosted_WvsQCD) cout<<"!decorrmass_deepboosted_WvsQCD"; if(!decorrmass_deepboosted_ZHbbvsQCD) cout<<"!decorrmass_deepboosted_ZHbbvsQCD";
-	if(!decorrmass_deepboosted_ZvsQCD) cout<<"!decorrmass_deepboosted_ZvsQCD"; if(!decorrmass_deepboosted_ZbbvsQCD) cout<<"!decorrmass_deepboosted_ZbbvsQCD ";
-	if(!decorrmass_deepboosted_HbbvsQCD) cout<<"!decorrmass_deepboosted_HbbvsQCD"; if(!decorrmass_deepboosted_H4qvsQCD) cout<<"!decorrmass_deepboosted_H4qvsQCD";
-	if(!deepboosted_bbvsLight) cout<<"!deepboosted_bbvsLight";  if(!deepboosted_ccvsLight) cout<<"!deepboosted_ccvsLight";
-	if(!deepboosted_TvsQCD) cout<<"!deepboosted_TvsQCD"; if(!deepboosted_ZHccvsQCD) cout<<"!deepboosted_ZHccvsQCD";
-	if(!deepboosted_WvsQCD) cout<<"!deepboosted_WvsQCD"; if(!deepboosted_ZHbbvsQCD) cout<<"!deepboosted_ZHbbvsQCD";
-	if(!deepboosted_ZvsQCD) cout<<"!deepboosted_ZvsQCD"; if(!deepboosted_ZbbvsQCD) cout<<"!deepboosted_ZbbvsQCD";
-	if(!deepboosted_HbbvsQCD) cout<<"!deepboosted_HbbvsQCD"; if(!deepboosted_H4qvsQCD) cout<<"!deepboosted_H4qvsQCD";
-	if(!deepboosted_probHbb) cout<<"!deepboosted_probHbb";  if(!deepboosted_probQCDbb) cout<<"!deepboosted_probQCDbb";
-	if(!deepboosted_probQCDc) cout<<"!deepboosted_probQCDc";    if(!deepboosted_probTbqq) cout<<"!deepboosted_probTbqq";
-	if(!deepboosted_probTbcq) cout<<"!deepboosted_probTbcq";    if(!deepboosted_probTbq) cout<<"!deepboosted_probTbq";
-	if(!deepboosted_probQCDothers) cout<<"!deepboosted_probQCDothers";    if(!deepboosted_probQCDb) cout<<"!deepboosted_probQCDb";
-	if(!deepboosted_probTbc) cout<<"!deepboosted_probTbc";    if(!deepboosted_probWqq) cout<<"!deepboosted_probWqq";
-	if(!deepboosted_probQCDcc) cout<<"!deepboosted_probQCDcc";     if(!deepboosted_probHcc) cout<<"!deepboosted_probHcc";
-	if(!deepboosted_probWcq) cout<<"!deepboosted_probWcq";    if(!deepboosted_probZcc) cout<<"!deepboosted_probZcc";
-	if(!deepboosted_probZqq) cout<<"!deepboosted_probZqq";    if(!deepboosted_probHqqqq) cout<<"!deepboosted_probHqqqq ";
-	if(!deepboosted_probZbb) cout<<"!deepboosted_probZbb ";    if(!deepdouble_H) cout<<"!deepdouble_H ";
-	if(!deepdouble_QCD) cout<<"!deepdouble_QCD";    if(!deepdouble_cb_H) cout<<"!deepdouble_cb_H";
-	if(!deepdouble_cl_H) cout<<"!deepdouble_cl_H";    if(!deepdouble_cl_QCD) cout<<"!deepdouble_cl_QCD "; if(!deepdouble_cb_QCD) cout<<"!deepdouble_cb_QCD";
-	if(!massinddeepdouble_QCD) cout<<"!massinddeepdouble_QCD";    if(!massinddeepdouble_H) cout<<"!massinddeepdouble_H";
-	if(!massinddeepdouble_cb_H) cout<<"!massinddeepdouble_cb_H ";    if(!massinddeepdouble_cl_H) cout<<"!massinddeepdouble_cl_H";
-	if(!massinddeepdouble_cl_QCD) cout<<"!massinddeepdouble_cl_QCD";    if(!massinddeepdouble_cb_QCD) cout<<"!massinddeepdouble_cb_QCD";
-	if(!decorrmass_deepboosted_probHbb) cout<<"!decorrmass_deepboosted_probHbb";  if(!decorrmass_deepboosted_probQCDbb) cout<<"!decorrmass_deepboosted_probQCDbb";
-	if(!decorrmass_deepboosted_probQCDc) cout<<"!decorrmass_deepboosted_probQCDc";    if(!decorrmass_deepboosted_probTbqq) cout<<"!decorrmass_deepboosted_probTbqq";
-	if(!decorrmass_deepboosted_probTbcq) cout<<"!decorrmass_deepboosted_probTbcq";    if(!decorrmass_deepboosted_probTbq) cout<<"!decorrmass_deepboosted_probTbq";
-	if(!decorrmass_deepboosted_probQCDothers) cout<<"!decorrmass_deepboosted_probQCDothers";    
-	if(!decorrmass_deepboosted_probQCDb) cout<<"!decorrmass_deepboosted_probQCDb";
-	if(!decorrmass_deepboosted_probTbc) cout<<"!decorrmass_deepboosted_probTbc";
-	if(!decorrmass_deepboosted_probWqq) cout<<"!decorrmass_deepboosted_probWqq";
-	if(!decorrmass_deepboosted_probQCDcc) cout<<"!decorrmass_deepboosted_probQCDcc";
-	if(!decorrmass_deepboosted_probHcc) cout<<"!decorrmass_deepboosted_probHcc";
-	if(!decorrmass_deepboosted_probWcq) cout<<"!decorrmass_deepboosted_probWcq ";
-	if(!decorrmass_deepboosted_probZcc) cout<<"!decorrmass_deepboosted_probZcc";
-	if(!decorrmass_deepboosted_probZqq) cout<<"!decorrmass_deepboosted_probZqq";
-	if(!decorrmass_deepboosted_probHqqqq) cout<<"!decorrmass_deepboosted_probHqqqq";
-	if(!decorrmass_deepboosted_probZbb) cout<<"!decorrmass_deepboosted_probZbb";
-	cout<<" "<<endl;*/
+        edm::LogWarning("NtupleWriterTopJets") << "Did not find all b-taggers! Available btaggers: " << btag_list;
         btag_warning = false;
       }
-      // throw runtime_error("did not find all b-taggers; see output for details");
     }
-  }
 
-  if(fill_pfcand){//fill pf candidates list: add pf-candidate to the event list and store index in the jet container
-    const auto& jet_daughter_ptrs = pat_jet.daughterPtrVector();
-    for(const auto & daughter_p : jet_daughter_ptrs){
-      size_t pfparticles_index = add_pfpart(*daughter_p, *uevent.pfparticles);
-      jet.add_pfcand_index(pfparticles_index);
-    }
-  }
 }
 
-
-NtupleWriterTopJets::NtupleWriterTopJets(Config & cfg, bool set_jets_member, unsigned int NPFJetwConstituents): ptmin(cfg.ptmin), etamax(cfg.etamax) {
-    handle = cfg.ctx.declare_event_output<vector<TopJet>>(cfg.dest_branchname, cfg.dest);
-    if(set_jets_member){
-        topjets_handle = cfg.ctx.get_handle<vector<TopJet>>("topjets");
-    }
-    src_token = cfg.cc.consumes<std::vector<pat::Jet>>(cfg.src);
-    njettiness_src = cfg.njettiness_src;
-    src_njettiness1_token = cfg.cc.consumes<edm::ValueMap<float> >(edm::InputTag(njettiness_src, "tau1"));
-    src_njettiness2_token = cfg.cc.consumes<edm::ValueMap<float> >(edm::InputTag(njettiness_src, "tau2"));
-    src_njettiness3_token = cfg.cc.consumes<edm::ValueMap<float> >(edm::InputTag(njettiness_src, "tau3"));
-    src_njettiness4_token = cfg.cc.consumes<edm::ValueMap<float> >(edm::InputTag(njettiness_src, "tau4"));
-
-    njettiness_groomed_src = cfg.njettiness_groomed_src;
-    src_njettiness1_groomed_token = cfg.cc.consumes<edm::ValueMap<float> >(edm::InputTag(njettiness_groomed_src, "tau1"));
-    src_njettiness2_groomed_token = cfg.cc.consumes<edm::ValueMap<float> >(edm::InputTag(njettiness_groomed_src, "tau2"));
-    src_njettiness3_groomed_token = cfg.cc.consumes<edm::ValueMap<float> >(edm::InputTag(njettiness_groomed_src, "tau3"));
-    src_njettiness4_groomed_token = cfg.cc.consumes<edm::ValueMap<float> >(edm::InputTag(njettiness_groomed_src, "tau4"));
-
-    qjets_src = cfg.qjets_src;
-    src_qjets_token = cfg.cc.consumes<edm::ValueMap<float> >(edm::InputTag(qjets_src, "QjetsVolatility"));
-
-    ecf_beta1_src = cfg.ecf_beta1_src;
-    src_ecf_beta1_N2_token = cfg.cc.consumes<edm::ValueMap<float> >(edm::InputTag(ecf_beta1_src, "ecfN2"));
-    src_ecf_beta1_N3_token = cfg.cc.consumes<edm::ValueMap<float> >(edm::InputTag(ecf_beta1_src, "ecfN3"));
-    ecf_beta2_src = cfg.ecf_beta2_src;
-    src_ecf_beta2_N2_token = cfg.cc.consumes<edm::ValueMap<float> >(edm::InputTag(ecf_beta2_src, "ecfN2"));
-    src_ecf_beta2_N3_token = cfg.cc.consumes<edm::ValueMap<float> >(edm::InputTag(ecf_beta2_src, "ecfN3"));
-
-    subjet_src = cfg.subjet_src;
-    higgs_src= cfg.higgs_src;
-
-    if (cfg.toptagging_src == "") {
-      do_toptagging = false;
-    } else {
-      do_toptagging = true;
-      src_hepTopTag_token = cfg.cc.consumes<edm::View<reco::HTTTopJetTagInfo> >(edm::InputTag(cfg.toptagging_src));
-    }
-
-    softdrop_src = cfg.softdrop_src;
-    if(softdrop_src.find("Mass")==string::npos){
-      src_softdrop_token = cfg.cc.consumes<std::vector<pat::Jet>>(cfg.softdrop_src);
-    }
-
-    src_higgs_token = cfg.cc.consumes<std::vector<pat::Jet>>(cfg.higgs_src);
-    higgs_name=cfg.higgs_name;
-    do_taginfo_subjets = cfg.do_taginfo_subjets;
-    src = cfg.src;
-    do_btagging = cfg.do_btagging;
-    do_btagging_subjets = cfg.do_btagging_subjets;
-    if(!njettiness_src.empty() || !qjets_src.empty()){
-        substructure_variables_src_token = cfg.cc.consumes<reco::BasicJetCollection>(cfg.substructure_variables_src);
-	substructure_variables_src_tokenreco = cfg.cc.consumes<reco::PFJetCollection>(cfg.substructure_variables_src);
-    }
-    if(!njettiness_groomed_src.empty()){
-        substructure_groomed_variables_src_token = cfg.cc.consumes<reco::BasicJetCollection>(cfg.substructure_groomed_variables_src);
-	substructure_groomed_variables_src_tokenreco = cfg.cc.consumes<reco::PFJetCollection>(cfg.substructure_groomed_variables_src);
-    }
-    btag_warning=true;
-    topjet_collection = cfg.dest_branchname;
-
-    topjet_puppiSpecificProducer = getPuppiJetSpecificProducer(src.label());
-
-    save_lepton_keys_ = false;
-
-    h_muons.clear();
-    h_elecs.clear();
-
-    higgstaginfo_src = cfg.higgstaginfo_src;
-    src_higgstaginfo_token =  cfg.cc.consumes<std::vector<reco::BoostedDoubleSVTagInfo> >(cfg.higgstaginfo_src);
-    NPFJetwConstituents_ = NPFJetwConstituents;
-}
-
-NtupleWriterTopJets::NtupleWriterTopJets(Config & cfg, bool set_jets_member, const std::vector<std::string>& muon_sources, const std::vector<std::string>& elec_sources, unsigned int NPFJetwConstituents):
-  NtupleWriterTopJets::NtupleWriterTopJets(cfg, set_jets_member, NPFJetwConstituents) {
-
-    save_lepton_keys_ = true;
-
-    for(const auto& muo_src : muon_sources){ auto h_muon = cfg.ctx.get_handle<std::vector<Muon>    >(muo_src); h_muons.push_back(h_muon); }
-    for(const auto& ele_src : elec_sources){ auto h_elec = cfg.ctx.get_handle<std::vector<Electron>>(ele_src); h_elecs.push_back(h_elec); }
-    NPFJetwConstituents_ = NPFJetwConstituents;
-}
-
-NtupleWriterTopJets::~NtupleWriterTopJets(){}
 
 
 void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent, const edm::EventSetup& iSetup){
@@ -973,9 +935,14 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
 	bool storePFcands = false;
 	if(i<NPFJetwConstituents_) storePFcands = true;
         try{
-          uhh2::NtupleWriterJets::fill_jet_info(uevent,pat_topjet, topjet, do_btagging, false, topjet_puppiSpecificProducer,storePFcands, true);
+          uhh2::NtupleWriterJets::fill_jet_info(uevent,pat_topjet, topjet, do_btagging, false, topjet_puppiSpecificProducer,storePFcands);
         }catch(runtime_error &){
           throw cms::Exception("fill_jet_info error", "Error in fill_jet_info for topjets in NtupleWriterTopJets with src = " + src.label());
+        }
+	try{
+	  fill_btag_info(uevent,pat_topjet, topjet);
+        }catch(runtime_error &){
+          throw cms::Exception("fill_btag_info error", "Error in fill_btag_info for topjets in NtupleWriterTopJets with src = " + src.label());
         }
 
         /*--- lepton keys ---*/
@@ -1304,7 +1271,7 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
             auto patsubjetd = dynamic_cast<const pat::Jet *>(pat_topjet.daughter(k));
             if (patsubjetd) {
 	      try{
-		NtupleWriterJets::fill_jet_info(uevent,*patsubjetd, subjet, do_btagging_subjets, do_taginfo_subjets, "", storePFcands, false);
+		NtupleWriterJets::fill_jet_info(uevent,*patsubjetd, subjet, do_btagging_subjets, do_taginfo_subjets, "", storePFcands);
 	      }catch(runtime_error &){
                 throw cms::Exception("fill_jet_info error", "Error in fill_jet_info for daughters in NtupleWriterTopJets with src = " + src.label());
 	      }
@@ -1333,7 +1300,7 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
 	    auto tpatsubjet = dynamic_cast<const pat::Jet *>(tSubjets.at(sj).get());
             if (tpatsubjet) {
 	      try{
-		NtupleWriterJets::fill_jet_info(uevent,*tpatsubjet, subjet, do_btagging_subjets, do_taginfo_subjets, "", storePFcands, false);
+		NtupleWriterJets::fill_jet_info(uevent,*tpatsubjet, subjet, do_btagging_subjets, do_taginfo_subjets, "", storePFcands);
 	      }catch(runtime_error &){
                 throw cms::Exception("fill_jet_info error", "Error in fill_jet_info for subjets in NtupleWriterTopJets with src = " + src.label());
 	      }

--- a/core/plugins/NtupleWriterJets.cxx
+++ b/core/plugins/NtupleWriterJets.cxx
@@ -164,7 +164,7 @@ void NtupleWriterJets::process(const edm::Event & event, uhh2::Event & uevent,  
 	bool storePFcands = false;
 	if(i<NPFJetwConstituents_) storePFcands = true;
         try {
-          fill_jet_info(uevent,pat_jet, jet, true, false, jet_puppiSpecificProducer,storePFcands);
+          fill_jet_info(uevent,pat_jet, jet, true, false, jet_puppiSpecificProducer,storePFcands,false);
         }
         catch(runtime_error & ex){
           throw cms::Exception("fill_jet_info error", "Error in fill_jet_info NtupleWriterJets::process for jets with src = " + src.label());
@@ -194,7 +194,7 @@ void NtupleWriterJets::process(const edm::Event & event, uhh2::Event & uevent,  
 }
 
 
-void NtupleWriterJets::fill_jet_info(uhh2::Event & uevent, const pat::Jet & pat_jet, Jet & jet, bool do_btagging, bool do_taginfo, const std::string & puppiJetSpecificProducer, bool fill_pfcand){
+void NtupleWriterJets::fill_jet_info(uhh2::Event & uevent, const pat::Jet & pat_jet, Jet & jet, bool do_btagging, bool do_taginfo, const std::string & puppiJetSpecificProducer, bool fill_pfcand, bool isTopJet){
   jet.set_charge(pat_jet.charge());
   jet.set_pt(pat_jet.pt());
   jet.set_eta(pat_jet.eta());
@@ -340,6 +340,34 @@ deepboosted_probHbb=false,deepboosted_probQCDbb=false,deepboosted_probQCDc=false
 deepdouble_H=false,deepdouble_QCD=false, deepdouble_cl_H=false,deepdouble_cl_QCD=false, deepdouble_cb_H=false,deepdouble_cb_QCD=false,
 massinddeepdouble_H=false,massinddeepdouble_QCD=false, massinddeepdouble_cl_H=false,massinddeepdouble_cl_QCD=false, massinddeepdouble_cb_H=false,massinddeepdouble_cb_QCD=false,
 decorrmass_deepboosted_probHbb=false,decorrmass_deepboosted_probQCDbb=false,decorrmass_deepboosted_probQCDc=false,decorrmass_deepboosted_probTbqq=false,decorrmass_deepboosted_probTbcq=false,decorrmass_deepboosted_probTbq=false,decorrmass_deepboosted_probQCDothers=false,decorrmass_deepboosted_probQCDb=false,decorrmass_deepboosted_probTbc=false,decorrmass_deepboosted_probWqq=false,decorrmass_deepboosted_probQCDcc=false,decorrmass_deepboosted_probHcc=false,decorrmass_deepboosted_probWcq=false,decorrmass_deepboosted_probZcc=false,decorrmass_deepboosted_probZqq=false,decorrmass_deepboosted_probHqqqq=false,decorrmass_deepboosted_probZbb=false;
+    if(!isTopJet){
+      //slim (= not fat) jets don't have DeepBoosted info, etc
+      // set booleans to 'true' to avoid warnings in b-taggers check
+      doubleak8 = true; doubleca15 = true;
+      decorrmass_deepboosted_bbvsLight=true; decorrmass_deepboosted_ccvsLight=true; 
+      decorrmass_deepboosted_TvsQCD=true; decorrmass_deepboosted_ZHccvsQCD=true; 
+      decorrmass_deepboosted_WvsQCD=true; decorrmass_deepboosted_ZHbbvsQCD=true;
+      decorrmass_deepboosted_ZvsQCD=true; decorrmass_deepboosted_ZbbvsQCD=true;
+      decorrmass_deepboosted_HbbvsQCD=true; decorrmass_deepboosted_H4qvsQCD=true;
+      deepboosted_bbvsLight=true; deepboosted_ccvsLight=true; deepboosted_TvsQCD=true;
+      deepboosted_ZHccvsQCD=true; deepboosted_WvsQCD=true; deepboosted_ZHbbvsQCD=true;
+      deepboosted_ZvsQCD=true; deepboosted_ZbbvsQCD=true; deepboosted_HbbvsQCD=true;
+      deepboosted_H4qvsQCD=true; deepboosted_probHbb=true; deepboosted_probQCDbb=true; deepboosted_probQCDc=true;
+      deepboosted_probTbqq=true; deepboosted_probTbcq=true; deepboosted_probTbq=true; deepboosted_probQCDothers=true;
+      deepboosted_probQCDb=true; deepboosted_probTbc=true; deepboosted_probWqq=true; deepboosted_probQCDcc=true;
+      deepboosted_probHcc=true; deepboosted_probWcq=true; deepboosted_probZcc=true; deepboosted_probZqq=true; deepboosted_probHqqqq=true;
+      deepboosted_probZbb=true; deepdouble_H=true; deepdouble_QCD=true; deepdouble_cl_H=true;
+      deepdouble_cl_QCD=true; deepdouble_cb_H=true; deepdouble_cb_QCD=true;
+      massinddeepdouble_H=true; massinddeepdouble_QCD=true; massinddeepdouble_cl_H=true;
+      massinddeepdouble_cl_QCD=true; massinddeepdouble_cb_H=true; massinddeepdouble_cb_QCD=true;
+      decorrmass_deepboosted_probHbb=true; decorrmass_deepboosted_probQCDbb=true; 
+      decorrmass_deepboosted_probQCDc=true; decorrmass_deepboosted_probTbqq=true;
+      decorrmass_deepboosted_probTbcq=true; decorrmass_deepboosted_probTbq=true; decorrmass_deepboosted_probQCDothers=true;
+      decorrmass_deepboosted_probQCDb=true; decorrmass_deepboosted_probTbc=true; decorrmass_deepboosted_probWqq=true;
+      decorrmass_deepboosted_probQCDcc=true; decorrmass_deepboosted_probHcc=true; decorrmass_deepboosted_probWcq=true;
+      decorrmass_deepboosted_probZcc=true; decorrmass_deepboosted_probZqq=true; decorrmass_deepboosted_probHqqqq=true;
+      decorrmass_deepboosted_probZbb=true;
+    }
     for(const auto & name_value : bdisc){
       const auto & name = name_value.first;
       const auto & value = name_value.second;
@@ -551,30 +579,14 @@ decorrmass_deepboosted_probHbb=false,decorrmass_deepboosted_probQCDbb=false,deco
         jet.set_btag_MassIndependentDeepDoubleCvLJet_probQCD(value);
         massinddeepdouble_cl_QCD = true;
       }
-      // else if(name == "pfDeepBoostedDiscriminatorsJetTags:bbvsLight"){
-      //   jet.set_btag_DeepBoosted_bbvsLight(value);
-      //   deepboosted_bbvsLight=true;
-      // }
-      // else if(name == "pfDeepBoostedDiscriminatorsJetTags:ccvsLight"){
-      //   jet.set_btag_DeepBoosted_ccvsLight(value);
-      //   deepboosted_ccvsLight=true;
-      // }
       else if(name == "pfDeepBoostedDiscriminatorsJetTags:TvsQCD"){
         jet.set_btag_DeepBoosted_TvsQCD(value);
         deepboosted_TvsQCD=true;
       }
-      // else if(name == "pfDeepBoostedDiscriminatorsJetTags:ZHccvsQCD"){
-      //   jet.set_btag_DeepBoosted_ZHccvsQCD(value);
-      //   deepboosted_ZHccvsQCD=true;
-      // }
       else if(name == "pfDeepBoostedDiscriminatorsJetTags:WvsQCD"){
         jet.set_btag_DeepBoosted_WvsQCD(value);
         deepboosted_WvsQCD=true;
       }
-      // else if(name == "pfDeepBoostedDiscriminatorsJetTags:ZHbbvsQCD"){
-      //   jet.set_btag_DeepBoosted_ZHbbvsQCD(value);
-      //   deepboosted_ZHbbvsQCD=true;
-      // }
       else if(name == "pfDeepBoostedDiscriminatorsJetTags:ZvsQCD"){
         jet.set_btag_DeepBoosted_ZvsQCD(value);
         deepboosted_ZvsQCD=true;
@@ -665,6 +677,9 @@ decorrmass_deepboosted_probHbb=false,decorrmass_deepboosted_probQCDbb=false,deco
       }
 
     }
+   
+
+
 
     if(!csv || !csvmva || !doubleak8 || !doubleca15 || !deepcsv_b || !deepcsv_bb
        || !deepflavour_bb || !deepflavour_b || !deepflavour_lepb
@@ -701,6 +716,52 @@ decorrmass_deepboosted_probHbb=false,decorrmass_deepboosted_probQCDbb=false,deco
           btag_list += " ";
         }
         edm::LogWarning("NtupleWriterJets") << "Did not find all b-taggers! Available btaggers: " << btag_list;
+	/*	cout<<"Didn't find these: "<<endl;
+	if(!csv) cout<<"!csv"; 
+	if(!doubleak8) cout<<"!doubleak8"; 
+	if(!doubleca15) cout<<"!doubleca15"; if(!deepcsv_b) cout<<"!deepcsv_b";
+	if(!deepcsv_bb) cout<<"!deepcsv_bb"; if(!csvmva) cout<<"!csvmva";
+	if(!deepflavour_bb) cout<<"!deepflavour_bb"; if(!deepflavour_b) cout<<"!deepflavour_b "; if(!deepflavour_lepb) cout<<"!deepflavour_lepb";
+	if(!deepflavour_uds) cout<<"!deepflavour_uds "; if(!deepflavour_c) cout<<"!deepflavour_c "; if(!deepflavour_g) cout<<"!deepflavour_g";
+	if(!decorrmass_deepboosted_bbvsLight) cout<<"!decorrmass_deepboosted_bbvsLight"; if(!decorrmass_deepboosted_ccvsLight) cout<<"!decorrmass_deepboosted_ccvsLight";
+	if(!decorrmass_deepboosted_TvsQCD) cout<<"!decorrmass_deepboosted_TvsQCD"; if(!decorrmass_deepboosted_ZHccvsQCD) cout<<"!decorrmass_deepboosted_ZHccvsQCD";
+	if(!decorrmass_deepboosted_WvsQCD) cout<<"!decorrmass_deepboosted_WvsQCD"; if(!decorrmass_deepboosted_ZHbbvsQCD) cout<<"!decorrmass_deepboosted_ZHbbvsQCD";
+	if(!decorrmass_deepboosted_ZvsQCD) cout<<"!decorrmass_deepboosted_ZvsQCD"; if(!decorrmass_deepboosted_ZbbvsQCD) cout<<"!decorrmass_deepboosted_ZbbvsQCD ";
+	if(!decorrmass_deepboosted_HbbvsQCD) cout<<"!decorrmass_deepboosted_HbbvsQCD"; if(!decorrmass_deepboosted_H4qvsQCD) cout<<"!decorrmass_deepboosted_H4qvsQCD";
+	if(!deepboosted_bbvsLight) cout<<"!deepboosted_bbvsLight";  if(!deepboosted_ccvsLight) cout<<"!deepboosted_ccvsLight";
+	if(!deepboosted_TvsQCD) cout<<"!deepboosted_TvsQCD"; if(!deepboosted_ZHccvsQCD) cout<<"!deepboosted_ZHccvsQCD";
+	if(!deepboosted_WvsQCD) cout<<"!deepboosted_WvsQCD"; if(!deepboosted_ZHbbvsQCD) cout<<"!deepboosted_ZHbbvsQCD";
+	if(!deepboosted_ZvsQCD) cout<<"!deepboosted_ZvsQCD"; if(!deepboosted_ZbbvsQCD) cout<<"!deepboosted_ZbbvsQCD";
+	if(!deepboosted_HbbvsQCD) cout<<"!deepboosted_HbbvsQCD"; if(!deepboosted_H4qvsQCD) cout<<"!deepboosted_H4qvsQCD";
+	if(!deepboosted_probHbb) cout<<"!deepboosted_probHbb";  if(!deepboosted_probQCDbb) cout<<"!deepboosted_probQCDbb";
+	if(!deepboosted_probQCDc) cout<<"!deepboosted_probQCDc";    if(!deepboosted_probTbqq) cout<<"!deepboosted_probTbqq";
+	if(!deepboosted_probTbcq) cout<<"!deepboosted_probTbcq";    if(!deepboosted_probTbq) cout<<"!deepboosted_probTbq";
+	if(!deepboosted_probQCDothers) cout<<"!deepboosted_probQCDothers";    if(!deepboosted_probQCDb) cout<<"!deepboosted_probQCDb";
+	if(!deepboosted_probTbc) cout<<"!deepboosted_probTbc";    if(!deepboosted_probWqq) cout<<"!deepboosted_probWqq";
+	if(!deepboosted_probQCDcc) cout<<"!deepboosted_probQCDcc";     if(!deepboosted_probHcc) cout<<"!deepboosted_probHcc";
+	if(!deepboosted_probWcq) cout<<"!deepboosted_probWcq";    if(!deepboosted_probZcc) cout<<"!deepboosted_probZcc";
+	if(!deepboosted_probZqq) cout<<"!deepboosted_probZqq";    if(!deepboosted_probHqqqq) cout<<"!deepboosted_probHqqqq ";
+	if(!deepboosted_probZbb) cout<<"!deepboosted_probZbb ";    if(!deepdouble_H) cout<<"!deepdouble_H ";
+	if(!deepdouble_QCD) cout<<"!deepdouble_QCD";    if(!deepdouble_cb_H) cout<<"!deepdouble_cb_H";
+	if(!deepdouble_cl_H) cout<<"!deepdouble_cl_H";    if(!deepdouble_cl_QCD) cout<<"!deepdouble_cl_QCD "; if(!deepdouble_cb_QCD) cout<<"!deepdouble_cb_QCD";
+	if(!massinddeepdouble_QCD) cout<<"!massinddeepdouble_QCD";    if(!massinddeepdouble_H) cout<<"!massinddeepdouble_H";
+	if(!massinddeepdouble_cb_H) cout<<"!massinddeepdouble_cb_H ";    if(!massinddeepdouble_cl_H) cout<<"!massinddeepdouble_cl_H";
+	if(!massinddeepdouble_cl_QCD) cout<<"!massinddeepdouble_cl_QCD";    if(!massinddeepdouble_cb_QCD) cout<<"!massinddeepdouble_cb_QCD";
+	if(!decorrmass_deepboosted_probHbb) cout<<"!decorrmass_deepboosted_probHbb";  if(!decorrmass_deepboosted_probQCDbb) cout<<"!decorrmass_deepboosted_probQCDbb";
+	if(!decorrmass_deepboosted_probQCDc) cout<<"!decorrmass_deepboosted_probQCDc";    if(!decorrmass_deepboosted_probTbqq) cout<<"!decorrmass_deepboosted_probTbqq";
+	if(!decorrmass_deepboosted_probTbcq) cout<<"!decorrmass_deepboosted_probTbcq";    if(!decorrmass_deepboosted_probTbq) cout<<"!decorrmass_deepboosted_probTbq";
+	if(!decorrmass_deepboosted_probQCDothers) cout<<"!decorrmass_deepboosted_probQCDothers";    
+	if(!decorrmass_deepboosted_probQCDb) cout<<"!decorrmass_deepboosted_probQCDb";
+	if(!decorrmass_deepboosted_probTbc) cout<<"!decorrmass_deepboosted_probTbc";
+	if(!decorrmass_deepboosted_probWqq) cout<<"!decorrmass_deepboosted_probWqq";
+	if(!decorrmass_deepboosted_probQCDcc) cout<<"!decorrmass_deepboosted_probQCDcc";
+	if(!decorrmass_deepboosted_probHcc) cout<<"!decorrmass_deepboosted_probHcc";
+	if(!decorrmass_deepboosted_probWcq) cout<<"!decorrmass_deepboosted_probWcq ";
+	if(!decorrmass_deepboosted_probZcc) cout<<"!decorrmass_deepboosted_probZcc";
+	if(!decorrmass_deepboosted_probZqq) cout<<"!decorrmass_deepboosted_probZqq";
+	if(!decorrmass_deepboosted_probHqqqq) cout<<"!decorrmass_deepboosted_probHqqqq";
+	if(!decorrmass_deepboosted_probZbb) cout<<"!decorrmass_deepboosted_probZbb";
+	cout<<" "<<endl;*/
         btag_warning = false;
       }
       // throw runtime_error("did not find all b-taggers; see output for details");
@@ -912,7 +973,7 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
 	bool storePFcands = false;
 	if(i<NPFJetwConstituents_) storePFcands = true;
         try{
-          uhh2::NtupleWriterJets::fill_jet_info(uevent,pat_topjet, topjet, do_btagging, false, topjet_puppiSpecificProducer,storePFcands);
+          uhh2::NtupleWriterJets::fill_jet_info(uevent,pat_topjet, topjet, do_btagging, false, topjet_puppiSpecificProducer,storePFcands, true);
         }catch(runtime_error &){
           throw cms::Exception("fill_jet_info error", "Error in fill_jet_info for topjets in NtupleWriterTopJets with src = " + src.label());
         }
@@ -1243,7 +1304,7 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
             auto patsubjetd = dynamic_cast<const pat::Jet *>(pat_topjet.daughter(k));
             if (patsubjetd) {
 	      try{
-		NtupleWriterJets::fill_jet_info(uevent,*patsubjetd, subjet, do_btagging_subjets, do_taginfo_subjets, "", storePFcands);
+		NtupleWriterJets::fill_jet_info(uevent,*patsubjetd, subjet, do_btagging_subjets, do_taginfo_subjets, "", storePFcands, false);
 	      }catch(runtime_error &){
                 throw cms::Exception("fill_jet_info error", "Error in fill_jet_info for daughters in NtupleWriterTopJets with src = " + src.label());
 	      }
@@ -1272,7 +1333,7 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
 	    auto tpatsubjet = dynamic_cast<const pat::Jet *>(tSubjets.at(sj).get());
             if (tpatsubjet) {
 	      try{
-		NtupleWriterJets::fill_jet_info(uevent,*tpatsubjet, subjet, do_btagging_subjets, do_taginfo_subjets, "", storePFcands);
+		NtupleWriterJets::fill_jet_info(uevent,*tpatsubjet, subjet, do_btagging_subjets, do_taginfo_subjets, "", storePFcands, false);
 	      }catch(runtime_error &){
                 throw cms::Exception("fill_jet_info error", "Error in fill_jet_info for subjets in NtupleWriterTopJets with src = " + src.label());
 	      }

--- a/core/plugins/NtupleWriterJets.h
+++ b/core/plugins/NtupleWriterJets.h
@@ -22,7 +22,7 @@ namespace uhh2 {
 
 class NtupleWriterJets: public NtupleWriterModule {
 public:
-    static void fill_jet_info(uhh2::Event & uevent, const pat::Jet & pat_jet, Jet & jet, bool do_btagging, bool do_taginfo, const std::string & puppiJetSpecificProducer="", bool fill_pfcand=false);
+    static void fill_jet_info(uhh2::Event & uevent, const pat::Jet & pat_jet, Jet & jet, bool do_btagging, bool do_taginfo, const std::string & puppiJetSpecificProducer="", bool fill_pfcand=false, bool isTopJet=false);
 
     explicit NtupleWriterJets(Config & cfg, bool set_jets_member, unsigned int NPFJetwConstituents);
     explicit NtupleWriterJets(Config & cfg, bool set_jets_member, const std::vector<std::string>&, const std::vector<std::string>&, unsigned int NPFJetwConstituents);

--- a/core/plugins/NtupleWriterJets.h
+++ b/core/plugins/NtupleWriterJets.h
@@ -22,7 +22,7 @@ namespace uhh2 {
 
 class NtupleWriterJets: public NtupleWriterModule {
 public:
-    static void fill_jet_info(uhh2::Event & uevent, const pat::Jet & pat_jet, Jet & jet, bool do_btagging, bool do_taginfo, const std::string & puppiJetSpecificProducer="", bool fill_pfcand=false, bool isTopJet=false);
+    static void fill_jet_info(uhh2::Event & uevent, const pat::Jet & pat_jet, Jet & jet, bool do_btagging, bool do_taginfo, const std::string & puppiJetSpecificProducer="", bool fill_pfcand=false);
 
     explicit NtupleWriterJets(Config & cfg, bool set_jets_member, unsigned int NPFJetwConstituents);
     explicit NtupleWriterJets(Config & cfg, bool set_jets_member, const std::vector<std::string>&, const std::vector<std::string>&, unsigned int NPFJetwConstituents);
@@ -77,7 +77,7 @@ public:
     explicit NtupleWriterTopJets(Config & cfg, bool set_jets_member, const std::vector<std::string>&, const std::vector<std::string>&, unsigned int NPFJetwConstituents);
 
     virtual void process(const edm::Event &, uhh2::Event &,  const edm::EventSetup&);
-
+    static void fill_btag_info(uhh2::Event & uevent, const pat::Jet & pat_jet, TopJet & jet);
     virtual ~NtupleWriterTopJets();
 
 private:

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -80,14 +80,81 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
         'pfDeepCSVJetTags:probbb',
         'pfBoostedDoubleSecondaryVertexAK8BJetTags',
         'pfBoostedDoubleSecondaryVertexCA15BJetTags',
+    ]
+ 
+    ak4btagDiscriminators = [
         'pfDeepFlavourJetTags:probb',
         'pfDeepFlavourJetTags:probbb',
         'pfDeepFlavourJetTags:problepb',
         'pfDeepFlavourJetTags:probc',
         'pfDeepFlavourJetTags:probuds',
-        'pfDeepFlavourJetTags:probg',
+        'pfDeepFlavourJetTags:probg'
     ]
 
+    ak8btagDiscriminators = [
+        'pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:bbvsLight',
+        'pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:ccvsLight',
+        'pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:TvsQCD',
+        'pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:ZHccvsQCD',
+        'pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:WvsQCD',
+        'pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:ZHbbvsQCD',
+        'pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:H4qvsQCD',
+        'pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:HbbvsQCD',
+        'pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:ZbbvsQCD',
+        'pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:ZvsQCD',
+        'pfDeepBoostedDiscriminatorsJetTags:TvsQCD',
+        'pfDeepBoostedDiscriminatorsJetTags:WvsQCD',
+        'pfDeepBoostedDiscriminatorsJetTags:H4qvsQCD',
+        'pfDeepBoostedDiscriminatorsJetTags:HbbvsQCD',
+        'pfDeepBoostedDiscriminatorsJetTags:ZbbvsQCD',
+        'pfDeepBoostedDiscriminatorsJetTags:ZvsQCD',
+        'pfMassDecorrelatedDeepBoostedJetTags:probHbb',
+        'pfMassDecorrelatedDeepBoostedJetTags:probQCDc',
+        'pfMassDecorrelatedDeepBoostedJetTags:probQCDbb',
+        'pfMassDecorrelatedDeepBoostedJetTags:probTbqq',
+        'pfMassDecorrelatedDeepBoostedJetTags:probTbcq',
+        'pfMassDecorrelatedDeepBoostedJetTags:probTbq',
+        'pfMassDecorrelatedDeepBoostedJetTags:probQCDothers',
+        'pfMassDecorrelatedDeepBoostedJetTags:probQCDb',
+        'pfMassDecorrelatedDeepBoostedJetTags:probTbc',
+        'pfMassDecorrelatedDeepBoostedJetTags:probWqq',
+        'pfMassDecorrelatedDeepBoostedJetTags:probQCDcc',
+        'pfMassDecorrelatedDeepBoostedJetTags:probHcc',
+        'pfMassDecorrelatedDeepBoostedJetTags:probWcq',
+        'pfMassDecorrelatedDeepBoostedJetTags:probZcc',
+        'pfMassDecorrelatedDeepBoostedJetTags:probZqq',
+        'pfMassDecorrelatedDeepBoostedJetTags:probHqqqq',
+        'pfMassDecorrelatedDeepBoostedJetTags:probZbb',
+        'pfDeepDoubleBvLJetTags:probHbb',
+        'pfDeepDoubleBvLJetTags:probQCD',
+        'pfDeepDoubleCvBJetTags:probHbb',
+        'pfDeepDoubleCvBJetTags:probHcc',
+        'pfDeepDoubleCvLJetTags:probHcc',
+        'pfDeepDoubleCvLJetTags:probQCD',
+        'pfMassIndependentDeepDoubleBvLJetTags:probHbb',
+        'pfMassIndependentDeepDoubleBvLJetTags:probQCD',
+        'pfMassIndependentDeepDoubleCvBJetTags:probHbb',
+        'pfMassIndependentDeepDoubleCvBJetTags:probHcc',
+        'pfMassIndependentDeepDoubleCvLJetTags:probHcc',
+        'pfMassIndependentDeepDoubleCvLJetTags:probQCD',
+        'pfDeepBoostedJetTags:probHbb',
+        'pfDeepBoostedJetTags:probQCDc',
+        'pfDeepBoostedJetTags:probQCDbb',
+        'pfDeepBoostedJetTags:probTbqq',
+        'pfDeepBoostedJetTags:probTbcq',
+        'pfDeepBoostedJetTags:probTbq',
+        'pfDeepBoostedJetTags:probQCDothers',
+        'pfDeepBoostedJetTags:probQCDb',
+        'pfDeepBoostedJetTags:probTbc',
+        'pfDeepBoostedJetTags:probWqq',
+        'pfDeepBoostedJetTags:probQCDcc',
+        'pfDeepBoostedJetTags:probHcc',
+        'pfDeepBoostedJetTags:probWcq',
+        'pfDeepBoostedJetTags:probZcc',
+        'pfDeepBoostedJetTags:probZqq',
+        'pfDeepBoostedJetTags:probHqqqq',
+        'pfDeepBoostedJetTags:probZbb'
+    ]
 
 
     bTagInfos = [
@@ -483,7 +550,6 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
         btagDiscriminators=bTagDiscriminators
     )
 
-
     process.packedGenParticlesForJetsNoNu = cms.EDFilter("CandPtrSelector",
         src=cms.InputTag("packedGenParticles"),
         cut=cms.string("abs(pdgId) != 12 && abs(pdgId) != 14 && abs(pdgId) != 16")
@@ -537,7 +603,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
     # * the subjets are available with the same name as the groomed jets with instance label 'SubJets'
     #
     # The method will produce several collections, also following a naming convention:
-    # * a petJets collection for the ungroomed fatjets with name 'patJets' + fatjets_name (unless it already exists)
+    # * a patJets collection for the ungroomed fatjets with name 'patJets' + fatjets_name (unless it already exists)
     # * two pat jet collections (one for fat jets and one for subjets) with names
     #   - 'patJets' + groomed_jets_name for the fat jets and
     #   - 'patJets' + groomed_jets_name + 'Subjets' for the subjets
@@ -563,7 +629,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
             raise RuntimeError, "cannot guess jet algo (ca/ak) from jet producer %s", fatjets_name
 
         if verbose:
-            print '* Adding fatjets_subjets for', fatjets_name
+            print '***  Adding fatjets_subjets for', fatjets_name
 
         subjets_name = groomed_jets_name + 'Subjets'  # e.g. CA8CHSPruned + Subjets
 
@@ -680,11 +746,55 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
                              groomed_genjets_name, 'SubJets'),
                          getJetMCFlavour=not useData,
                          **common_btag_parameters
+#                         **common_btag_parameters_subjet
                          )
         # Always add taginfos to subjets, but possible not to store them,
         # configurable with ntuple writer parameter: subjet_taginfos
+        # Attention: Only CVS b-tag info is stored for sub-jets
         getattr(process, subjets_patname).addTagInfos = True
         delattr(process, "selectedPatJets"+cap(subjets_name))
+
+
+        # Add DeepFlavor b-tagging to sub-jets
+        labelName = cap(subjets_patname)
+        is_puppi = "puppi" in labelName.lower()
+
+        # # This call to updateJetCollection adds one PATJetUpdater to only remove the JECs,
+        # # then uses that as the input to another PATJetUpdater, which re-applies the JECs,
+        # # adds in all b tag stuff, etc.
+        # # The 2nd PATJetsUpdater has the extra "TransientCorrected" bit in its name.
+        # # It also produces a final similar "selectedUpdatedPatJets"+labelName+postfix collection
+        # # which is a PATJetSelector
+        postfix = ''
+        updater_src = "updatedPatJets" + labelName + postfix  # 1st PATJetUpdater, that removes JECs, is src to updater_name
+        updater_name = "updatedPatJetsTransientCorrected" + labelName + postfix  # 2nd PATJetUpdater
+        selector_name = "selectedUpdatedPatJets" + labelName + postfix
+        if is_puppi:
+            correction_tag = "AK4PFPuppi"
+        else:
+            correction_tag = "AK4PFchs"
+
+        jetcorr_list = ['L1FastJet', 'L2Relative', 'L3Absolute']
+        if is_puppi:
+            jetcorr_list = jetcorr_list[1:]
+        if useData:
+            jetcorr_list.append("L2L3Residual")
+        discriminators = ak4btagDiscriminators[:]
+
+        updateJetCollection(
+            process,
+            labelName=labelName,
+            jetSource=cms.InputTag(subjets_patname),
+            pvSource=cms.InputTag('offlineSlimmedPrimaryVertices'),
+            svSource=cms.InputTag('slimmedSecondaryVertices'),
+            jetCorrections=jetcorr_arg,  
+            btagDiscriminators=discriminators,
+            postfix=postfix
+        )
+
+        subjets_patname = "updatedPatJetsTransientCorrected" + cap(subjets_patname)
+
+        # print "btagDiscriminators ", discriminators
 
         # add the merged jet collection which contains the links from groomed
         # fat jets to the subjets:
@@ -975,89 +1085,12 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
     task.add(process.packedPatJetsAk8PuppiJets)
 
     ###############################################
-    # Add deep flavour/jet/tagging taggers & discriminants
-    #
-    ak4btagDiscriminators = [
-        'pfDeepFlavourJetTags:probb',
-        'pfDeepFlavourJetTags:probbb',
-        'pfDeepFlavourJetTags:problepb',
-        'pfDeepFlavourJetTags:probc',
-        'pfDeepFlavourJetTags:probuds',
-        'pfDeepFlavourJetTags:probg'
-    ]
-
-    ak8btagDiscriminators = [
-        'pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:bbvsLight',
-        'pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:ccvsLight',
-        'pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:TvsQCD',
-        'pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:ZHccvsQCD',
-        'pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:WvsQCD',
-        'pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:ZHbbvsQCD',
-        'pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:H4qvsQCD',
-        'pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:HbbvsQCD',
-        'pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:ZbbvsQCD',
-        'pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:ZvsQCD',
-        'pfDeepBoostedDiscriminatorsJetTags:TvsQCD',
-        'pfDeepBoostedDiscriminatorsJetTags:WvsQCD',
-        'pfDeepBoostedDiscriminatorsJetTags:H4qvsQCD',
-        'pfDeepBoostedDiscriminatorsJetTags:HbbvsQCD',
-        'pfDeepBoostedDiscriminatorsJetTags:ZbbvsQCD',
-        'pfDeepBoostedDiscriminatorsJetTags:ZvsQCD',
-
-        'pfMassDecorrelatedDeepBoostedJetTags:probHbb',
-        'pfMassDecorrelatedDeepBoostedJetTags:probQCDc',
-        'pfMassDecorrelatedDeepBoostedJetTags:probQCDbb',
-        'pfMassDecorrelatedDeepBoostedJetTags:probTbqq',
-        'pfMassDecorrelatedDeepBoostedJetTags:probTbcq',
-        'pfMassDecorrelatedDeepBoostedJetTags:probTbq',
-        'pfMassDecorrelatedDeepBoostedJetTags:probQCDothers',
-        'pfMassDecorrelatedDeepBoostedJetTags:probQCDb',
-        'pfMassDecorrelatedDeepBoostedJetTags:probTbc',
-        'pfMassDecorrelatedDeepBoostedJetTags:probWqq',
-        'pfMassDecorrelatedDeepBoostedJetTags:probQCDcc',
-        'pfMassDecorrelatedDeepBoostedJetTags:probHcc',
-        'pfMassDecorrelatedDeepBoostedJetTags:probWcq',
-        'pfMassDecorrelatedDeepBoostedJetTags:probZcc',
-        'pfMassDecorrelatedDeepBoostedJetTags:probZqq',
-        'pfMassDecorrelatedDeepBoostedJetTags:probHqqqq',
-        'pfMassDecorrelatedDeepBoostedJetTags:probZbb',
-        'pfDeepDoubleBvLJetTags:probHbb',
-        'pfDeepDoubleBvLJetTags:probQCD',
-        'pfDeepDoubleCvBJetTags:probHbb',
-        'pfDeepDoubleCvBJetTags:probHcc',
-        'pfDeepDoubleCvLJetTags:probHcc',
-        'pfDeepDoubleCvLJetTags:probQCD',
-        'pfMassIndependentDeepDoubleBvLJetTags:probHbb',
-        'pfMassIndependentDeepDoubleBvLJetTags:probQCD',
-        'pfMassIndependentDeepDoubleCvBJetTags:probHbb',
-        'pfMassIndependentDeepDoubleCvBJetTags:probHcc',
-        'pfMassIndependentDeepDoubleCvLJetTags:probHcc',
-        'pfMassIndependentDeepDoubleCvLJetTags:probQCD',
-        'pfDeepBoostedJetTags:probHbb',
-        'pfDeepBoostedJetTags:probQCDc',
-        'pfDeepBoostedJetTags:probQCDbb',
-        'pfDeepBoostedJetTags:probTbqq',
-        'pfDeepBoostedJetTags:probTbcq',
-        'pfDeepBoostedJetTags:probTbq',
-        'pfDeepBoostedJetTags:probQCDothers',
-        'pfDeepBoostedJetTags:probQCDb',
-        'pfDeepBoostedJetTags:probTbc',
-        'pfDeepBoostedJetTags:probWqq',
-        'pfDeepBoostedJetTags:probQCDcc',
-        'pfDeepBoostedJetTags:probHcc',
-        'pfDeepBoostedJetTags:probWcq',
-        'pfDeepBoostedJetTags:probZcc',
-        'pfDeepBoostedJetTags:probZqq',
-        'pfDeepBoostedJetTags:probHqqqq',
-        'pfDeepBoostedJetTags:probZbb'
-    ]
-
     # Do deep flavours & deep tagging
     # This MUST be run *After* JetSubstructurePacker, so that the subjets are already there,
     # otherwise the DeepBoostedJetTagInfoProducer will fail
     # Also add in PUPPI multiplicities while we're at it.
-#    for name in ['slimmedJetsPuppi', 'patJetsAK8PFPUPPI', 'packedPatJetsAk8PuppiJets']:
-    for name in ['slimmedJetsPuppi', 'patJetsAK8PFPUPPI', 'packedPatJetsAk8PuppiJets','packedPatJetsAk8CHSJets']:
+    for name in ['slimmedJets', 'slimmedJetsPuppi', 'patJetsAK8PFPUPPI', 'packedPatJetsAk8PuppiJets','packedPatJetsAk8CHSJets']:
+        print "name", name
         labelName = cap(name)
         is_ak8 = "ak8" in name.lower()
         is_puppi = "puppi" in name.lower()
@@ -1100,7 +1133,8 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
             jetcorr_list.append("L2L3Residual")
 
         discriminators = ak4btagDiscriminators[:]
-#        if is_ak8 and is_puppi and is_topjet:
+#        discriminators = bTagDiscriminators[:]
+        discriminators.extend(ak4btagDiscriminators)
         if is_ak8 and is_topjet:
             discriminators.extend(ak8btagDiscriminators)
 
@@ -1209,21 +1243,23 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
     #
     # Jet collections
     rename_module(process, task, "updatedPatJetsTransientCorrectedSlimmedJetsPuppiNewDFTraining", "jetsAk4Puppi")
+    rename_module(process, task, "updatedPatJetsTransientCorrectedSlimmedJetsNewDFTraining", "jetsAk4CHS")
     rename_module(process, task, "updatedPatJetsTransientCorrectedPatJetsAK8PFPUPPIWithPuppiDaughters", "jetsAk8Puppi")
     rename_module(process, task, ak8chs_patname, "jetsAk8CHS")
     # TopJet collections
     rename_module(process, task, "updatedPatJetsTransientCorrectedPackedPatJetsAk8PuppiJetsWithPuppiDaughters", "jetsAk8PuppiSubstructure")
-    rename_module(process, task, "updatedPatJetsTransientCorrectedPackedPatJetsAk8CHSJetsNewDFTraining", "jetsAk8CHSSubstructure")
+    rename_module(process, task, "updatedPatJetsTransientCorrectedPackedPatJetsAk8CHSJetsNewDFTraining", "jetsAk8CHSSubstructure", update_userData=False)
 #    rename_module(process, task, "packedPatJetsAk8CHSJets", "jetsAk8CHSSubstructure", update_userData=False)  # don't update userData as JetSubstructurePacker
 
-    # Dummy module to allow us to rename slimmedJets to something more descriptive
-    process.jetsAk4CHS = cms.EDFilter("PATJetSelector",
-        cut=cms.string(''),
-        cutLoose=cms.string(''),
-        nLoose=cms.uint32(0),
-        src=cms.InputTag("slimmedJets")
-    )
-    task.add(process.jetsAk4CHS)
+
+    # # Dummy module to allow us to rename slimmedJets to something more descriptive
+    # process.jetsAk4CHS = cms.EDFilter("PATJetSelector",
+    #     cut=cms.string(''),
+    #     cutLoose=cms.string(''),
+    #     nLoose=cms.uint32(0),
+    #     src=cms.InputTag("slimmedJets")
+    # )
+    # task.add(process.jetsAk4CHS)
 
 
     # Higgs tagging commissioning

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -80,12 +80,12 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
         'pfDeepCSVJetTags:probbb',
         'pfBoostedDoubleSecondaryVertexAK8BJetTags',
         'pfBoostedDoubleSecondaryVertexCA15BJetTags',
-        # 'pfDeepFlavourJetTags:probb',
-        # 'pfDeepFlavourJetTags:probbb',
-        # 'pfDeepFlavourJetTags:problepb',
-        # 'pfDeepFlavourJetTags:probc',
-        # 'pfDeepFlavourJetTags:probuds',
-        # 'pfDeepFlavourJetTags:probg',
+        'pfDeepFlavourJetTags:probb',
+        'pfDeepFlavourJetTags:probbb',
+        'pfDeepFlavourJetTags:problepb',
+        'pfDeepFlavourJetTags:probc',
+        'pfDeepFlavourJetTags:probuds',
+        'pfDeepFlavourJetTags:probg',
     ]
 
 

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -74,13 +74,18 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
         'pfJetProbabilityBJetTags',
         'pfJetBProbabilityBJetTags',
         'pfSimpleSecondaryVertexHighEffBJetTags',
-        #'pfSimpleSecondaryVertexHighPurBJetTags',
         'pfCombinedInclusiveSecondaryVertexV2BJetTags',
         'pfCombinedMVAV2BJetTags',
         'pfDeepCSVJetTags:probb',
         'pfDeepCSVJetTags:probbb',
         'pfBoostedDoubleSecondaryVertexAK8BJetTags',
         'pfBoostedDoubleSecondaryVertexCA15BJetTags',
+        # 'pfDeepFlavourJetTags:probb',
+        # 'pfDeepFlavourJetTags:probbb',
+        # 'pfDeepFlavourJetTags:problepb',
+        # 'pfDeepFlavourJetTags:probc',
+        # 'pfDeepFlavourJetTags:probuds',
+        # 'pfDeepFlavourJetTags:probg',
     ]
 
 
@@ -992,12 +997,8 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
         'pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:HbbvsQCD',
         'pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:ZbbvsQCD',
         'pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:ZvsQCD',
-#        'pfDeepBoostedDiscriminatorsJetTags:bbvsLight',
- #       'pfDeepBoostedDiscriminatorsJetTags:ccvsLight',
         'pfDeepBoostedDiscriminatorsJetTags:TvsQCD',
-#        'pfDeepBoostedDiscriminatorsJetTags:ZHccvsQCD',
         'pfDeepBoostedDiscriminatorsJetTags:WvsQCD',
-#        'pfDeepBoostedDiscriminatorsJetTags:ZHbbvsQCD',
         'pfDeepBoostedDiscriminatorsJetTags:H4qvsQCD',
         'pfDeepBoostedDiscriminatorsJetTags:HbbvsQCD',
         'pfDeepBoostedDiscriminatorsJetTags:ZbbvsQCD',
@@ -1055,7 +1056,8 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
     # This MUST be run *After* JetSubstructurePacker, so that the subjets are already there,
     # otherwise the DeepBoostedJetTagInfoProducer will fail
     # Also add in PUPPI multiplicities while we're at it.
-    for name in ['slimmedJetsPuppi', 'patJetsAK8PFPUPPI', 'packedPatJetsAk8PuppiJets']:
+#    for name in ['slimmedJetsPuppi', 'patJetsAK8PFPUPPI', 'packedPatJetsAk8PuppiJets']:
+    for name in ['slimmedJetsPuppi', 'patJetsAK8PFPUPPI', 'packedPatJetsAk8PuppiJets','packedPatJetsAk8CHSJets']:
         labelName = cap(name)
         is_ak8 = "ak8" in name.lower()
         is_puppi = "puppi" in name.lower()
@@ -1098,7 +1100,8 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
             jetcorr_list.append("L2L3Residual")
 
         discriminators = ak4btagDiscriminators[:]
-        if is_ak8 and is_puppi and is_topjet:
+#        if is_ak8 and is_puppi and is_topjet:
+        if is_ak8 and is_topjet:
             discriminators.extend(ak8btagDiscriminators)
 
         updateJetCollection(
@@ -1210,7 +1213,8 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
     rename_module(process, task, ak8chs_patname, "jetsAk8CHS")
     # TopJet collections
     rename_module(process, task, "updatedPatJetsTransientCorrectedPackedPatJetsAk8PuppiJetsWithPuppiDaughters", "jetsAk8PuppiSubstructure")
-    rename_module(process, task, "packedPatJetsAk8CHSJets", "jetsAk8CHSSubstructure", update_userData=False)  # don't update userData as JetSubstructurePacker
+    rename_module(process, task, "updatedPatJetsTransientCorrectedPackedPatJetsAk8CHSJetsNewDFTraining", "jetsAk8CHSSubstructure")
+#    rename_module(process, task, "packedPatJetsAk8CHSJets", "jetsAk8CHSSubstructure", update_userData=False)  # don't update userData as JetSubstructurePacker
 
     # Dummy module to allow us to rename slimmedJets to something more descriptive
     process.jetsAk4CHS = cms.EDFilter("PATJetSelector",


### PR DESCRIPTION
Add DeepBoosted info to AK8CHS jets. Also DeepFlavor info is filled for AK4 jets, including AK4 sub-jets of top-jets.

