### PR TITLE
[102X] Turn off photon puppi isolation for 2016v2

### DIFF
--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -207,6 +207,8 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
       context.reset(new uhh2::CMSSWContext(*ges, outfile, tr));
   }
 
+  // Keep this early on, since we may need to modify things using it
+  year = iConfig.getParameter<std::string>("year");
 
   // TODO: cleanup the configuration by better grouping which
   // parameters are for which objects. Could even pass
@@ -342,6 +344,8 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
       cfg.id_keys = iConfig.getParameter<std::vector<std::string>>("photon_IDtags");
       assert(pv_sources.size() > 0); // note: pvs are needed for electron id.
       cfg.pv_src = pv_sources[0];
+      cfg.doPuppiIso = true;
+      if (year == "2016v2") { cfg.doPuppiIso = false; } // PUPPI isolation doens't exist in 80X
       writer_modules.emplace_back(new NtupleWriterPhotons(cfg, true, false));
   }
   if(doMuons){
@@ -512,7 +516,6 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
   branch(tr, "event", &event->event);
   branch(tr, "luminosityBlock", &event->luminosityBlock);
   branch(tr, "isRealData", &event->isRealData);
-  year = iConfig.getParameter<std::string>("year");
   branch(tr, "year", &event->year);
   branch(tr, "rho", &event->rho);
   //always create rho branch, as some SFrame modules rely on it being present; only fill it

--- a/core/plugins/NtupleWriterLeptons.cxx
+++ b/core/plugins/NtupleWriterLeptons.cxx
@@ -148,6 +148,7 @@ NtupleWriterPhotons::NtupleWriterPhotons(Config & cfg, bool set_photons_member, 
   src_token = cfg.cc.consumes<std::vector<pat::Photon>>(cfg.src);
   pv_token = cfg.cc.consumes<std::vector<reco::Vertex>>(cfg.pv_src);
   IDtag_keys = cfg.id_keys;
+  doPuppiIso_ = cfg.doPuppiIso;
 }
 
 NtupleWriterPhotons::~NtupleWriterPhotons(){}
@@ -173,25 +174,27 @@ void NtupleWriterPhotons::process(const edm::Event & event, uhh2::Event & uevent
         pho.set_eta( pat_pho.eta());
         pho.set_phi( pat_pho.phi());
         pho.set_energy( pat_pho.energy());
-	pho.set_vertex_x(pat_pho.vertex().x());
-	pho.set_vertex_y(pat_pho.vertex().y());
-	pho.set_vertex_z(pat_pho.vertex().z());
-	pho.set_puppiChargedHadronIso(pat_pho.puppiChargedHadronIso());
-	pho.set_puppiNeutralHadronIso(pat_pho.puppiNeutralHadronIso());
-	pho.set_puppiPhotonIso(pat_pho.puppiPhotonIso());
+        pho.set_vertex_x(pat_pho.vertex().x());
+        pho.set_vertex_y(pat_pho.vertex().y());
+        pho.set_vertex_z(pat_pho.vertex().z());
+        if (doPuppiIso_){
+          pho.set_puppiChargedHadronIso(pat_pho.puppiChargedHadronIso());
+          pho.set_puppiNeutralHadronIso(pat_pho.puppiNeutralHadronIso());
+          pho.set_puppiPhotonIso(pat_pho.puppiPhotonIso());
+        }
         pho.set_supercluster_eta( pat_pho.superCluster()->eta() );
         pho.set_supercluster_phi( pat_pho.superCluster()->phi() );
 
-	pho.set_trackIso(pat_pho.trackIso());
-	pho.set_ecalIso(pat_pho.ecalIso());
-	pho.set_hcalIso(pat_pho.hcalIso());
-	pho.set_caloIso(pat_pho.caloIso());
+        pho.set_trackIso(pat_pho.trackIso());
+        pho.set_ecalIso(pat_pho.ecalIso());
+        pho.set_hcalIso(pat_pho.hcalIso());
+        pho.set_caloIso(pat_pho.caloIso());
 
-	//	pho.set_patParticleIso(pat_pho.patParticleIso());
-	pho.set_chargedHadronIso(pat_pho.chargedHadronIso());
-	pho.set_neutralHadronIso(pat_pho.neutralHadronIso());
-	pho.set_photonIso(pat_pho.photonIso());
-	pho.set_puChargedHadronIso(pat_pho.puChargedHadronIso());
+        //	pho.set_patParticleIso(pat_pho.patParticleIso());
+        pho.set_chargedHadronIso(pat_pho.chargedHadronIso());
+        pho.set_neutralHadronIso(pat_pho.neutralHadronIso());
+        pho.set_photonIso(pat_pho.photonIso());
+        pho.set_puChargedHadronIso(pat_pho.puChargedHadronIso());
 
         for(const auto& tag_str : IDtag_keys){
           if(!pat_pho.hasUserInt(tag_str)) throw cms::Exception("Missing userInt label", "Label for pat::Photon::userInt not found: "+tag_str);

--- a/core/plugins/NtupleWriterLeptons.h
+++ b/core/plugins/NtupleWriterLeptons.h
@@ -39,6 +39,7 @@ public:
     struct Config: public NtupleWriterModule::Config {     
       edm::InputTag pv_src;
       std::vector<std::string> id_keys;
+      bool doPuppiIso;
 
       // inherit constructor does not work yet :-(
       Config(uhh2::Context & ctx_, edm::ConsumesCollector && cc_, const edm::InputTag & src_,
@@ -58,7 +59,7 @@ private:
     Event::Handle<std::vector<Photon>> handle; // main handle to write output to
     boost::optional<Event::Handle<std::vector<Photon>>> photons_handle; // handle of name "electrons" in case set_electrons_member is true
 
-    bool save_source_candidates_;
+    bool save_source_candidates_, doPuppiIso_;
 };
 
 


### PR DESCRIPTION
This is because (a) the method didn't exist in 80X when the dataset was made, (b) the pat::Photon constructor doesn't initialise the puppiIsolation variables, so we just read junk values, hence we get values like 10^26, and that differ between runnings.