### PR TITLE
[102X] add more flags for PF/GEN constituents storing

### DIFF
--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -223,9 +223,32 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
   bool doJets = iConfig.getParameter<bool>("doJets");
 
   doGenJets = iConfig.getParameter<bool>("doGenJets");
+  doGenJetConstituentsNjets = iConfig.getParameter<unsigned>("doGenJetConstituentsNjets");
+  doGenJetConstituentsMinJetPt = iConfig.getParameter<double>("doGenJetConstituentsMinJetPt");
+  if(doGenJetConstituentsMinJetPt<1e-6) doGenJetConstituentsMinJetPt=2e4;
+  doGenJetConstituents = false;
+  if((doGenJetConstituentsNjets>0 || doGenJetConstituentsMinJetPt>0) && doGenJets) 
+    doGenJetConstituents=true;
+
   doGenTopJets = iConfig.getParameter<bool>("doGenTopJets");
-  doGenJetConstituents = iConfig.getParameter<unsigned>("doGenJetConstituents");
-  doPFJetConstituents = iConfig.getParameter<unsigned>("doPFJetConstituents");
+  doGenTopJetConstituentsNjets = iConfig.getParameter<unsigned>("doGenTopJetConstituentsNjets");
+  doGenTopJetConstituentsMinJetPt = iConfig.getParameter<double>("doGenTopJetConstituentsMinJetPt");
+  if(doGenTopJetConstituentsMinJetPt<1e-6) doGenTopJetConstituentsMinJetPt=2e4;
+  doGenTopJetConstituents = false;
+  if((doGenTopJetConstituentsNjets>0 || doGenTopJetConstituentsMinJetPt>0) && doGenTopJets) 
+    doGenTopJetConstituents=true;
+
+  doPFJetConstituentsNjets = iConfig.getParameter<unsigned>("doPFJetConstituentsNjets");
+  doPFJetConstituentsMinJetPt = iConfig.getParameter<double>("doPFJetConstituentsMinJetPt");
+  doPFJetConstituents = false;
+  if(doPFJetConstituentsNjets>0 || doPFJetConstituentsMinJetPt>0) 
+    doPFJetConstituents=true;
+  doPFTopJetConstituentsNjets = iConfig.getParameter<unsigned>("doPFTopJetConstituentsNjets");
+  doPFTopJetConstituentsMinJetPt = iConfig.getParameter<double>("doPFTopJetConstituentsMinJetPt");
+  doPFTopJetConstituents = false;
+  if(doPFTopJetConstituentsNjets>0 || doPFTopJetConstituentsMinJetPt>0) 
+    doPFTopJetConstituents=true;
+
   doPhotons = iConfig.getParameter<bool>("doPhotons");
   doMET = iConfig.getParameter<bool>("doMET");
   doGenMET = iConfig.getParameter<bool>("doGenMET");
@@ -242,13 +265,56 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
   doEcalBadCalib = iConfig.getParameter<bool>("doEcalBadCalib");
   doPrefire = iConfig.getParameter<bool>("doPrefire");
 
-  doHOTVR = iConfig.getParameter<bool>("doHOTVR");
+
   doXCone = iConfig.getParameter<bool>("doXCone");
-  doGenHOTVR = iConfig.getParameter<bool>("doGenHOTVR");
+  doPFxconeJetConstituentsNjets = iConfig.getParameter<unsigned>("doPFxconeJetConstituentsNjets");
+  doPFxconeJetConstituentsMinJetPt = iConfig.getParameter<double>("doPFxconeJetConstituentsMinJetPt");
+  doPFxconeJetConstituents = false;
+  if((doPFxconeJetConstituentsNjets>0 || doPFxconeJetConstituentsMinJetPt>0) && doXCone) 
+    doPFxconeJetConstituents=true;
+  if(doPFxconeJetConstituentsMinJetPt<1e-6) doPFxconeJetConstituentsMinJetPt=2e4;
+
+  doHOTVR = iConfig.getParameter<bool>("doHOTVR");
+  doPFhotvrJetConstituentsNjets = iConfig.getParameter<unsigned>("doPFhotvrJetConstituentsNjets");
+  doPFhotvrJetConstituentsMinJetPt = iConfig.getParameter<double>("doPFhotvrJetConstituentsMinJetPt");
+  doPFhotvrJetConstituents = false;
+  if((doPFhotvrJetConstituentsNjets>0 || doPFhotvrJetConstituentsMinJetPt>0) && doHOTVR) 
+    doPFhotvrJetConstituents=true;
+  if(doPFhotvrJetConstituentsMinJetPt<1e-6) doPFhotvrJetConstituentsMinJetPt=2e4;
+
+
   doGenXCone = iConfig.getParameter<bool>("doGenXCone");
