### PR TITLE
[102X] Disable lepton genjets by default

### DIFF
--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -2332,8 +2332,8 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                     doGenJetConstituentsNjets=cms.uint32(0),#store constituents for N leading genjets, where N is parameter
                                     doGenJetConstituentsMinJetPt=cms.double(-1),#store constituence for all genjets with pt above threshold, set to negative value if not used
                                     genjet_sources=cms.vstring(
-                                       #"slimmedGenJets", "slimmedGenJetsAK8", "ca15GenJets"),
-                                       "muonGenJets", "electronGenJets", "slimmedGenJets", "slimmedGenJetsAK8"),
+                                        # "muonGenJets", "electronGenJets",
+                                        "slimmedGenJets", "slimmedGenJetsAK8"),
                                     genjet_ptmin=cms.double(10.0),
                                     genjet_etamax=cms.double(5.0),
 


### PR DESCRIPTION
Since tests in #1139 look OK, we can now remove the lepton genjets from the default list. You can just uncomment one line to add it back in for special samples.