### PR TITLE
[102X] GenJet multiplicities

### DIFF
--- a/core/include/GenJet.h
+++ b/core/include/GenJet.h
@@ -8,6 +8,7 @@ public:
   GenJet(){
     m_genparticles_indices.clear();
     m_chf = m_cef = m_nhf = m_nef = m_muf = -1.0;
+    m_chargedMultiplicity = m_neutralMultiplicity = m_muonMultiplicity = m_electronMultiplicity = m_photonMultiplicity = 0;
   }
   ~GenJet(){};
 
@@ -26,8 +27,20 @@ public:
   double muf() const{return m_muf;}
   void  set_muf(double muf){m_muf=muf;}
 
+  int chargedMultiplicity() const{return m_chargedMultiplicity;} // All charged particles, including electrons and muons
+  void set_chargedMultiplicity(int x){m_chargedMultiplicity=x;}
+  int neutralMultiplicity() const{return m_neutralMultiplicity;} // All neutrals, including photons
+  void set_neutralMultiplicity(int x){m_neutralMultiplicity=x;}
+  int muonMultiplicity() const{return m_muonMultiplicity;}
+  void set_muonMultiplicity(int x){m_muonMultiplicity=x;}
+  int electronMultiplicity() const{return m_electronMultiplicity;}
+  void set_electronMultiplicity(int x){m_electronMultiplicity=x;}
+  int photonMultiplicity() const{return m_photonMultiplicity;}
+  void set_photonMultiplicity(int x){m_photonMultiplicity=x;}
+
 private:
   std::vector<unsigned int> m_genparticles_indices;
   double m_chf,m_cef,m_nhf,m_nef,m_muf;// jet energy fractions calculated from stable partons used for jet clustering
+  int m_chargedMultiplicity, m_neutralMultiplicity, m_muonMultiplicity, m_electronMultiplicity, m_photonMultiplicity;
 };
 

--- a/core/include/GenJet.h
+++ b/core/include/GenJet.h
@@ -16,15 +16,15 @@ public:
   std::vector<unsigned int> genparticles_indices() const{return m_genparticles_indices;}
   void add_genparticles_index(int ind){m_genparticles_indices.push_back(ind);}
 
-  double chf() const{return m_chf;}
+  double chf() const{return m_chf;}  // charged hadron energy fraction
   void  set_chf(double chf){m_chf=chf;}
-  double cef() const{return m_cef;}
+  double cef() const{return m_cef;}  // charged electromagnetic energy fraction AKA electrons
   void  set_cef(double cef){m_cef=cef;}
-  double nhf() const{return m_nhf;}
+  double nhf() const{return m_nhf;}  // neutral hadron energy fraction
   void  set_nhf(double nhf){m_nhf=nhf;}
-  double nef() const{return m_nef;}
+  double nef() const{return m_nef;}  // neutral electromagnetic energy fraction AKA photons
   void  set_nef(double nef){m_nef=nef;}
-  double muf() const{return m_muf;}
+  double muf() const{return m_muf;}  // muon energy fraction
   void  set_muf(double muf){m_muf=muf;}
 
   int chargedMultiplicity() const{return m_chargedMultiplicity;} // All charged particles, including electrons and muons

--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -1024,6 +1024,11 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
            double chf = 0; double cef = 0;
            double nhf = 0; double nef = 0;
            double muf = 0;
+           int chMult = 0;
+           int nMult = 0;
+           int muMult = 0;
+           int elMult = 0;
+           int phMult = 0;
            for (unsigned int k = 0; k < reco_gentopjet.numberOfDaughters(); k++) {
              GenJet subjet_v4;
              subjet_v4.set_pt(reco_gentopjet.daughter(k)->p4().pt());
@@ -1037,13 +1042,26 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
              muf +=subjet_v4.muf();
              chf += subjet_v4.chf();
              nhf += subjet_v4.nhf();
+             chMult += subjet_v4.chargedMultiplicity();
+             nMult += subjet_v4.neutralMultiplicity();
+             muMult += subjet_v4.muonMultiplicity();
+             elMult += subjet_v4.electronMultiplicity();
+             phMult += subjet_v4.photonMultiplicity();
              gentopjet.add_subjet(subjet_v4);
            }
+           // We have to manually update the main fatjet using quantities from the subjets,
+           // since the fatjet is a BasicJet which has no constituent info
            gentopjet.set_chf(chf);
            gentopjet.set_nhf(nhf);
            gentopjet.set_cef(cef);
            gentopjet.set_nef(nef);
            gentopjet.set_muf(muf);
+           gentopjet.set_charge(jet_charge);
+           gentopjet.set_chargedMultiplicity(chMult);
+           gentopjet.set_neutralMultiplicity(nMult);
+           gentopjet.set_muonMultiplicity(muMult);
+           gentopjet.set_electronMultiplicity(elMult);
+           gentopjet.set_photonMultiplicity(phMult);
          }
          gentopjets[j].push_back(gentopjet);
        }