+  doGenxconeJetConstituentsNjets = iConfig.getParameter<unsigned>("doGenxconeJetConstituentsNjets");
+  doGenxconeJetConstituentsMinJetPt = iConfig.getParameter<double>("doGenxconeJetConstituentsMinJetPt");
+  if(doGenxconeJetConstituentsMinJetPt<1e-6) doGenxconeJetConstituentsMinJetPt=2e4;
+  doGenxconeJetConstituents = false;
+  if((doGenxconeJetConstituentsNjets>0 || doGenxconeJetConstituentsMinJetPt>0) && doGenXCone) 
+    doGenxconeJetConstituents=true;
+
+  doGenHOTVR = iConfig.getParameter<bool>("doGenHOTVR");
+  doGenhotvrJetConstituentsNjets = iConfig.getParameter<unsigned>("doGenhotvrJetConstituentsNjets");
+  doGenhotvrJetConstituentsMinJetPt = iConfig.getParameter<double>("doGenhotvrJetConstituentsMinJetPt");
+  if(doGenhotvrJetConstituentsMinJetPt<1e-6) doGenhotvrJetConstituentsMinJetPt=2e4;
+  doGenhotvrJetConstituents = false;
+  if((doGenhotvrJetConstituentsNjets>0 || doGenhotvrJetConstituentsMinJetPt>0) && doGenHOTVR) 
+    doGenhotvrJetConstituents=true;
+
 
   doXCone_dijet = iConfig.getParameter<bool>("doXCone_dijet");
+  doPFxconeDijetJetConstituentsNjets = iConfig.getParameter<unsigned>("doPFxconeDijetJetConstituentsNjets");
+  doPFxconeDijetJetConstituentsMinJetPt = iConfig.getParameter<double>("doPFxconeDijetJetConstituentsMinJetPt");
+  doPFxconeDijetJetConstituents = false;
+  if((doPFxconeDijetJetConstituentsNjets>0 || doPFxconeDijetJetConstituentsMinJetPt>0) && doXCone_dijet) 
+    doPFxconeDijetJetConstituents=true;
+  if(doPFxconeDijetJetConstituentsMinJetPt<1e-6) doPFxconeDijetJetConstituentsMinJetPt=2e4;
+
   doGenXCone_dijet = iConfig.getParameter<bool>("doGenXCone_dijet");
+  doGenxconeDijetJetConstituentsNjets = iConfig.getParameter<unsigned>("doGenxconeDijetJetConstituentsNjets");
+  doGenxconeDijetJetConstituentsMinJetPt = iConfig.getParameter<double>("doGenxconeDijetJetConstituentsMinJetPt");
+  if(doGenxconeDijetJetConstituentsMinJetPt<1e-6) doGenxconeDijetJetConstituentsMinJetPt=2e4;
+  doGenxconeDijetJetConstituents = false;
+  if((doGenxconeDijetJetConstituentsNjets>0 || doGenxconeDijetJetConstituentsMinJetPt>0) && doGenXCone_dijet) 
+    doGenxconeDijetJetConstituents=true;
 
   auto pv_sources = iConfig.getParameter<std::vector<std::string> >("pv_sources");
 
@@ -328,7 +394,7 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
         NtupleWriterJets::Config cfg(*context, consumesCollector(), jet_sources[i], jet_sources[i]);
         cfg.ptmin = jet_ptmin;
         cfg.etamax = jet_etamax;
-        writer_modules.emplace_back(new NtupleWriterJets(cfg, i==0, muon_sources, elec_sources,doPFJetConstituents));
+        writer_modules.emplace_back(new NtupleWriterJets(cfg, i==0, muon_sources, elec_sources,doPFJetConstituentsNjets,doPFJetConstituentsMinJetPt));
       }
   }
   if(doTopJets){
@@ -433,7 +499,7 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
         std::string topbranch=topjet_source+"_"+subjet_source;
         cfg.dest_branchname = topbranch;
         cfg.dest = topbranch;
-        writer_modules.emplace_back(new NtupleWriterTopJets(cfg, j==0, muon_sources, elec_sources,doPFJetConstituents));
+        writer_modules.emplace_back(new NtupleWriterTopJets(cfg, j==0, muon_sources, elec_sources,doPFTopJetConstituentsNjets,doPFTopJetConstituentsMinJetPt));
 
       }
     }
@@ -555,7 +621,7 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
     branch(tr, "genInfo","GenInfo", event->genInfo);
     branch(tr, "GenParticles","std::vector<GenParticle>", event->genparticles);
   }
-  if(doPFJetConstituents>0){
+  if(doPFJetConstituents || doPFTopJetConstituents || doPFxconeJetConstituents || doPFhotvrJetConstituents || doPFxconeDijetJetConstituents){
     event->pfparticles = new vector<PFParticle>();
     branch(tr, "PFParticles","std::vector<PFParticle>", event->pfparticles);
   }
@@ -597,7 +663,7 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
   }
   if(doAllPFParticles){
     pf_collection_token = consumes<vector<pat::PackedCandidate>>(iConfig.getParameter<edm::InputTag>("pf_collection_source"));
-    if(doPFJetConstituents<1){
+    if(!doPFJetConstituents && !doPFTopJetConstituents && !doPFxconeJetConstituents && !doPFhotvrJetConstituents && !doPFxconeDijetJetConstituents){
       event->pfparticles = new vector<PFParticle>;
       branch(tr, "PFParticles", "std::vector<PFParticle>", &event->pfparticles);
     }
@@ -702,7 +768,7 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
    print_times(timer, "rho");
 
-   if(doPFJetConstituents>0){
+   if(doPFJetConstituents || doPFTopJetConstituents || doPFxconeJetConstituents || doPFhotvrJetConstituents || doPFxconeDijetJetConstituents){
      event->pfparticles->clear();
    }
 
@@ -937,7 +1003,7 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 	   }
 	 }
 	 bool add_genparts=false;
-	 if(genjets[j].size()<doGenJetConstituents) add_genparts=true;
+	 if(genjets[j].size()<doGenJetConstituentsNjets || gen_jet.pt()>doGenJetConstituentsMinJetPt) add_genparts=true;
 	 fill_geninfo_recojet(gen_jet,jet,add_genparts);
 	 genjets[j].push_back(jet);
        }
