### PR TITLE
[102X] add more flags for PF/GEN constituents storing

### DIFF
--- a/core/plugins/NtupleWriter.h
+++ b/core/plugins/NtupleWriter.h
@@ -66,7 +66,23 @@ class NtupleWriter : public edm::EDFilter {
       bool doAllGenParticles;
       bool doAllGenParticlesPythia8;
       unsigned doGenJetConstituents;
-      unsigned doPFJetConstituents;
+      unsigned doPFJetConstituentsNjets;
+      double doPFJetConstituentsMinJetPt;
+      bool doPFJetConstituents;
+      unsigned doPFTopJetConstituentsNjets;
+      double doPFTopJetConstituentsMinJetPt;
+      bool doPFTopJetConstituents;
+      unsigned doPFxconeJetConstituentsNjets;
+      double doPFxconeJetConstituentsMinJetPt;
+      bool doPFxconeJetConstituents;
+      unsigned doPFhotvrJetConstituentsNjets;
+      double doPFhotvrJetConstituentsMinJetPt;
+      bool doPFhotvrJetConstituents;
+      unsigned doPFxconeDijetJetConstituentsNjets;
+      double doPFxconeDijetJetConstituentsMinJetPt;
+      bool doPFxconeDijetJetConstituents;
+
+
       bool doPV;
       bool doTrigger;
       bool doEcalBadCalib;

--- a/core/plugins/NtupleWriter.h
+++ b/core/plugins/NtupleWriter.h
@@ -65,7 +65,22 @@ class NtupleWriter : public edm::EDFilter {
       bool doGenInfo;
       bool doAllGenParticles;
       bool doAllGenParticlesPythia8;
-      unsigned doGenJetConstituents;
+      unsigned doGenJetConstituentsNjets;
+      double doGenJetConstituentsMinJetPt;
+      bool doGenJetConstituents;
+      unsigned doGenTopJetConstituentsNjets;
+      double doGenTopJetConstituentsMinJetPt;
+      bool doGenTopJetConstituents;
+      unsigned doGenxconeJetConstituentsNjets;
+      double doGenxconeJetConstituentsMinJetPt;
+      bool doGenxconeJetConstituents;
+      unsigned doGenxconeDijetJetConstituentsNjets;
+      double doGenxconeDijetJetConstituentsMinJetPt;
+      bool doGenxconeDijetJetConstituents;
+      unsigned doGenhotvrJetConstituentsNjets;
+      double doGenhotvrJetConstituentsMinJetPt;
+      bool doGenhotvrJetConstituents;
+
       unsigned doPFJetConstituentsNjets;
       double doPFJetConstituentsMinJetPt;
       bool doPFJetConstituents;

--- a/core/plugins/NtupleWriterJets.cxx
+++ b/core/plugins/NtupleWriterJets.cxx
@@ -81,7 +81,7 @@ std::string getPuppiJetSpecificProducer(const std::string & name) {
   return multiplicity_name;
 }
 
-NtupleWriterJets::NtupleWriterJets(Config & cfg, bool set_jets_member, unsigned int NPFJetwConstituents){
+NtupleWriterJets::NtupleWriterJets(Config & cfg, bool set_jets_member, unsigned int NPFJetwConstituents, double MinPtJetwConstituents){
     handle = cfg.ctx.declare_event_output<vector<Jet>>(cfg.dest_branchname, cfg.dest);
     
     ptmin = cfg.ptmin;
@@ -99,19 +99,19 @@ NtupleWriterJets::NtupleWriterJets(Config & cfg, bool set_jets_member, unsigned 
     h_muons.clear();
     h_elecs.clear();
     NPFJetwConstituents_ = NPFJetwConstituents;
+    MinPtJetwConstituents_ = 2e4;
+    if(MinPtJetwConstituents>0) 
+      MinPtJetwConstituents_ = MinPtJetwConstituents;
     //    auto h_pfcand = cfg.ctx.get_handle<vector<PFParticle>>("PFParticles"); h_pfcands.push_back(h_pfcand);
 }
 
-NtupleWriterJets::NtupleWriterJets(Config & cfg, bool set_jets_member, const std::vector<std::string>& muon_sources, const std::vector<std::string>& elec_sources, unsigned int NPFJetwConstituents):
-  NtupleWriterJets::NtupleWriterJets(cfg, set_jets_member, NPFJetwConstituents) {
+NtupleWriterJets::NtupleWriterJets(Config & cfg, bool set_jets_member, const std::vector<std::string>& muon_sources, const std::vector<std::string>& elec_sources, unsigned int NPFJetwConstituents, double MinPtJetwConstituents):
+  NtupleWriterJets::NtupleWriterJets(cfg, set_jets_member, NPFJetwConstituents, MinPtJetwConstituents) {
 
     save_lepton_keys_ = true;
 
     for(const auto& muo_src : muon_sources){ auto h_muon = cfg.ctx.get_handle<std::vector<Muon>    >(muo_src); h_muons.push_back(h_muon); }
     for(const auto& ele_src : elec_sources){ auto h_elec = cfg.ctx.get_handle<std::vector<Electron>>(ele_src); h_elecs.push_back(h_elec); }
-    //    auto h_pfcand = cfg.ctx.get_handle<vector<PFParticle>>("pfparticles"); h_pfcands.push_back(h_pfcand);
-    NPFJetwConstituents_ = NPFJetwConstituents;
-
 }
 
 NtupleWriterJets::~NtupleWriterJets(){}
@@ -162,7 +162,7 @@ void NtupleWriterJets::process(const edm::Event & event, uhh2::Event & uevent,  
 
 
 	bool storePFcands = false;
-	if(i<NPFJetwConstituents_) storePFcands = true;
+	if(i<NPFJetwConstituents_ || jet.pt()>MinPtJetwConstituents_) storePFcands = true;
         try {
           fill_jet_info(uevent,pat_jet, jet, true, false, jet_puppiSpecificProducer,storePFcands);
         }
@@ -406,7 +406,7 @@ void NtupleWriterJets::fill_jet_info(uhh2::Event & uevent, const pat::Jet & pat_
 }
 
 
-NtupleWriterTopJets::NtupleWriterTopJets(Config & cfg, bool set_jets_member, unsigned int NPFJetwConstituents): ptmin(cfg.ptmin), etamax(cfg.etamax) {
+NtupleWriterTopJets::NtupleWriterTopJets(Config & cfg, bool set_jets_member, unsigned int NPFJetwConstituents, double MinPtJetwConstituents): ptmin(cfg.ptmin), etamax(cfg.etamax) {
     handle = cfg.ctx.declare_event_output<vector<TopJet>>(cfg.dest_branchname, cfg.dest);
     if(set_jets_member){
         topjets_handle = cfg.ctx.get_handle<vector<TopJet>>("topjets");
@@ -476,10 +476,13 @@ NtupleWriterTopJets::NtupleWriterTopJets(Config & cfg, bool set_jets_member, uns
     higgstaginfo_src = cfg.higgstaginfo_src;
     src_higgstaginfo_token =  cfg.cc.consumes<std::vector<reco::BoostedDoubleSVTagInfo> >(cfg.higgstaginfo_src);
     NPFJetwConstituents_ = NPFJetwConstituents;
+    MinPtJetwConstituents_ = 2e4;
+    if(MinPtJetwConstituents>0) 
+      MinPtJetwConstituents_ = MinPtJetwConstituents;
 }
 
-NtupleWriterTopJets::NtupleWriterTopJets(Config & cfg, bool set_jets_member, const std::vector<std::string>& muon_sources, const std::vector<std::string>& elec_sources, unsigned int NPFJetwConstituents):
-  NtupleWriterTopJets::NtupleWriterTopJets(cfg, set_jets_member, NPFJetwConstituents) {
+NtupleWriterTopJets::NtupleWriterTopJets(Config & cfg, bool set_jets_member, const std::vector<std::string>& muon_sources, const std::vector<std::string>& elec_sources, unsigned int NPFJetwConstituents, double MinPtJetwConstituents):
+  NtupleWriterTopJets::NtupleWriterTopJets(cfg, set_jets_member, NPFJetwConstituents, MinPtJetwConstituents) {
 
     save_lepton_keys_ = true;
 
@@ -933,7 +936,7 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
         topjets.emplace_back();
         TopJet & topjet = topjets.back();
 	bool storePFcands = false;
-	if(i<NPFJetwConstituents_) storePFcands = true;
+	if(i<NPFJetwConstituents_ || topjet.pt()>MinPtJetwConstituents_) storePFcands = true;
         try{
           uhh2::NtupleWriterJets::fill_jet_info(uevent,pat_topjet, topjet, do_btagging, false, topjet_puppiSpecificProducer,storePFcands);
         }catch(runtime_error &){

--- a/core/plugins/NtupleWriterJets.h
+++ b/core/plugins/NtupleWriterJets.h
@@ -24,8 +24,8 @@ class NtupleWriterJets: public NtupleWriterModule {
 public:
     static void fill_jet_info(uhh2::Event & uevent, const pat::Jet & pat_jet, Jet & jet, bool do_btagging, bool do_taginfo, const std::string & puppiJetSpecificProducer="", bool fill_pfcand=false);
 
-    explicit NtupleWriterJets(Config & cfg, bool set_jets_member, unsigned int NPFJetwConstituents);
-    explicit NtupleWriterJets(Config & cfg, bool set_jets_member, const std::vector<std::string>&, const std::vector<std::string>&, unsigned int NPFJetwConstituents);
+    explicit NtupleWriterJets(Config & cfg, bool set_jets_member, unsigned int NPFJetwConstituents, double MinPtJetwConstituents);
+    explicit NtupleWriterJets(Config & cfg, bool set_jets_member, const std::vector<std::string>&, const std::vector<std::string>&, unsigned int NPFJetwConstituents, double MinPtJetwConstituents);
 
     virtual void process(const edm::Event &, uhh2::Event &,  const edm::EventSetup&);
 
@@ -46,6 +46,7 @@ private:
     std::vector<Event::Handle<std::vector<PFParticle>>> h_pfcands;
 
     unsigned int NPFJetwConstituents_;
+    double MinPtJetwConstituents_;
 };
 
 
@@ -73,8 +74,8 @@ public:
         std::string ecf_beta2_src;
     };
 
-    explicit NtupleWriterTopJets(Config & cfg, bool set_jets_member, unsigned int NPFJetwConstituents);
-    explicit NtupleWriterTopJets(Config & cfg, bool set_jets_member, const std::vector<std::string>&, const std::vector<std::string>&, unsigned int NPFJetwConstituents);
+    explicit NtupleWriterTopJets(Config & cfg, bool set_jets_member, unsigned int NPFJetwConstituents, double MinPtJetwConstituents);
+    explicit NtupleWriterTopJets(Config & cfg, bool set_jets_member, const std::vector<std::string>&, const std::vector<std::string>&, unsigned int NPFJetwConstituents, double MinPtJetwConstituents);
 
     virtual void process(const edm::Event &, uhh2::Event &,  const edm::EventSetup&);
     static void fill_btag_info(uhh2::Event & uevent, const pat::Jet & pat_jet, TopJet & jet);
@@ -98,6 +99,7 @@ private:
 
     bool save_lepton_keys_;
     unsigned int NPFJetwConstituents_;
+    double MinPtJetwConstituents_;
     std::vector<Event::Handle<std::vector<Muon>    >> h_muons;
     std::vector<Event::Handle<std::vector<Electron>>> h_elecs;
     std::vector<Event::Handle<std::vector<PFParticle>>> h_pfcands;

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -2274,7 +2274,9 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
                                     doPFJetConstituentsNjets=cms.uint32(1),#store constituents for N leading jets, where N is parameter
                                     doPFJetConstituentsMinJetPt=cms.double(10.0),#store constituence for all jets with pt above threshold, set to negative value if not used
                                     doGenJets=cms.bool(not useData),
-                                    doGenJetConstituents=cms.uint32(0), #number of genjets with stored gen.constituents
+                                    #store GEN constituents: doGenJetConstituentsNjets and doGenJetConstituentsMinJetPt are combined with OR
+                                    doGenJetConstituentsNjets=cms.uint32(1),#store constituents for N leading genjets, where N is parameter
+                                    doGenJetConstituentsMinJetPt=cms.double(20.0),#store constituence for all genjets with pt above threshold, set to negative value if not used
                                     genjet_sources=cms.vstring(
                                        #"slimmedGenJets", "slimmedGenJetsAK8", "ca15GenJets"),
                                     "slimmedGenJets", "slimmedGenJetsAK8"),
@@ -2282,6 +2284,10 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
                                     genjet_etamax=cms.double(5.0),
 
                                     doGenTopJets=cms.bool(not useData),
+                                    #store GEN constituents: doGenJetConstituentsNjets and doGenJetConstituentsMinJetPt are combined with OR
+                                    doGenTopJetConstituentsNjets=cms.uint32(1),#store constituents for N leading genjets, where N is parameter
+                                    doGenTopJetConstituentsMinJetPt=cms.double(200.0),#store constituence for all genjets with pt above threshold, set to negative value if not used
+
                                     gentopjet_sources=cms.VInputTag(
                                         cms.InputTag("ak8GenJetsSoftDrop")
                                     ),
@@ -2320,12 +2326,18 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
                                     ),
 
                                     doGenHOTVR=cms.bool(not useData),
+                                    doGenhotvrJetConstituentsNjets=cms.uint32(1),#store constituents for N leading genjets, where N is parameter
+                                    doGenhotvrJetConstituentsMinJetPt=cms.double(200.0),#store constituence for all genjets with pt above threshold, set to negative value if not used
+
                                     doGenXCone=cms.bool(not useData),
+                                    doGenxconeJetConstituentsNjets=cms.uint32(1),#store constituents for N leading genjets, where N is parameter
+                                    doGenxconeJetConstituentsMinJetPt=cms.double(200.0),#store constituence for all genjets with pt above threshold, set to negative value if not used
+
                                     GenHOTVR_sources=cms.VInputTag(
                                         cms.InputTag("hotvrGen")
                                     ),
                                     GenXCone_sources=cms.VInputTag(
-                                        cms.InputTag("genXCone23TopJets"),
+#                                        cms.InputTag("genXCone23TopJets"),
                                         cms.InputTag("genXCone33TopJets"),
                                     ),
                                     doXCone_dijet=cms.bool(True), #XCone for dijet (JERC) studies, should be stored for QCD MC and JetHT DATA
@@ -2349,6 +2361,9 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
 
                                     ),
                                     doGenXCone_dijet=cms.bool(not useData),
+                                    #store GEN constituents: doGenJetConstituentsNjets and doGenJetConstituentsMinJetPt are combined with OR
+                                    doGenxconeDijetJetConstituentsNjets=cms.uint32(1),#store constituents for N leading topjets, where N is parameter
+                                    doGenxconeDijetJetConstituentsMinJetPt=cms.double(10.0),#store constituence for all topjets with pt above threshold, set to negative value if not 
                                     GenXCone_dijet_sources=cms.VInputTag(
                                         cms.InputTag("genXCone2jets04"),
                                         cms.InputTag("genXCone3jets04"),

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -1388,6 +1388,42 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
                                              BetaSubJets = cms.double(2.0)   # conical mesure for subjets
                                              )
     task.add(process.xconeCHS2jets04)
+    process.xconePUPPI4jets04 = cms.EDProducer("XConeProducer",
+                                             src=cms.InputTag("puppi"),
+                                             usePseudoXCone=usePseudoXCone,  # use PseudoXCone (faster) or XCone
+                                             NJets = cms.uint32(4),          # number of fatjets
+                                             RJets = cms.double(0.4),        # cone radius of fatjets
+                                             BetaJets = cms.double(2.0),     # conical mesure (beta = 2.0 is XCone default)
+                                             NSubJets = cms.uint32(1),       # number of subjets in each fatjet
+                                             RSubJets = cms.double(0.2),     # cone radius of subjetSrc
+                                             BetaSubJets = cms.double(2.0)   # conical mesure for subjets
+                                             )
+    task.add(process.xconePUPPI4jets04)
+
+    process.xconePUPPI3jets04 = cms.EDProducer("XConeProducer",
+                                             src=cms.InputTag("puppi"),
+                                             usePseudoXCone=usePseudoXCone,  # use PseudoXCone (faster) or XCone
+                                             NJets = cms.uint32(3),          # number of fatjets
+                                             RJets = cms.double(0.4),        # cone radius of fatjets
+                                             BetaJets = cms.double(2.0),     # conical mesure (beta = 2.0 is XCone default)
+                                             NSubJets = cms.uint32(1),       # number of subjets in each fatjet
+                                             RSubJets = cms.double(0.2),     # cone radius of subjetSrc
+                                             BetaSubJets = cms.double(2.0)   # conical mesure for subjets
+                                             )
+    task.add(process.xconePUPPI3jets04)
+
+    process.xconePUPPI2jets04 = cms.EDProducer("XConeProducer",
+                                             src=cms.InputTag("puppi"),
+                                             usePseudoXCone=usePseudoXCone,  # use PseudoXCone (faster) or XCone
+                                             NJets = cms.uint32(2),          # number of fatjets
+                                             RJets = cms.double(0.4),        # cone radius of fatjets
+                                             BetaJets = cms.double(2.0),     # conical mesure (beta = 2.0 is XCone default)
+                                             NSubJets = cms.uint32(1),       # number of subjets in each fatjet
+                                             RSubJets = cms.double(0.2),     # cone radius of subjetSrc
+                                             BetaSubJets = cms.double(2.0)   # conical mesure for subjets
+                                             )
+    task.add(process.xconePUPPI2jets04)
+
 
     process.genXCone4jets04 = cms.EDProducer("GenXConeProducer",
                                              src=cms.InputTag("packedGenParticlesForJetsNoNu"),
@@ -1470,6 +1506,42 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
                                              BetaSubJets = cms.double(2.0)   # conical mesure for subjets
                                              )
     task.add(process.xconeCHS2jets08)
+
+    process.xconePUPPI4jets08 = cms.EDProducer("XConeProducer",
+                                             src=cms.InputTag("puppi"),
+                                             usePseudoXCone=usePseudoXCone,  # use PseudoXCone (faster) or XCone
+                                             NJets = cms.uint32(4),          # number of fatjets
+                                             RJets = cms.double(0.8),        # cone radius of fatjets
+                                             BetaJets = cms.double(2.0),     # conical mesure (beta = 2.0 is XCone default)
+                                             NSubJets = cms.uint32(1),       # number of subjets in each fatjet
+                                             RSubJets = cms.double(0.4),     # cone radius of subjetSrc
+                                             BetaSubJets = cms.double(2.0)   # conical mesure for subjets
+                                             )
+    task.add(process.xconePUPPI4jets08)
+
+    process.xconePUPPI3jets08 = cms.EDProducer("XConeProducer",
+                                             src=cms.InputTag("puppi"),
+                                             usePseudoXCone=usePseudoXCone,  # use PseudoXCone (faster) or XCone
+                                             NJets = cms.uint32(3),          # number of fatjets
+                                             RJets = cms.double(0.8),        # cone radius of fatjets
+                                             BetaJets = cms.double(2.0),     # conical mesure (beta = 2.0 is XCone default)
+                                             NSubJets = cms.uint32(1),       # number of subjets in each fatjet
+                                             RSubJets = cms.double(0.4),     # cone radius of subjetSrc
+                                             BetaSubJets = cms.double(2.0)   # conical mesure for subjets
+                                             )
+    task.add(process.xconePUPPI3jets08)
+
+    process.xconePUPPI2jets08 = cms.EDProducer("XConeProducer",
+                                             src=cms.InputTag("puppi"),
+                                             usePseudoXCone=usePseudoXCone,  # use PseudoXCone (faster) or XCone
+                                             NJets = cms.uint32(2),          # number of fatjets
+                                             RJets = cms.double(0.8),        # cone radius of fatjets
+                                             BetaJets = cms.double(2.0),     # conical mesure (beta = 2.0 is XCone default)
+                                             NSubJets = cms.uint32(1),       # number of subjets in each fatjet
+                                             RSubJets = cms.double(0.4),     # cone radius of subjetSrc
+                                             BetaSubJets = cms.double(2.0)   # conical mesure for subjets
+                                             )
+    task.add(process.xconePUPPI2jets08)
 
     process.genXCone4jets08 = cms.EDProducer("GenXConeProducer",
                                              src=cms.InputTag("packedGenParticlesForJetsNoNu"),
@@ -1960,6 +2032,9 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
                                     doTopJets = cms.bool(True),
                                     topjet_ptmin=cms.double(150.0),
                                     topjet_etamax=cms.double(5.0),
+                                    #store PF constituents: doPFJetConstituentsNjets and doPFJetConstituentsMinJetPt are combined with OR
+                                    doPFTopJetConstituentsNjets=cms.uint32(1),#store constituents for N leading topjets, where N is parameter
+                                    doPFTopJetConstituentsMinJetPt=cms.double(200.0),#store constituence for all topjets with pt above threshold, set to negative value if not used
 
                                     TopJets=cms.VPSet(
                                         # Each PSet outputs a TopJet collection, with name {topjet_source}_{subjet_source}
@@ -2195,8 +2270,9 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
                                     # prunedPrunedGenParticles are stored (see above)
                                     doAllGenParticles=cms.bool(False),
                                     doAllGenParticlesPythia8=cms.bool(False),
-#                                    doPFJetConstituents=cms.uint32(0),
-                                    doPFJetConstituents=cms.uint32(1),
+                                    #store PF constituents: doPFJetConstituentsNjets and doPFJetConstituentsMinJetPt are combined with OR
+                                    doPFJetConstituentsNjets=cms.uint32(1),#store constituents for N leading jets, where N is parameter
+                                    doPFJetConstituentsMinJetPt=cms.double(10.0),#store constituence for all jets with pt above threshold, set to negative value if not used
                                     doGenJets=cms.bool(not useData),
                                     doGenJetConstituents=cms.uint32(0), #number of genjets with stored gen.constituents
                                     genjet_sources=cms.vstring(
@@ -2227,14 +2303,20 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
                                     pf_collection_source=cms.InputTag("packedPFCandidates"),
 
                                     # *** HOTVR & XCone stuff
-                                    doHOTVR=cms.bool(True),
                                     doXCone=cms.bool(True),
-                                    HOTVR_sources=cms.VInputTag(
-                                        cms.InputTag("hotvrPuppi")
-                                    ),
+                                    #store PF constituents: doPFJetConstituentsNjets and doPFJetConstituentsMinJetPt are combined with OR
+                                    doPFxconeJetConstituentsNjets=cms.uint32(1),#store constituents for N leading topjets, where N is parameter
+                                    doPFxconeJetConstituentsMinJetPt=cms.double(200.0),#store constituence for all topjets with pt above threshold, set to negative value if not used
                                     XCone_sources=cms.VInputTag(
                                         cms.InputTag("xconePuppi"),
                                         cms.InputTag("xconeCHS"),
+                                    ),
+                                    doHOTVR=cms.bool(True),
+                                    #store PF constituents: doPFJetConstituentsNjets and doPFJetConstituentsMinJetPt are combined with OR
+                                    doPFhotvrJetConstituentsNjets=cms.uint32(1),#store constituents for N leading topjets, where N is parameter
+                                    doPFhotvrJetConstituentsMinJetPt=cms.double(200.0),#store constituence for all topjets with pt above threshold, set to negative value if not used
+                                    HOTVR_sources=cms.VInputTag(
+                                        cms.InputTag("hotvrPuppi")
                                     ),
 
                                     doGenHOTVR=cms.bool(not useData),
@@ -2247,6 +2329,10 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
                                         cms.InputTag("genXCone33TopJets"),
                                     ),
                                     doXCone_dijet=cms.bool(True), #XCone for dijet (JERC) studies, should be stored for QCD MC and JetHT DATA
+                                    #store PF constituents: doPFJetConstituentsNjets and doPFJetConstituentsMinJetPt are combined with OR
+                                    doPFxconeDijetJetConstituentsNjets=cms.uint32(1),#store constituents for N leading topjets, where N is parameter
+                                    doPFxconeDijetJetConstituentsMinJetPt=cms.double(10.0),#store constituence for all topjets with pt above threshold, set to negative value if not used
+
                                     XCone_dijet_sources=cms.VInputTag(
                                         cms.InputTag("xconeCHS2jets04"),
                                         cms.InputTag("xconeCHS3jets04"),
@@ -2254,6 +2340,13 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=150.):
                                         cms.InputTag("xconeCHS2jets08"),
                                         cms.InputTag("xconeCHS3jets08"),
                                         cms.InputTag("xconeCHS4jets08"),
+                                        cms.InputTag("xconePUPPI2jets04"),
+                                        cms.InputTag("xconePUPPI3jets04"),
+                                        cms.InputTag("xconePUPPI4jets04"),
+                                        cms.InputTag("xconePUPPI2jets08"),
+                                        cms.InputTag("xconePUPPI3jets08"),
+                                        cms.InputTag("xconePUPPI4jets08"),
+
                                     ),
                                     doGenXCone_dijet=cms.bool(not useData),
                                     GenXCone_dijet_sources=cms.VInputTag(


### PR DESCRIPTION
Upon request, handles to store PF and GEN constituents are changed. Now, in addition to storing constituents for certain number of jets (with flag doPFJetConstituentsNjets), one can also store them for (all) jets above pt threshold (with flag doPFJetConstituentsMinJetPt). If not used, min pt threshold should be set to 0 or negative value to be handled properly.
Each family of jets (AK4 jets, TopJets, HOTVR, XCone, XCone_dijet) has its own set of flags. The same is true for GEN jet families. 

Minor changes: removed genXCone23 and added XCONE_dijet PUPPI jets. 