### PR TITLE
[102X] Replace auto_ptr with make_shared

### DIFF
--- a/common/src/BTagCalibrationStandalone.cc
+++ b/common/src/BTagCalibrationStandalone.cc
@@ -434,9 +434,7 @@ std::cerr << "ERROR in BTagCalibration: "
             << ost;
 throw std::exception();
     }
-    otherSysTypeReaders_[ost] = std::auto_ptr<BTagCalibrationReaderImpl>(
-        new BTagCalibrationReaderImpl(op, ost)
-    );
+    otherSysTypeReaders_[ost] = std::make_shared<BTagCalibrationReaderImpl>(op, ost);
   }
 }
 


### PR DESCRIPTION
Fixes warning, shouldn't affect usage.

Also testing this to avoid running ntuples:
[onlycompile]