@@ -1046,6 +1112,7 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
            gentopjet.set_muf(muf);
          }
          gentopjets[j].push_back(gentopjet);
+
        }
      }
    }
@@ -1135,7 +1202,7 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
    // ------------- PF constituents --------------
   
    if(doAllPFParticles){
-     if(!doPFJetConstituents) event->pfparticles->clear();
+     if(!doPFJetConstituents && !doPFTopJetConstituents && !doPFxconeJetConstituents && !doPFhotvrJetConstituents && !doPFxconeDijetJetConstituents) event->pfparticles->clear();
      edm::Handle<vector<pat::PackedCandidate> > pfColl_handle;
      iEvent.getByToken(pf_collection_token, pfColl_handle);
 
@@ -1342,7 +1409,8 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 	}
 	thisJet.set_JEC_factor_raw(1.);
 	thisJet.set_JEC_L1factor_raw(1.);
-	if(hotvrJets[j].size()<doPFJetConstituents){
+	bool storePFparts = (hotvrJets[j].size()<doPFhotvrJetConstituentsNjets || thisJet.pt()>doPFhotvrJetConstituentsMinJetPt);
+	if(storePFparts){
 	  const auto& jet_daughter_ptrs = patJet.daughterPtrVector();
 	  for(const auto & daughter_p : jet_daughter_ptrs){
 	    size_t pfparticles_index = add_pfpart(*daughter_p,*event->pfparticles);
@@ -1376,7 +1444,7 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 	  }
 	  subjet.set_JEC_factor_raw(1.);
 	  subjet.set_JEC_L1factor_raw(1.);
-	  if(hotvrJets[j].size()<doPFJetConstituents){
+	  if(storePFparts){
 	    const auto& jet_daughter_ptrs = subItr->daughterPtrVector();
 	    for(const auto & daughter_p : jet_daughter_ptrs){
 	      size_t pfparticles_index = add_pfpart(*daughter_p,*event->pfparticles);
@@ -1425,7 +1493,8 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 	}
 	thisJet.set_JEC_factor_raw(1.);
 	thisJet.set_JEC_L1factor_raw(1.);
-	if(xconeJets[j].size()<doPFJetConstituents){
+	bool storePFparts = (xconeJets[j].size()<doPFxconeJetConstituentsNjets || thisJet.pt()>doPFxconeJetConstituentsMinJetPt);
+	if(storePFparts){
 	  const auto& jet_daughter_ptrs = patJet.daughterPtrVector();
 	  for(const auto & daughter_p : jet_daughter_ptrs){
 	    size_t pfparticles_index = add_pfpart(*daughter_p,*event->pfparticles);
@@ -1459,7 +1528,7 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 	  }
 	  subjet.set_JEC_factor_raw(1.);
 	  subjet.set_JEC_L1factor_raw(1.);
-	  if(xconeJets[j].size()<doPFJetConstituents){
+	  if(storePFparts){
 	    const auto& jet_daughter_ptrs = subItr->daughterPtrVector();
 	    for(const auto & daughter_p : jet_daughter_ptrs){
 	      size_t pfparticles_index = add_pfpart(*daughter_p,*event->pfparticles);
@@ -1508,8 +1577,8 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 	}
 	thisJet.set_JEC_factor_raw(1.);
 	thisJet.set_JEC_L1factor_raw(1.);
-
-	if(xconeJets_dijet[j].size()<doPFJetConstituents){
+	bool storePFparts = (xconeJets_dijet[j].size()<doPFxconeDijetJetConstituentsNjets || thisJet.pt()>doPFxconeDijetJetConstituentsMinJetPt);
+	if(storePFparts){
 	  const auto& jet_daughter_ptrs = patJet.daughterPtrVector();
 	  for(const auto & daughter_p : jet_daughter_ptrs){
 	    size_t pfparticles_index = add_pfpart(*daughter_p,*event->pfparticles);
@@ -1543,7 +1612,7 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 	  }
 	  subjet.set_JEC_factor_raw(1.);
 	  subjet.set_JEC_L1factor_raw(1.);
-	  if(xconeJets_dijet[j].size()<doPFJetConstituents){
+	  if(storePFparts){
 	    const auto& jet_daughter_ptrs = subItr->daughterPtrVector();
 	    for(const auto & daughter_p : jet_daughter_ptrs){
 	      size_t pfparticles_index = add_pfpart(*daughter_p,*event->pfparticles);
@@ -1574,7 +1643,7 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 	thisJet.set_partonFlavour(patJet.partonFlavour());
 	thisJet.set_hadronFlavour(patJet.hadronFlavour());
 	bool add_genparts=false;
-	if(genhotvrJets[j].size()<doGenJetConstituents) add_genparts=true;
+	if(genhotvrJets[j].size()<doGenhotvrJetConstituentsNjets || thisJet.pt()>doGenhotvrJetConstituentsMinJetPt) add_genparts=true;
         for (const auto & subItr : patJet.subjets()) {
           GenJet subjet;
           subjet.set_pt(subItr->p4().pt());
@@ -1608,7 +1677,7 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 	thisJet.set_partonFlavour(patJet.partonFlavour());
 	thisJet.set_hadronFlavour(patJet.hadronFlavour());
 	bool add_genparts=false;
-	if(genxconeJets[j].size()<doGenJetConstituents) add_genparts=true;
+	if(genxconeJets[j].size()<doGenxconeJetConstituentsNjets || thisJet.pt()>doGenxconeJetConstituentsMinJetPt) add_genparts=true;
         for (const auto & subItr : patJet.subjets()) {
           GenJet subjet;
           subjet.set_pt(subItr->p4().pt());
@@ -1643,7 +1712,7 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 	thisJet.set_partonFlavour(patJet.partonFlavour());
 	thisJet.set_hadronFlavour(patJet.hadronFlavour());
 	bool add_genparts=false;
-	if(genxconeJets[j].size()<doGenJetConstituents) add_genparts=true;
+	if(genxconeJets_dijet[j].size()<doGenxconeDijetJetConstituentsNjets || thisJet.pt()>doGenxconeDijetJetConstituentsMinJetPt) add_genparts=true;
         for (const auto & subItr : patJet.subjets()) {
           GenJet subjet;
           subjet.set_pt(subItr->p4().pt());

--- a/core/plugins/NtupleWriter.h
+++ b/core/plugins/NtupleWriter.h
@@ -65,8 +65,39 @@ class NtupleWriter : public edm::EDFilter {
       bool doGenInfo;
       bool doAllGenParticles;
       bool doAllGenParticlesPythia8;
-      unsigned doGenJetConstituents;
-      unsigned doPFJetConstituents;
+      unsigned doGenJetConstituentsNjets;
+      double doGenJetConstituentsMinJetPt;
+      bool doGenJetConstituents;
+      unsigned doGenTopJetConstituentsNjets;
+      double doGenTopJetConstituentsMinJetPt;
+      bool doGenTopJetConstituents;
+      unsigned doGenxconeJetConstituentsNjets;
+      double doGenxconeJetConstituentsMinJetPt;
+      bool doGenxconeJetConstituents;
+      unsigned doGenxconeDijetJetConstituentsNjets;
+      double doGenxconeDijetJetConstituentsMinJetPt;
+      bool doGenxconeDijetJetConstituents;
+      unsigned doGenhotvrJetConstituentsNjets;
+      double doGenhotvrJetConstituentsMinJetPt;
+      bool doGenhotvrJetConstituents;
+
+      unsigned doPFJetConstituentsNjets;
+      double doPFJetConstituentsMinJetPt;
+      bool doPFJetConstituents;
+      unsigned doPFTopJetConstituentsNjets;
+      double doPFTopJetConstituentsMinJetPt;
+      bool doPFTopJetConstituents;
+      unsigned doPFxconeJetConstituentsNjets;
+      double doPFxconeJetConstituentsMinJetPt;
+      bool doPFxconeJetConstituents;
+      unsigned doPFhotvrJetConstituentsNjets;
+      double doPFhotvrJetConstituentsMinJetPt;
+      bool doPFhotvrJetConstituents;
+      unsigned doPFxconeDijetJetConstituentsNjets;
+      double doPFxconeDijetJetConstituentsMinJetPt;
+      bool doPFxconeDijetJetConstituents;
+
+
       bool doPV;
       bool doTrigger;
       bool doEcalBadCalib;

--- a/core/plugins/NtupleWriterJets.cxx
+++ b/core/plugins/NtupleWriterJets.cxx
@@ -81,7 +81,7 @@ std::string getPuppiJetSpecificProducer(const std::string & name) {
   return multiplicity_name;
 }
 
-NtupleWriterJets::NtupleWriterJets(Config & cfg, bool set_jets_member, unsigned int NPFJetwConstituents){
+NtupleWriterJets::NtupleWriterJets(Config & cfg, bool set_jets_member, unsigned int NPFJetwConstituents, double MinPtJetwConstituents){
     handle = cfg.ctx.declare_event_output<vector<Jet>>(cfg.dest_branchname, cfg.dest);
     
     ptmin = cfg.ptmin;
@@ -99,19 +99,19 @@ NtupleWriterJets::NtupleWriterJets(Config & cfg, bool set_jets_member, unsigned 
     h_muons.clear();
     h_elecs.clear();
     NPFJetwConstituents_ = NPFJetwConstituents;
+    MinPtJetwConstituents_ = 2e4;
+    if(MinPtJetwConstituents>0) 
+      MinPtJetwConstituents_ = MinPtJetwConstituents;
     //    auto h_pfcand = cfg.ctx.get_handle<vector<PFParticle>>("PFParticles"); h_pfcands.push_back(h_pfcand);
 }
 
-NtupleWriterJets::NtupleWriterJets(Config & cfg, bool set_jets_member, const std::vector<std::string>& muon_sources, const std::vector<std::string>& elec_sources, unsigned int NPFJetwConstituents):
-  NtupleWriterJets::NtupleWriterJets(cfg, set_jets_member, NPFJetwConstituents) {
+NtupleWriterJets::NtupleWriterJets(Config & cfg, bool set_jets_member, const std::vector<std::string>& muon_sources, const std::vector<std::string>& elec_sources, unsigned int NPFJetwConstituents, double MinPtJetwConstituents):
+  NtupleWriterJets::NtupleWriterJets(cfg, set_jets_member, NPFJetwConstituents, MinPtJetwConstituents) {
 
     save_lepton_keys_ = true;
 
     for(const auto& muo_src : muon_sources){ auto h_muon = cfg.ctx.get_handle<std::vector<Muon>    >(muo_src); h_muons.push_back(h_muon); }
     for(const auto& ele_src : elec_sources){ auto h_elec = cfg.ctx.get_handle<std::vector<Electron>>(ele_src); h_elecs.push_back(h_elec); }
-    //    auto h_pfcand = cfg.ctx.get_handle<vector<PFParticle>>("pfparticles"); h_pfcands.push_back(h_pfcand);
-    NPFJetwConstituents_ = NPFJetwConstituents;
-
 }
 
 NtupleWriterJets::~NtupleWriterJets(){}
@@ -162,7 +162,7 @@ void NtupleWriterJets::process(const edm::Event & event, uhh2::Event & uevent,  
 
 
 	bool storePFcands = false;
-	if(i<NPFJetwConstituents_) storePFcands = true;
+	if(i<NPFJetwConstituents_ || jet.pt()>MinPtJetwConstituents_) storePFcands = true;
         try {
           fill_jet_info(uevent,pat_jet, jet, true, false, jet_puppiSpecificProducer,storePFcands);
         }
@@ -406,7 +406,7 @@ void NtupleWriterJets::fill_jet_info(uhh2::Event & uevent, const pat::Jet & pat_
 }
 
 
-NtupleWriterTopJets::NtupleWriterTopJets(Config & cfg, bool set_jets_member, unsigned int NPFJetwConstituents): ptmin(cfg.ptmin), etamax(cfg.etamax) {
+NtupleWriterTopJets::NtupleWriterTopJets(Config & cfg, bool set_jets_member, unsigned int NPFJetwConstituents, double MinPtJetwConstituents): ptmin(cfg.ptmin), etamax(cfg.etamax) {
     handle = cfg.ctx.declare_event_output<vector<TopJet>>(cfg.dest_branchname, cfg.dest);
     if(set_jets_member){
         topjets_handle = cfg.ctx.get_handle<vector<TopJet>>("topjets");
@@ -476,10 +476,13 @@ NtupleWriterTopJets::NtupleWriterTopJets(Config & cfg, bool set_jets_member, uns
     higgstaginfo_src = cfg.higgstaginfo_src;
     src_higgstaginfo_token =  cfg.cc.consumes<std::vector<reco::BoostedDoubleSVTagInfo> >(cfg.higgstaginfo_src);
     NPFJetwConstituents_ = NPFJetwConstituents;
+    MinPtJetwConstituents_ = 2e4;
+    if(MinPtJetwConstituents>0) 
+      MinPtJetwConstituents_ = MinPtJetwConstituents;
 }
 
-NtupleWriterTopJets::NtupleWriterTopJets(Config & cfg, bool set_jets_member, const std::vector<std::string>& muon_sources, const std::vector<std::string>& elec_sources, unsigned int NPFJetwConstituents):
-  NtupleWriterTopJets::NtupleWriterTopJets(cfg, set_jets_member, NPFJetwConstituents) {
+NtupleWriterTopJets::NtupleWriterTopJets(Config & cfg, bool set_jets_member, const std::vector<std::string>& muon_sources, const std::vector<std::string>& elec_sources, unsigned int NPFJetwConstituents, double MinPtJetwConstituents):
+  NtupleWriterTopJets::NtupleWriterTopJets(cfg, set_jets_member, NPFJetwConstituents, MinPtJetwConstituents) {
 
     save_lepton_keys_ = true;
 
@@ -933,7 +936,7 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
         topjets.emplace_back();
         TopJet & topjet = topjets.back();
 	bool storePFcands = false;
-	if(i<NPFJetwConstituents_) storePFcands = true;
+	if(i<NPFJetwConstituents_ || topjet.pt()>MinPtJetwConstituents_) storePFcands = true;
         try{
           uhh2::NtupleWriterJets::fill_jet_info(uevent,pat_topjet, topjet, do_btagging, false, topjet_puppiSpecificProducer,storePFcands);
         }catch(runtime_error &){

--- a/core/plugins/NtupleWriterJets.h
+++ b/core/plugins/NtupleWriterJets.h
@@ -24,8 +24,8 @@ class NtupleWriterJets: public NtupleWriterModule {
 public:
     static void fill_jet_info(uhh2::Event & uevent, const pat::Jet & pat_jet, Jet & jet, bool do_btagging, bool do_taginfo, const std::string & puppiJetSpecificProducer="", bool fill_pfcand=false);
 
-    explicit NtupleWriterJets(Config & cfg, bool set_jets_member, unsigned int NPFJetwConstituents);
-    explicit NtupleWriterJets(Config & cfg, bool set_jets_member, const std::vector<std::string>&, const std::vector<std::string>&, unsigned int NPFJetwConstituents);
+    explicit NtupleWriterJets(Config & cfg, bool set_jets_member, unsigned int NPFJetwConstituents, double MinPtJetwConstituents);
+    explicit NtupleWriterJets(Config & cfg, bool set_jets_member, const std::vector<std::string>&, const std::vector<std::string>&, unsigned int NPFJetwConstituents, double MinPtJetwConstituents);
 
     virtual void process(const edm::Event &, uhh2::Event &,  const edm::EventSetup&);
 
@@ -46,6 +46,7 @@ private:
     std::vector<Event::Handle<std::vector<PFParticle>>> h_pfcands;
 
     unsigned int NPFJetwConstituents_;
+    double MinPtJetwConstituents_;
 };
 
 
@@ -73,8 +74,8 @@ public:
         std::string ecf_beta2_src;
     };
 
-    explicit NtupleWriterTopJets(Config & cfg, bool set_jets_member, unsigned int NPFJetwConstituents);
-    explicit NtupleWriterTopJets(Config & cfg, bool set_jets_member, const std::vector<std::string>&, const std::vector<std::string>&, unsigned int NPFJetwConstituents);
+    explicit NtupleWriterTopJets(Config & cfg, bool set_jets_member, unsigned int NPFJetwConstituents, double MinPtJetwConstituents);
+    explicit NtupleWriterTopJets(Config & cfg, bool set_jets_member, const std::vector<std::string>&, const std::vector<std::string>&, unsigned int NPFJetwConstituents, double MinPtJetwConstituents);
 
     virtual void process(const edm::Event &, uhh2::Event &,  const edm::EventSetup&);
     static void fill_btag_info(uhh2::Event & uevent, const pat::Jet & pat_jet, TopJet & jet);
@@ -98,6 +99,7 @@ private:
 
     bool save_lepton_keys_;
     unsigned int NPFJetwConstituents_;
+    double MinPtJetwConstituents_;
     std::vector<Event::Handle<std::vector<Muon>    >> h_muons;
     std::vector<Event::Handle<std::vector<Electron>>> h_elecs;
     std::vector<Event::Handle<std::vector<PFParticle>>> h_pfcands;

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -1401,6 +1401,42 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                              BetaSubJets = cms.double(2.0)   # conical mesure for subjets
                                              )
     task.add(process.xconeCHS2jets04)
+    process.xconePUPPI4jets04 = cms.EDProducer("XConeProducer",
+                                             src=cms.InputTag("puppi"),
+                                             usePseudoXCone=usePseudoXCone,  # use PseudoXCone (faster) or XCone
+                                             NJets = cms.uint32(4),          # number of fatjets
+                                             RJets = cms.double(0.4),        # cone radius of fatjets
+                                             BetaJets = cms.double(2.0),     # conical mesure (beta = 2.0 is XCone default)
+                                             NSubJets = cms.uint32(1),       # number of subjets in each fatjet
+                                             RSubJets = cms.double(0.2),     # cone radius of subjetSrc
+                                             BetaSubJets = cms.double(2.0)   # conical mesure for subjets
+                                             )
+    task.add(process.xconePUPPI4jets04)
+
+    process.xconePUPPI3jets04 = cms.EDProducer("XConeProducer",
+                                             src=cms.InputTag("puppi"),
+                                             usePseudoXCone=usePseudoXCone,  # use PseudoXCone (faster) or XCone
+                                             NJets = cms.uint32(3),          # number of fatjets
+                                             RJets = cms.double(0.4),        # cone radius of fatjets
+                                             BetaJets = cms.double(2.0),     # conical mesure (beta = 2.0 is XCone default)
+                                             NSubJets = cms.uint32(1),       # number of subjets in each fatjet
+                                             RSubJets = cms.double(0.2),     # cone radius of subjetSrc
+                                             BetaSubJets = cms.double(2.0)   # conical mesure for subjets
+                                             )
+    task.add(process.xconePUPPI3jets04)
+
+    process.xconePUPPI2jets04 = cms.EDProducer("XConeProducer",
+                                             src=cms.InputTag("puppi"),
+                                             usePseudoXCone=usePseudoXCone,  # use PseudoXCone (faster) or XCone
+                                             NJets = cms.uint32(2),          # number of fatjets
+                                             RJets = cms.double(0.4),        # cone radius of fatjets
+                                             BetaJets = cms.double(2.0),     # conical mesure (beta = 2.0 is XCone default)
+                                             NSubJets = cms.uint32(1),       # number of subjets in each fatjet
+                                             RSubJets = cms.double(0.2),     # cone radius of subjetSrc
+                                             BetaSubJets = cms.double(2.0)   # conical mesure for subjets
+                                             )
+    task.add(process.xconePUPPI2jets04)
+
 
     process.genXCone4jets04 = cms.EDProducer("GenXConeProducer",
                                              src=cms.InputTag("packedGenParticlesForJetsNoNu"),
@@ -1483,6 +1519,42 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                              BetaSubJets = cms.double(2.0)   # conical mesure for subjets
                                              )
     task.add(process.xconeCHS2jets08)
+
+    process.xconePUPPI4jets08 = cms.EDProducer("XConeProducer",
+                                             src=cms.InputTag("puppi"),
+                                             usePseudoXCone=usePseudoXCone,  # use PseudoXCone (faster) or XCone
+                                             NJets = cms.uint32(4),          # number of fatjets
+                                             RJets = cms.double(0.8),        # cone radius of fatjets
+                                             BetaJets = cms.double(2.0),     # conical mesure (beta = 2.0 is XCone default)
+                                             NSubJets = cms.uint32(1),       # number of subjets in each fatjet
+                                             RSubJets = cms.double(0.4),     # cone radius of subjetSrc
+                                             BetaSubJets = cms.double(2.0)   # conical mesure for subjets
+                                             )
+    task.add(process.xconePUPPI4jets08)
+
+    process.xconePUPPI3jets08 = cms.EDProducer("XConeProducer",
+                                             src=cms.InputTag("puppi"),
+                                             usePseudoXCone=usePseudoXCone,  # use PseudoXCone (faster) or XCone
+                                             NJets = cms.uint32(3),          # number of fatjets
+                                             RJets = cms.double(0.8),        # cone radius of fatjets
+                                             BetaJets = cms.double(2.0),     # conical mesure (beta = 2.0 is XCone default)
+                                             NSubJets = cms.uint32(1),       # number of subjets in each fatjet
+                                             RSubJets = cms.double(0.4),     # cone radius of subjetSrc
+                                             BetaSubJets = cms.double(2.0)   # conical mesure for subjets
+                                             )
+    task.add(process.xconePUPPI3jets08)
+
+    process.xconePUPPI2jets08 = cms.EDProducer("XConeProducer",
+                                             src=cms.InputTag("puppi"),
+                                             usePseudoXCone=usePseudoXCone,  # use PseudoXCone (faster) or XCone
+                                             NJets = cms.uint32(2),          # number of fatjets
+                                             RJets = cms.double(0.8),        # cone radius of fatjets
+                                             BetaJets = cms.double(2.0),     # conical mesure (beta = 2.0 is XCone default)
+                                             NSubJets = cms.uint32(1),       # number of subjets in each fatjet
+                                             RSubJets = cms.double(0.4),     # cone radius of subjetSrc
+                                             BetaSubJets = cms.double(2.0)   # conical mesure for subjets
+                                             )
+    task.add(process.xconePUPPI2jets08)
 
     process.genXCone4jets08 = cms.EDProducer("GenXConeProducer",
                                              src=cms.InputTag("packedGenParticlesForJetsNoNu"),
@@ -1975,6 +2047,9 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                     # be smaller than topjet_ptmin to account for JECs
                                     topjet_ptmin=cms.double(150.0),
                                     topjet_etamax=cms.double(5.0),
+                                    #store PF constituents: doPFJetConstituentsNjets and doPFJetConstituentsMinJetPt are combined with OR
+                                    doPFTopJetConstituentsNjets=cms.uint32(1),#store constituents for N leading topjets, where N is parameter
+                                    doPFTopJetConstituentsMinJetPt=cms.double(200.0),#store constituence for all topjets with pt above threshold, set to negative value if not used
 
                                     TopJets=cms.VPSet(
                                         # Each PSet outputs a TopJet collection, with name {topjet_source}_{subjet_source}
@@ -2210,10 +2285,13 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                     # prunedPrunedGenParticles are stored (see above)
                                     doAllGenParticles=cms.bool(False),
                                     doAllGenParticlesPythia8=cms.bool(False),
-#                                    doPFJetConstituents=cms.uint32(0),
-                                    doPFJetConstituents=cms.uint32(1),
+                                    #store PF constituents: doPFJetConstituentsNjets and doPFJetConstituentsMinJetPt are combined with OR
+                                    doPFJetConstituentsNjets=cms.uint32(1),#store constituents for N leading jets, where N is parameter
+                                    doPFJetConstituentsMinJetPt=cms.double(10.0),#store constituence for all jets with pt above threshold, set to negative value if not used
                                     doGenJets=cms.bool(not useData),
-                                    doGenJetConstituents=cms.uint32(0), #number of genjets with stored gen.constituents
+                                    #store GEN constituents: doGenJetConstituentsNjets and doGenJetConstituentsMinJetPt are combined with OR
+                                    doGenJetConstituentsNjets=cms.uint32(1),#store constituents for N leading genjets, where N is parameter
+                                    doGenJetConstituentsMinJetPt=cms.double(20.0),#store constituence for all genjets with pt above threshold, set to negative value if not used
                                     genjet_sources=cms.vstring(
                                        #"slimmedGenJets", "slimmedGenJetsAK8", "ca15GenJets"),
                                     "slimmedGenJets", "slimmedGenJetsAK8"),
@@ -2221,9 +2299,11 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                     genjet_etamax=cms.double(5.0),
 
                                     doGenTopJets=cms.bool(not useData),
-                                    # gentopjet_sources=cms.VInputTag(
-                                    #     cms.InputTag("ak8GenJetsSoftDrop")
-                                    # ),
+                                    #store GEN constituents: doGenJetConstituentsNjets and doGenJetConstituentsMinJetPt are combined with OR
+                                    doGenTopJetConstituentsNjets=cms.uint32(1),#store constituents for N leading genjets, where N is parameter
+                                    doGenTopJetConstituentsMinJetPt=cms.double(200.0),#store constituence for all genjets with pt above threshold, set to negative value if not used
+
+
                                     gentopjet_sources=cms.VInputTag(
                                         cms.InputTag("ak8GenJetsFat"),
                                         cms.InputTag("ak8GenJetsSoftDrop")
@@ -2249,26 +2329,42 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                     pf_collection_source=cms.InputTag("packedPFCandidates"),
 
                                     # *** HOTVR & XCone stuff
-                                    doHOTVR=cms.bool(True),
                                     doXCone=cms.bool(True),
-                                    HOTVR_sources=cms.VInputTag(
-                                        cms.InputTag("hotvrPuppi")
-                                    ),
+                                    #store PF constituents: doPFJetConstituentsNjets and doPFJetConstituentsMinJetPt are combined with OR
+                                    doPFxconeJetConstituentsNjets=cms.uint32(1),#store constituents for N leading topjets, where N is parameter
+                                    doPFxconeJetConstituentsMinJetPt=cms.double(200.0),#store constituence for all topjets with pt above threshold, set to negative value if not used
                                     XCone_sources=cms.VInputTag(
                                         cms.InputTag("xconePuppi"),
                                         cms.InputTag("xconeCHS"),
                                     ),
+                                    doHOTVR=cms.bool(True),
+                                    #store PF constituents: doPFJetConstituentsNjets and doPFJetConstituentsMinJetPt are combined with OR
+                                    doPFhotvrJetConstituentsNjets=cms.uint32(1),#store constituents for N leading topjets, where N is parameter
+                                    doPFhotvrJetConstituentsMinJetPt=cms.double(200.0),#store constituence for all topjets with pt above threshold, set to negative value if not used
+                                    HOTVR_sources=cms.VInputTag(
+                                        cms.InputTag("hotvrPuppi")
+                                    ),
 
                                     doGenHOTVR=cms.bool(not useData),
+                                    doGenhotvrJetConstituentsNjets=cms.uint32(1),#store constituents for N leading genjets, where N is parameter
+                                    doGenhotvrJetConstituentsMinJetPt=cms.double(200.0),#store constituence for all genjets with pt above threshold, set to negative value if not used
+
                                     doGenXCone=cms.bool(not useData),
+                                    doGenxconeJetConstituentsNjets=cms.uint32(1),#store constituents for N leading genjets, where N is parameter
+                                    doGenxconeJetConstituentsMinJetPt=cms.double(200.0),#store constituence for all genjets with pt above threshold, set to negative value if not used
+
                                     GenHOTVR_sources=cms.VInputTag(
                                         cms.InputTag("hotvrGen")
                                     ),
                                     GenXCone_sources=cms.VInputTag(
-                                        cms.InputTag("genXCone23TopJets"),
+#                                        cms.InputTag("genXCone23TopJets"),
                                         cms.InputTag("genXCone33TopJets"),
                                     ),
                                     doXCone_dijet=cms.bool(True), #XCone for dijet (JERC) studies, should be stored for QCD MC and JetHT DATA
+                                    #store PF constituents: doPFJetConstituentsNjets and doPFJetConstituentsMinJetPt are combined with OR
+                                    doPFxconeDijetJetConstituentsNjets=cms.uint32(1),#store constituents for N leading topjets, where N is parameter
+                                    doPFxconeDijetJetConstituentsMinJetPt=cms.double(10.0),#store constituence for all topjets with pt above threshold, set to negative value if not used
+
                                     XCone_dijet_sources=cms.VInputTag(
                                         cms.InputTag("xconeCHS2jets04"),
                                         cms.InputTag("xconeCHS3jets04"),
@@ -2276,8 +2372,18 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                         cms.InputTag("xconeCHS2jets08"),
                                         cms.InputTag("xconeCHS3jets08"),
                                         cms.InputTag("xconeCHS4jets08"),
+                                        cms.InputTag("xconePUPPI2jets04"),
+                                        cms.InputTag("xconePUPPI3jets04"),
+                                        cms.InputTag("xconePUPPI4jets04"),
+                                        cms.InputTag("xconePUPPI2jets08"),
+                                        cms.InputTag("xconePUPPI3jets08"),
+                                        cms.InputTag("xconePUPPI4jets08"),
+
                                     ),
                                     doGenXCone_dijet=cms.bool(not useData),
+                                    #store GEN constituents: doGenJetConstituentsNjets and doGenJetConstituentsMinJetPt are combined with OR
+                                    doGenxconeDijetJetConstituentsNjets=cms.uint32(1),#store constituents for N leading topjets, where N is parameter
+                                    doGenxconeDijetJetConstituentsMinJetPt=cms.double(10.0),#store constituence for all topjets with pt above threshold, set to negative value if not 
                                     GenXCone_dijet_sources=cms.VInputTag(
                                         cms.InputTag("genXCone2jets04"),
                                         cms.InputTag("genXCone3jets04"),


### PR DESCRIPTION
Upon request, handles to store PF and GEN constituents are changed. Now, in addition to storing constituents for certain number of jets (with flag doPFJetConstituentsNjets), one can also store them for (all) jets above pt threshold (with flag doPFJetConstituentsMinJetPt). If not used, min pt threshold should be set to 0 or negative value to be handled properly.
Each family of jets (AK4 jets, TopJets, HOTVR, XCone, XCone_dijet) has its own set of flags. The same is true for GEN jet families.

Minor changes: removed genXCone23 and added XCONE_dijet PUPPI jets.