### PR TITLE
[102X] Fix higgs tagging variables for AK8 Puppi TopJets

### DIFF
--- a/core/include/TopJet.h
+++ b/core/include/TopJet.h
@@ -81,7 +81,8 @@ public:
    }
 
   TopJet(){
-      m_qjets_volatility = m_tau1 = m_tau2 = m_tau3 = m_tau4 = m_mvahiggsdiscr = m_softdropmass = m_tau1_groomed = m_tau2_groomed = m_tau3_groomed = m_tau4_groomed = m_ecfN2_beta1 = m_ecfN2_beta2 = m_ecfN3_beta1 = m_ecfN3_beta2 = -1.0f;
+      m_qjets_volatility = m_tau1 = m_tau2 = m_tau3 = m_tau4 = m_softdropmass = m_tau1_groomed = m_tau2_groomed = m_tau3_groomed = m_tau4_groomed = m_ecfN2_beta1 = m_ecfN2_beta2 = m_ecfN3_beta1 = m_ecfN3_beta2 = -1.0f;
+      m_mvahiggsdiscr = -2;
       m_btag_BoostedDoubleSecondaryVertexAK8 = -2;
       m_btag_BoostedDoubleSecondaryVertexCA15 = -2;
       m_btag_MassDecorrelatedDeepBoosted_bbvsLight=-2;

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -1300,7 +1300,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
 
 
     # Higgs tagging commissioning
-    process.pfBoostedDoubleSVTagInfos = cms.EDProducer("BoostedDoubleSVProducer",
+    process.pfBoostedDoubleSVTagInfosCHS = cms.EDProducer("BoostedDoubleSVProducer",
         trackSelectionBlock,
         beta=cms.double(1.0),
         R0=cms.double(0.8),
@@ -1310,9 +1310,22 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
         ),
         svTagInfos=cms.InputTag("pfInclusiveSecondaryVertexFinderTagInfosAk8CHSJetsFat")  # This name is taken from the modules added by addJetcollection in add_fatjets_subjets
     )
-    task.add(process.pfBoostedDoubleSVTagInfos)
+    process.pfBoostedDoubleSVTagInfosCHS.trackSelection.jetDeltaRMax = cms.double(0.8)
+    task.add(process.pfBoostedDoubleSVTagInfosCHS)
 
-    process.pfBoostedDoubleSVTagInfos.trackSelection.jetDeltaRMax = cms.double(0.8)
+    process.pfBoostedDoubleSVTagInfosPuppi = cms.EDProducer("BoostedDoubleSVProducer",
+        trackSelectionBlock,
+        beta=cms.double(1.0),
+        R0=cms.double(0.8),
+        maxSVDeltaRToJet=cms.double(0.7),
+        trackPairV0Filter=cms.PSet(
+           k0sMassWindow=cms.double(0.03)
+        ),
+        svTagInfos=cms.InputTag("pfInclusiveSecondaryVertexFinderTagInfosAk8PuppiJetsFat")  # This name is taken from the modules added by addJetcollection in add_fatjets_subjets
+    )
+    process.pfBoostedDoubleSVTagInfosPuppi.trackSelection.jetDeltaRMax = cms.double(0.8)
+    task.add(process.pfBoostedDoubleSVTagInfosPuppi)
+
 
     ###############################################
     # HOTVR & XCONE
@@ -2124,7 +2137,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                             # the discriminator has to be taken from ungroomed jets
                                             higgstag_source=cms.string("patJetsAk8CHSJetsFat"),
                                             higgstag_name=cms.string("pfBoostedDoubleSecondaryVertexAK8BJetTags"),
-                                            higgstaginfo_source=cms.string("pfBoostedDoubleSVTagInfos"),
+                                            higgstaginfo_source=cms.string("pfBoostedDoubleSVTagInfosCHS"),
 
                                             # If empty, njettiness is directly taken from jet UserFloat,
                                             # otherwise taken from the provided source
@@ -2157,7 +2170,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
 
                                             higgstag_source=cms.string("patJetsAk8PuppiJetsFat"),
                                             higgstag_name=cms.string("pfBoostedDoubleSecondaryVertexAK8BJetTags"),
-                                            higgstaginfo_source=cms.string("pfBoostedDoubleSVTagInfos"),  # FIXME Does this need replacing?
+                                            higgstaginfo_source=cms.string("pfBoostedDoubleSVTagInfosPuppi"),  # FIXME Does this need replacing?
 
                                             njettiness_source=cms.string("NjettinessAk8Puppi"),
                                             substructure_variables_source=cms.string("ak8PuppiJetsFat"),

--- a/examples/config/ExampleJetTags.xml
+++ b/examples/config/ExampleJetTags.xml
@@ -15,7 +15,8 @@
 
         <UserConfig>
             <!-- define which collections to read from the input. Only specify what you need to save I/O time -->
-            <Item Name="JetCollection" Value="slimmedJets" />
+            <Item Name="JetCollection" Value="jetsAk4CHS" />
+            <Item Name="TopJetCollection" Value="jetsAk8PuppiSubstructure_SoftDropPuppi" />
 
 
             <!-- the class name of the AnalysisModule subclasses to run: -->

--- a/examples/src/ExampleModuleJetTags.cxx
+++ b/examples/src/ExampleModuleJetTags.cxx
@@ -11,10 +11,12 @@
 using namespace std;
 using namespace uhh2;
 
-/** \brief Example of how to use & check Jet IDs via tags
+/** \brief Example of how to use & check Jet IDs/discriminators via tags
  *
  * This brief example shows how to use a tag,
  * and produces a histogram to show how many jets passed each ID.
+ * It also shows the distribution of each tag value for TopJets, which store
+ * values and not IDs.
  */
 
 namespace uhh2examples {
@@ -59,6 +61,48 @@ void ExampleJetTagsHists::fill(const Event & event){
 ExampleJetTagsHists::~ExampleJetTagsHists(){}
 
 
+class ExampleTopJetTagsHists: public uhh2::Hists {
+public:
+    ExampleTopJetTagsHists(uhh2::Context & ctx, const std::string & dirname, const vector<string> & topjetTagNames_);
+
+    virtual void fill(const uhh2::Event & ev) override;
+    virtual ~ExampleTopJetTagsHists();
+private:
+    TH2F * hTopJetTags;
+    vector<string> topjetTagNames;
+};
+
+ExampleTopJetTagsHists::ExampleTopJetTagsHists(Context & ctx, const string & dirname, const vector<string> & topjetTagNames_):
+Hists(ctx, dirname),
+topjetTagNames(topjetTagNames_)
+{
+    hTopJetTags = book<TH2F>("topjet_tags", ";TopJet Tag;Value", topjetTagNames.size(), 0, topjetTagNames.size(), 240, -60, 60);
+    // set custom x axis labels
+    for (uint i=1;i<=topjetTagNames.size();i++) {
+        hTopJetTags->GetXaxis()->SetBinLabel(i, topjetTagNames.at(i-1).c_str());
+    }
+}
+
+
+void ExampleTopJetTagsHists::fill(const Event & event){
+    // Loop over all tags for all topjets, and store their values
+    for (auto & jetItr : *event.topjets) {
+        for (uint i=0; i < topjetTagNames.size(); i++) {
+            // Here we want the tag from the tag string name
+            // Use tagname2tag to convert string to a tag, then use get_tag
+            if (jetItr.has_tag(jetItr.tagname2tag(topjetTagNames.at(i)))) {
+                hTopJetTags->Fill(i, jetItr.get_tag(jetItr.tagname2tag(topjetTagNames.at(i))), event.weight);
+            } else {
+                hTopJetTags->Fill(i, -10, event.weight);
+            }
+        }
+    }
+
+}
+
+ExampleTopJetTagsHists::~ExampleTopJetTagsHists(){}
+
+
 class ExampleModuleJetTags: public AnalysisModule {
 public:
 
@@ -70,7 +114,43 @@ private:
         "pileup_medium",
         "pileup_tight"
     };
-    unique_ptr<ExampleJetTagsHists> hists;
+    unique_ptr<ExampleJetTagsHists> jetHists;
+    vector<string> topjetTags = {
+      "mass",
+      "fRec",
+      "Ropt",
+      "RoptCalc",
+      "ptForRoptCalc",
+      "massRatioPassed",
+      "z_ratio",
+      "trackSipdSig_3",
+      "trackSipdSig_2",
+      "trackSipdSig_1",
+      "trackSipdSig_0",
+      "trackSipdSig_1_0",
+      "trackSipdSig_0_0",
+      "trackSipdSig_1_1",
+      "trackSipdSig_0_1",
+      "trackSip2dSigAboveCharm_0",
+      "trackSip2dSigAboveBottom_0",
+      "trackSip2dSigAboveBottom_1",
+      "tau1_trackEtaRel_0",
+      "tau1_trackEtaRel_1",
+      "tau1_trackEtaRel_2",
+      "tau0_trackEtaRel_0",
+      "tau0_trackEtaRel_1",
+      "tau0_trackEtaRel_2",
+      "tau_vertexMass_0",
+      "tau_vertexEnergyRatio_0",
+      "tau_vertexDeltaR_0",
+      "tau_flightDistance2dSig_0",
+      "tau_vertexMass_1",
+      "tau_vertexEnergyRatio_1",
+      "tau_flightDistance2dSig_1",
+      "jetNTracks",
+      "nSV"
+    };
+    unique_ptr<ExampleTopJetTagsHists> topjetHists;
     int counter;
 };
 
@@ -79,18 +159,26 @@ ExampleModuleJetTags::ExampleModuleJetTags(Context & ctx):
 counter(0)
 {
     cout << "Hello World from ExampleModuleJetTags!" << endl;
-    hists.reset(new ExampleJetTagsHists(ctx, "jetID", jetIDs));
+    jetHists.reset(new ExampleJetTagsHists(ctx, "jetID", jetIDs));
+    topjetHists.reset(new ExampleTopJetTagsHists(ctx, "topjetTags", topjetTags));
 }
 
 
 bool ExampleModuleJetTags::process(Event & event) {
     if (counter < 10) { // only printout for first few events
+        cout << " ** EVENT " << event.event << endl;
         for (const auto & jetItr : *event.jets) {
             // We can use the enum directly, this is the easiest way
             cout << "pileup_loose: " << jetItr.get_tag(Jet::pileup_loose) << endl;
         }
+        for (const auto & jetItr : *event.topjets) {
+            if (jetItr.has_tag(TopJet::tau0_trackEtaRel_0)) {
+                cout << "tau0_trackEtaRel_0: " << jetItr.get_tag(TopJet::tau0_trackEtaRel_0) << endl;
+            }
+        }
     }
-    hists->fill(event);
+    jetHists->fill(event);
+    topjetHists->fill(event);
 
     counter++;
     return true;


### PR DESCRIPTION
Previously used the CHS-derived values for the Puppi jet collections, now we add in a separate one for Puppi.

Also update example Jet Tag module to plot TopJet tags to check them.

Also change the MVA Higgs discriminator value to something outside its possible range of values [-1, 1].