### PR TITLE
[102X] GenTopJet substructure vars

### DIFF
--- a/core/include/GenTopJet.h
+++ b/core/include/GenTopJet.h
@@ -11,28 +11,30 @@ public:
 
   const std::vector<GenJet> & subjets() const{return m_subjets;}
   void add_subjet(const GenJet & p){m_subjets.push_back(p);}
+
   float tau1() const{return m_tau1;}
-  void  set_tau1(float tau1){m_tau1=tau1;}
   float tau2() const{return m_tau2;}
-  void  set_tau2(float tau2){m_tau2=tau2;}
   float tau3() const{return m_tau3;}
-  void  set_tau3(float tau3){m_tau3=tau3;}
   float tau4() const{return m_tau4;}
-  void  set_tau4(float tau4){m_tau4=tau4;}
- 
+
   // energy correlation functions, N2 & N3, each with beta=1 or beta=2
   float ecfN2_beta1() const {return m_ecfN2_beta1;}
   float ecfN2_beta2() const {return m_ecfN2_beta2;}
   float ecfN3_beta1() const {return m_ecfN3_beta1;}
   float ecfN3_beta2() const {return m_ecfN3_beta2;}
-  
+
+  void set_tau1(float tau1){m_tau1=tau1;}
+  void set_tau2(float tau2){m_tau2=tau2;}
+  void set_tau3(float tau3){m_tau3=tau3;}
+  void set_tau4(float tau4){m_tau4=tau4;}
+
   void set_ecfN2_beta1(float x){m_ecfN2_beta1 = x;}
   void set_ecfN2_beta2(float x){m_ecfN2_beta2 = x;}
   void set_ecfN3_beta1(float x){m_ecfN3_beta1 = x;}
   void set_ecfN3_beta2(float x){m_ecfN3_beta2 = x;}
 private:
   std::vector<GenJet> m_subjets;
-  double m_tau1,m_tau2,m_tau3,m_tau4;
+  float m_tau1, m_tau2, m_tau3, m_tau4;
   float m_ecfN2_beta1, m_ecfN2_beta2, m_ecfN3_beta1, m_ecfN3_beta2;
 
 };

--- a/core/include/GenTopJet.h
+++ b/core/include/GenTopJet.h
@@ -6,7 +6,7 @@ class GenTopJet : public GenJet {
 public:
 
   GenTopJet() {
-    m_tau1 = m_tau2 = m_tau3 = -1;
+    m_tau1 = m_tau2 = m_tau3 = m_tau4 = -1;
   }
 
   const std::vector<GenJet> & subjets() const{return m_subjets;}
@@ -17,9 +17,11 @@ public:
   void  set_tau2(float tau2){m_tau2=tau2;}
   float tau3() const{return m_tau3;}
   void  set_tau3(float tau3){m_tau3=tau3;}
+  float tau4() const{return m_tau4;}
+  void  set_tau4(float tau4){m_tau4=tau4;}
  
 private:
   std::vector<GenJet> m_subjets;
-  double m_tau1,m_tau2,m_tau3;
+  double m_tau1,m_tau2,m_tau3,m_tau4;
 };
 

--- a/core/include/GenTopJet.h
+++ b/core/include/GenTopJet.h
@@ -6,7 +6,7 @@ class GenTopJet : public GenJet {
 public:
 
   GenTopJet() {
-    m_tau1 = m_tau2 = m_tau3 = m_tau4 = -1;
+    m_tau1 = m_tau2 = m_tau3 = m_tau4 = m_ecfN2_beta1 = m_ecfN2_beta2 = m_ecfN3_beta1 = m_ecfN3_beta2 = -1;
   }
 
   const std::vector<GenJet> & subjets() const{return m_subjets;}
@@ -20,8 +20,20 @@ public:
   float tau4() const{return m_tau4;}
   void  set_tau4(float tau4){m_tau4=tau4;}
  
+  // energy correlation functions, N2 & N3, each with beta=1 or beta=2
+  float ecfN2_beta1() const {return m_ecfN2_beta1;}
+  float ecfN2_beta2() const {return m_ecfN2_beta2;}
+  float ecfN3_beta1() const {return m_ecfN3_beta1;}
+  float ecfN3_beta2() const {return m_ecfN3_beta2;}
+  
+  void set_ecfN2_beta1(float x){m_ecfN2_beta1 = x;}
+  void set_ecfN2_beta2(float x){m_ecfN2_beta2 = x;}
+  void set_ecfN3_beta1(float x){m_ecfN3_beta1 = x;}
+  void set_ecfN3_beta2(float x){m_ecfN3_beta2 = x;}
 private:
   std::vector<GenJet> m_subjets;
   double m_tau1,m_tau2,m_tau3,m_tau4;
+  float m_ecfN2_beta1, m_ecfN2_beta2, m_ecfN3_beta1, m_ecfN3_beta2;
+
 };
 