--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -1739,7 +1739,13 @@ void NtupleWriter::fill_geninfo_patjet(const pat::Jet& pat_genjet, GenJet& genje
   double nhf = 0; double nef = 0;
   double muf = 0;
 
-  // loop over all jet constituents, fill PF fractions info
+  int chMult = 0;
+  int nMult = 0;
+  int muMult = 0;
+  int elMult = 0;
+  int phMult = 0;
+
+  // loop over all jet constituents, fill PF fractions & multiplicity info
   for(unsigned int l = 0; l<pat_genjet.numberOfSourceCandidatePtrs(); ++l){
    const reco::Candidate* constituent =  pat_genjet.daughter(l);
    jet_charge += constituent->charge();
@@ -1748,19 +1754,28 @@ void NtupleWriter::fill_geninfo_patjet(const pat::Jet& pat_genjet, GenJet& genje
      genjet.add_genparticles_index(genparticles_index);
    }
 
-   if(abs(constituent->pdgId())==11) 
+   if(abs(constituent->pdgId())==11) {
      cef += constituent->energy();
-   else{ 
-     if(abs(constituent->pdgId())==22)
+     elMult++;
+     chMult++;
+   } else{
+     if(abs(constituent->pdgId())==22) {
        nef += constituent->energy();
-     else{ 
-       if(abs(constituent->pdgId())==13)
-	 muf += constituent->energy();
-       else{
-	 if(abs(constituent->charge())>0.1)
-	   chf += constituent->energy();
-	 else
-	   nhf += constituent->energy();
+       phMult++;
+       nMult++;
+     } else{
+       if(abs(constituent->pdgId())==13) {
+         muf += constituent->energy();
+         muMult++;
+         chMult++;
+       } else{
+        if(abs(constituent->charge())>0.1) {
+          chf += constituent->energy();
+          chMult++;
+        } else {
+          nhf += constituent->energy();
+          nMult++;
+        }
        }
      }
    }
@@ -1776,6 +1791,11 @@ void NtupleWriter::fill_geninfo_patjet(const pat::Jet& pat_genjet, GenJet& genje
  genjet.set_nef(nef);
  genjet.set_muf(muf);
  genjet.set_charge(jet_charge);
+ genjet.set_chargedMultiplicity(chMult);
+ genjet.set_neutralMultiplicity(nMult);
+ genjet.set_muonMultiplicity(muMult);
+ genjet.set_electronMultiplicity(elMult);
+ genjet.set_photonMultiplicity(phMult);
  // cout<<"N constituens ="<<pat_genjet.numberOfSourceCandidatePtrs()<<" with charge = "<<jet_charge<<endl;
 }
 
@@ -1788,27 +1808,42 @@ void NtupleWriter::fill_geninfo_recocand(const reco::Candidate& sub_jet, GenJet&
   double nhf = 0; double nef = 0;
   double muf = 0;
 
+  int chMult = 0;
+  int nMult = 0;
+  int muMult = 0;
+  int elMult = 0;
+  int phMult = 0;
+
   for(unsigned int l = 0; l<sub_jet.numberOfSourceCandidatePtrs(); ++l){
    const reco::Candidate* constituent =  sub_jet.daughter(l);
-  jet_charge += constituent->charge();
+   jet_charge += constituent->charge();
  
 
-  if(abs(constituent->pdgId())==11) 
-    cef += constituent->energy();
-  else{ 
-    if(abs(constituent->pdgId())==22)
-      nef += constituent->energy();
-    else{ 
-      if(abs(constituent->pdgId())==13)
-	muf += constituent->energy();
-      else{
-	if(abs(constituent->charge())>0.1)
-	  chf += constituent->energy();
-	else
-	  nhf += constituent->energy();
-      }
-    }
-  }
+   if(abs(constituent->pdgId())==11) {
+     cef += constituent->energy();
+     elMult++;
+     chMult++;
+   } else{
+     if(abs(constituent->pdgId())==22) {
+       nef += constituent->energy();
+       phMult++;
+       nMult++;
+     } else{
+       if(abs(constituent->pdgId())==13) {
+         muf += constituent->energy();
+         muMult++;
+         chMult++;
+       } else{
+        if(abs(constituent->charge())>0.1) {
+          chf += constituent->energy();
+          chMult++;
+        } else {
+          nhf += constituent->energy();
+          nMult++;
+        }
+       }
+     }
+   }
   }
 
   chf /= genjet.energy();
@@ -1822,6 +1857,12 @@ void NtupleWriter::fill_geninfo_recocand(const reco::Candidate& sub_jet, GenJet&
   genjet.set_nef(nef);
   genjet.set_muf(muf);
   genjet.set_charge(jet_charge);
+  genjet.set_chargedMultiplicity(chMult);
+  genjet.set_neutralMultiplicity(nMult);
+  genjet.set_muonMultiplicity(muMult);
+  genjet.set_electronMultiplicity(elMult);
+  genjet.set_photonMultiplicity(phMult);
+
   // cout<<"N constituens ="<<pat_genjet.numberOfSourceCandidatePtrs()<<" with charge = "<<jet_charge<<endl;
 }
 


### PR DESCRIPTION
Add multiplicities to GenJet class, same as those for Jet class. Also done for GenTopJet explicitly from its subjets, like for the energy fractions.

Useful especially for the lepton genjets that require a cut on e.g.  ==1 electron and == 0 muon 