--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -497,7 +497,7 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
     if(!gentopjet_sources.empty()){
         event->gentopjets = &gentopjets[0];
     }
-    auto gentopjet_tau_src = iConfig.getParameter<std::vector<std::string> >("gentopjet_njettiness_source");
+    auto gentopjet_tau_src = iConfig.getParameter<std::vector<std::string> >("gentopjet_njettiness_sources");
     for (const auto & srcItr : gentopjet_tau_src) {
       gentopjet_tau1_tokens.push_back(consumes<edm::ValueMap<float> >(edm::InputTag(srcItr, "tau1")));
       gentopjet_tau2_tokens.push_back(consumes<edm::ValueMap<float> >(edm::InputTag(srcItr, "tau2")));

--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -504,6 +504,16 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
       gentopjet_tau3_tokens.push_back(consumes<edm::ValueMap<float> >(edm::InputTag(srcItr, "tau3")));
       gentopjet_tau4_tokens.push_back(consumes<edm::ValueMap<float> >(edm::InputTag(srcItr, "tau4")));
     }
+    auto gentopjet_ecf_beta1_src = iConfig.getParameter<std::vector<std::string> >("gentopjet_ecf_beta1_sources");
+    for (const auto & srcItr : gentopjet_ecf_beta1_src) {
+      gentopjet_ecf_beta1_N2_tokens.push_back(consumes<edm::ValueMap<float> >(edm::InputTag(srcItr, "ecfN2")));
+      gentopjet_ecf_beta1_N3_tokens.push_back(consumes<edm::ValueMap<float> >(edm::InputTag(srcItr, "ecfN3")));
+    }
+    auto gentopjet_ecf_beta2_src = iConfig.getParameter<std::vector<std::string> >("gentopjet_ecf_beta2_sources");
+    for (const auto & srcItr : gentopjet_ecf_beta2_src) {
+      gentopjet_ecf_beta2_N2_tokens.push_back(consumes<edm::ValueMap<float> >(edm::InputTag(srcItr, "ecfN2")));
+      gentopjet_ecf_beta2_N3_tokens.push_back(consumes<edm::ValueMap<float> >(edm::InputTag(srcItr, "ecfN3")));
+    }
   }
   
   if(doMET){
@@ -960,6 +970,20 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
        edm::Handle<edm::ValueMap<float> > reco_gentopjets_tau4;
        if (j<gentopjet_tau4_tokens.size())
          iEvent.getByToken(gentopjet_tau4_tokens[j], reco_gentopjets_tau4);
+
+       edm::Handle<edm::ValueMap<float> > reco_gentopjets_ecf_beta1_N2;
+       if (j<gentopjet_ecf_beta1_N2_tokens.size())
+         iEvent.getByToken(gentopjet_ecf_beta1_N2_tokens[j], reco_gentopjets_ecf_beta1_N2);
+       edm::Handle<edm::ValueMap<float> > reco_gentopjets_ecf_beta1_N3;
+       if (j<gentopjet_ecf_beta1_N3_tokens.size())
+         iEvent.getByToken(gentopjet_ecf_beta1_N3_tokens[j], reco_gentopjets_ecf_beta1_N3);
+       edm::Handle<edm::ValueMap<float> > reco_gentopjets_ecf_beta2_N2;
+       if (j<gentopjet_ecf_beta2_N2_tokens.size())
+         iEvent.getByToken(gentopjet_ecf_beta2_N2_tokens[j], reco_gentopjets_ecf_beta2_N2);
+       edm::Handle<edm::ValueMap<float> > reco_gentopjets_ecf_beta2_N3;
+       if (j<gentopjet_ecf_beta2_N3_tokens.size())
+         iEvent.getByToken(gentopjet_ecf_beta2_N3_tokens[j], reco_gentopjets_ecf_beta2_N3);
+
        for (unsigned int i = 0; i < reco_gentopjets->size(); i++) {
          const reco::Jet & reco_gentopjet =  reco_gentopjets->at(i);
          if(reco_gentopjet.pt() < gentopjet_ptmin) continue;
@@ -980,6 +1004,15 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
            gentopjet.set_tau3((*reco_gentopjets_tau3)[ptr]);
          if(reco_gentopjets_tau4.isValid())
            gentopjet.set_tau4((*reco_gentopjets_tau4)[ptr]);
+
+         if(reco_gentopjets_ecf_beta1_N2.isValid())
+           gentopjet.set_ecfN2_beta1((*reco_gentopjets_ecf_beta1_N2)[ptr]);
+         if(reco_gentopjets_ecf_beta1_N3.isValid())
+           gentopjet.set_ecfN3_beta1((*reco_gentopjets_ecf_beta1_N3)[ptr]);
+         if(reco_gentopjets_ecf_beta2_N2.isValid())
+           gentopjet.set_ecfN2_beta2((*reco_gentopjets_ecf_beta2_N2)[ptr]);
+         if(reco_gentopjets_ecf_beta2_N3.isValid())
+           gentopjet.set_ecfN3_beta2((*reco_gentopjets_ecf_beta2_N3)[ptr]);
 
          if(dynamic_cast<const reco::GenJet *>(&reco_gentopjet)) { // This is a GenJet without subjets
            bool add_genparts=false;

--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -497,17 +497,11 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
     if(!gentopjet_sources.empty()){
         event->gentopjets = &gentopjets[0];
     }
-    auto gentopjet_tau1 = iConfig.getParameter<std::vector<edm::InputTag> >("gentopjet_tau1");
-    for(size_t j=0; j< gentopjet_tau1.size(); ++j){
-      gentopjet_tau1_tokens.push_back(consumes<edm::ValueMap<float> >(gentopjet_tau1[j]));
-    }
-    auto gentopjet_tau2 = iConfig.getParameter<std::vector<edm::InputTag> >("gentopjet_tau2");
-    for(size_t j=0; j< gentopjet_tau2.size(); ++j){
-      gentopjet_tau2_tokens.push_back(consumes<edm::ValueMap<float> >(gentopjet_tau2[j]));
-    }
-    auto gentopjet_tau3 = iConfig.getParameter<std::vector<edm::InputTag> >("gentopjet_tau3");
-    for(size_t j=0; j< gentopjet_tau3.size(); ++j){
-      gentopjet_tau3_tokens.push_back(consumes<edm::ValueMap<float> >(gentopjet_tau3[j]));
+    auto gentopjet_tau_src = iConfig.getParameter<std::vector<std::string> >("gentopjet_njettiness_source");
+    for (const auto & srcItr : gentopjet_tau_src) {
+      gentopjet_tau1_tokens.push_back(consumes<edm::ValueMap<float> >(edm::InputTag(srcItr, "tau1")));
+      gentopjet_tau2_tokens.push_back(consumes<edm::ValueMap<float> >(edm::InputTag(srcItr, "tau2")));
+      gentopjet_tau3_tokens.push_back(consumes<edm::ValueMap<float> >(edm::InputTag(srcItr, "tau3")));
     }
   }
   
@@ -981,17 +975,11 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
          if(reco_gentopjets_tau3.isValid())
            gentopjet.set_tau3((*reco_gentopjets_tau3)[ptr]);
 
-	 // //  std::vector<const reco::Candidate *> daughters;
-	 if(dynamic_cast<const reco::GenJet *>(&reco_gentopjet)) { // This is a GenJet without subjets
-	   //	   cout<<" This is a GenJet without subjets"<<endl;
-            // for (unsigned int l = 0; l < reco_gentopjet.numberOfDaughters(); l++) {
-            //   daughters.push_back(reco_gentopjet.daughter(l));
-	   bool add_genparts=false;
-	   if(gentopjets[j].size()<doGenJetConstituents) add_genparts=true;
-	   //	   cout<<"Fill Info for GenTopJet: "<<endl;
-	   fill_geninfo_recojet(reco_gentopjet, (GenJet&)gentopjet, add_genparts);
-	   //	   cout<<"END Fill Info for GenTopJet: "<<endl;
-	 }
+         if(dynamic_cast<const reco::GenJet *>(&reco_gentopjet)) { // This is a GenJet without subjets
+           bool add_genparts=false;
+           if(gentopjets[j].size()<doGenJetConstituents) add_genparts=true;
+           fill_geninfo_recojet(reco_gentopjet, (GenJet&)gentopjet, add_genparts);
+         }
          else { // This is a BasicJet with subjets
 	   //	   cout<<" This is a BasicJet with N subjets = "<<reco_gentopjet.numberOfDaughters()<<" and nConstituents="<<reco_gentopjet.nConstituents()<<endl;
 	 //	 if(!dynamic_cast<const reco::GenJet *>(&reco_gentopjet)){// This is a BasicJet with subjets

--- a/core/plugins/NtupleWriter.h
+++ b/core/plugins/NtupleWriter.h
@@ -115,6 +115,7 @@ class NtupleWriter : public edm::EDFilter {
       std::vector<edm::EDGetToken> gentopjet_tau1_tokens;
       std::vector<edm::EDGetToken> gentopjet_tau2_tokens;
       std::vector<edm::EDGetToken> gentopjet_tau3_tokens;
+      std::vector<edm::EDGetToken> gentopjet_tau4_tokens;
 
       std::vector<edm::EDGetToken> photon_tokens;
       std::vector<std::vector<Photon>> phs;

--- a/core/plugins/NtupleWriter.h
+++ b/core/plugins/NtupleWriter.h
@@ -116,6 +116,10 @@ class NtupleWriter : public edm::EDFilter {
       std::vector<edm::EDGetToken> gentopjet_tau2_tokens;
       std::vector<edm::EDGetToken> gentopjet_tau3_tokens;
       std::vector<edm::EDGetToken> gentopjet_tau4_tokens;
+      std::vector<edm::EDGetToken> gentopjet_ecf_beta1_N2_tokens;
+      std::vector<edm::EDGetToken> gentopjet_ecf_beta1_N3_tokens;
+      std::vector<edm::EDGetToken> gentopjet_ecf_beta2_N2_tokens;
+      std::vector<edm::EDGetToken> gentopjet_ecf_beta2_N3_tokens;
 
       std::vector<edm::EDGetToken> photon_tokens;
       std::vector<std::vector<Photon>> phs;

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -811,17 +811,15 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
     task.add(process.NjettinessAk8SoftDropPuppi)
 
     # AK8 GenJets
-    # process.NjettinessAk8Gen = Njettiness.clone(
-    #     src=cms.InputTag("ak8GenJets"),
-    #     cone=cms.double(0.8)
-    # )
-    # task.add(process.NjettinessAk8Gen)
+    process.NjettinessAk8Gen = process.NjettinessAk8CHS.clone(
+        src=cms.InputTag("ak8GenJetsFat")
+    )
+    task.add(process.NjettinessAk8Gen)
 
-    # process.NjettinessAk8SoftDropGen = Njettiness.clone(
-    #     src=cms.InputTag("ak8GenJetsSoftDrop"),
-    #     cone=cms.double(0.8)
-    # )
-    # task.add(process.NjettinessAk8SoftDropGen)
+    process.NjettinessAk8SoftDropGen = process.NjettinessAk8SoftDropCHS.clone(
+        src=cms.InputTag("ak8GenJetsSoftDrop")
+    )
+    task.add(process.NjettinessAk8SoftDropGen)
 
     # QJetsAdder
     # ----------
@@ -2163,22 +2161,32 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
                                     genjet_etamax=cms.double(5.0),
 
                                     doGenTopJets=cms.bool(not useData),
+                                    # gentopjet_sources=cms.VInputTag(
+                                    #     cms.InputTag("ak8GenJetsSoftDrop")
+                                    # ),
                                     gentopjet_sources=cms.VInputTag(
+                                        cms.InputTag("ak8GenJetsFat"),
                                         cms.InputTag("ak8GenJetsSoftDrop")
                                     ),
-                                    # gentopjet_sources =
-                                    # cms.VInputTag(cms.InputTag("ak8GenJets"),cms.InputTag("ak8GenJetsSoftDrop")),
-                                    # #this can be used to save N-subjettiness for ungroomed GenJets
                                     gentopjet_ptmin=cms.double(150.0),
                                     gentopjet_etamax=cms.double(5.0),
-                                    gentopjet_tau1=cms.VInputTag(),
-                                    gentopjet_tau2=cms.VInputTag(),
-                                    gentopjet_tau3=cms.VInputTag(),
-                                    # gentopjet_tau1 = cms.VInputTag(cms.InputTag("NjettinessAk8Gen","tau1"),cms.InputTag("NjettinessAk8SoftDropGen","tau1")), #this can be used to save N-subjettiness for GenJets
-                                    # gentopjet_tau2 = cms.VInputTag(cms.InputTag("NjettinessAk8Gen","tau2"),cms.InputTag("NjettinessAk8SoftDropGen","tau2")), #this can be used to save N-subjettiness for GenJets
-                                    # gentopjet_tau3 =
-                                    # cms.VInputTag(cms.InputTag("NjettinessAk8Gen","tau3"),cms.InputTag("NjettinessAk8SoftDropGen","tau3")),
-                                    # #this can be used to save N-subjettiness for GenJets
+                                    # gentopjet_tau1=cms.VInputTag(),
+                                    # gentopjet_tau2=cms.VInputTag(),
+                                    # gentopjet_tau3=cms.VInputTag(),
+                                    # this can be used to save N-subjettiness for GenJets:
+                                    # need one entry per gentopjet_source
+                                    gentopjet_tau1=cms.VInputTag(
+                                        cms.InputTag("NjettinessAk8Gen","tau1"),
+                                        cms.InputTag("NjettinessAk8SoftDropGen","tau1")
+                                    ),
+                                    gentopjet_tau2=cms.VInputTag(
+                                        cms.InputTag("NjettinessAk8Gen","tau2"),
+                                        cms.InputTag("NjettinessAk8SoftDropGen","tau2")
+                                    ),
+                                    gentopjet_tau3=cms.VInputTag(
+                                        cms.InputTag("NjettinessAk8Gen","tau3"),
+                                        cms.InputTag("NjettinessAk8SoftDropGen","tau3")
+                                    ),
 
                                     doAllPFParticles=cms.bool(False),
                                     pf_collection_source=cms.InputTag("packedPFCandidates"),

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -2172,7 +2172,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
                                     gentopjet_etamax=cms.double(5.0),
                                     # this can be used to save N-subjettiness for GenJets:
                                     # need one entry per gentopjet_source
-                                    gentopjet_njettiness_source=cms.vstring(
+                                    gentopjet_njettiness_sources=cms.vstring(
                                         "NjettinessAk8Gen",
                                         "NjettinessAk8SoftDropGen",
                                     ),

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -2170,22 +2170,11 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
                                     ),
                                     gentopjet_ptmin=cms.double(150.0),
                                     gentopjet_etamax=cms.double(5.0),
-                                    # gentopjet_tau1=cms.VInputTag(),
-                                    # gentopjet_tau2=cms.VInputTag(),
-                                    # gentopjet_tau3=cms.VInputTag(),
                                     # this can be used to save N-subjettiness for GenJets:
                                     # need one entry per gentopjet_source
-                                    gentopjet_tau1=cms.VInputTag(
-                                        cms.InputTag("NjettinessAk8Gen","tau1"),
-                                        cms.InputTag("NjettinessAk8SoftDropGen","tau1")
-                                    ),
-                                    gentopjet_tau2=cms.VInputTag(
-                                        cms.InputTag("NjettinessAk8Gen","tau2"),
-                                        cms.InputTag("NjettinessAk8SoftDropGen","tau2")
-                                    ),
-                                    gentopjet_tau3=cms.VInputTag(
-                                        cms.InputTag("NjettinessAk8Gen","tau3"),
-                                        cms.InputTag("NjettinessAk8SoftDropGen","tau3")
+                                    gentopjet_njettiness_source=cms.vstring(
+                                        "NjettinessAk8Gen",
+                                        "NjettinessAk8SoftDropGen",
                                     ),
 
                                     doAllPFParticles=cms.bool(False),

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -842,6 +842,8 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
     # The cut is taken from PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
     from RecoJets.JetProducers.ECF_cff import ecfNbeta1, ecfNbeta2
     ecf_pt_min = 250
+
+    # AK8 CHS
     process.ECFNbeta1Ak8SoftDropCHS = ecfNbeta1.clone(
         src=cms.InputTag("ak8CHSJetsSoftDropforsub"),
         cuts=cms.vstring('', '', 'pt > %f' % (ecf_pt_min))
@@ -854,7 +856,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
     )
     task.add(process.ECFNbeta2Ak8SoftDropCHS)
 
-
+    # AK8 PUPPI
     process.ECFNbeta1Ak8SoftDropPuppi = ecfNbeta1.clone(
         src=cms.InputTag("ak8PuppiJetsSoftDropforsub"),
         cuts=cms.vstring('', '', 'pt > %f' % (ecf_pt_min))
@@ -866,6 +868,19 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
         cuts=cms.vstring('', '', 'pt > %f' % (ecf_pt_min))
     )
     task.add(process.ECFNbeta2Ak8SoftDropPuppi)
+
+    # AK8 Gen
+    process.ECFNbeta1Ak8SoftDropGen = ecfNbeta1.clone(
+        src=cms.InputTag("ak8GenJetsSoftDrop"),
+        cuts=cms.vstring('', '', 'pt > %f' % (ecf_pt_min))
+    )
+    task.add(process.ECFNbeta1Ak8SoftDropGen)
+
+    process.ECFNbeta2Ak8SoftDropGen = ecfNbeta2.clone(
+        src=cms.InputTag("ak8GenJetsSoftDrop"),
+        cuts=cms.vstring('', '', 'pt > %f' % (ecf_pt_min))
+    )
+    task.add(process.ECFNbeta2Ak8SoftDropGen)
 
     # Warning, can be very slow
     # process.ECFNbeta1CA15SoftDropCHS = ecfNbeta1.clone(
@@ -2175,6 +2190,14 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
                                     gentopjet_njettiness_sources=cms.vstring(
                                         "NjettinessAk8Gen",
                                         "NjettinessAk8SoftDropGen",
+                                    ),
+                                    gentopjet_ecf_beta1_sources=cms.vstring(
+                                        "",
+                                        "ECFNbeta1Ak8SoftDropGen"
+                                    ),
+                                    gentopjet_ecf_beta2_sources=cms.vstring(
+                                        "",
+                                        "ECFNbeta2Ak8SoftDropGen"
                                     ),
 
                                     doAllPFParticles=cms.bool(False),


### PR DESCRIPTION
Store ungroomed & groomed gentopjet collections, both now have tau_1,2,3,4. Also add ECFs to GenTopJet class, only store for groomed genjets like for TopJets.
tau_2,3,4 seems to be calculated as 0 for groomed GenTopJet, I don't know why - the setup is the same as for TopJets, and tau_1 is non-zero.

Also tried to simplify sources a bit to avoid too much repetition. 

