### PR TITLE
[102X] Tidy up extra genparticle storage options

### DIFF
--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -256,7 +256,6 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
   doGenMET = iConfig.getParameter<bool>("doGenMET");
   doGenInfo = iConfig.getParameter<bool>("doGenInfo");
   doAllGenParticles = iConfig.getParameter<bool>("doAllGenParticles");
-  doAllGenParticlesPythia8  = iConfig.getParameter<bool>("doAllGenParticlesPythia8");
   
   doAllPFParticles = iConfig.getParameter<bool>("doAllPFParticles");
 
@@ -935,14 +934,7 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
        iEvent.getByToken(stablegenparticle_token,packed);
 
        for(size_t j=0; j<packed->size();j++){
-         bool skip_particle = false;
          const pat::PackedGenParticle* iter = dynamic_cast<const pat::PackedGenParticle*>(&(packed->at(j)));
-         if(doAllGenParticlesPythia8){//for pythia8: store particles with status code, see http://home.thep.lu.se/~torbjorn/pythia81html/ParticleProperties.html
-           if(iter->status()<2)
-             skip_particle = true;
-         }
-	 //for Herwig++ pruning is already done in the ntuplewriter python script
-         if(skip_particle) continue;
 
          index++;
 
@@ -961,11 +953,7 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
          genp.set_daughter1(-1);
          genp.set_daughter2(-1);
 
-         bool islepton = abs(iter->pdgId())>=11 && abs(iter->pdgId())<=16 ;
-
-         if(!islepton) {
-             event->genparticles->push_back(genp);
-         }
+         event->genparticles->push_back(genp);
        }
      }
 

--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -255,7 +255,7 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
   doMET = iConfig.getParameter<bool>("doMET");
   doGenMET = iConfig.getParameter<bool>("doGenMET");
   doGenInfo = iConfig.getParameter<bool>("doGenInfo");
-  doAllGenParticles = iConfig.getParameter<bool>("doAllGenParticles");
+  doStableGenParticles = iConfig.getParameter<bool>("doStableGenParticles");
   
   doAllPFParticles = iConfig.getParameter<bool>("doAllPFParticles");
 
@@ -617,7 +617,7 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
   }
   if(doGenInfo){
     genparticle_token = consumes<reco::GenParticleCollection>(iConfig.getParameter<edm::InputTag>("genparticle_source"));
-    if(doAllGenParticles) stablegenparticle_token = consumes<edm::View<reco::Candidate> >(iConfig.getParameter<edm::InputTag>("stablegenparticle_source"));
+    if(doStableGenParticles) stablegenparticle_token = consumes<edm::View<reco::Candidate> >(iConfig.getParameter<edm::InputTag>("stablegenparticle_source"));
     event->genInfo = new GenInfo();
     event->genparticles = new vector<GenParticle>();
     branch(tr, "genInfo","GenInfo", event->genInfo);
@@ -891,7 +891,7 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
      edm::Handle<reco::GenParticleCollection> genPartColl;
      // use genPartColl for the Matrix-Element particles. Also use it for stable leptons
-     // in case doAllGenParticles is false.
+     // in case doStableGenParticles is false.
      iEvent.getByToken(genparticle_token, genPartColl);
      int index=-1;
      for(reco::GenParticleCollection::const_iterator iter = genPartColl->begin(); iter != genPartColl->end(); ++ iter){
@@ -928,7 +928,7 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
      }
 
      //store stable gen particles from packed collection
-     if(doAllGenParticles){
+     if(doStableGenParticles){
        edm::Handle<edm::View<reco::Candidate> > packed;
        // use packed particle collection for all STABLE (status 1) particles
        iEvent.getByToken(stablegenparticle_token,packed);

--- a/core/plugins/NtupleWriter.h
+++ b/core/plugins/NtupleWriter.h
@@ -64,7 +64,6 @@ class NtupleWriter : public edm::EDFilter {
       bool doPhotons;
       bool doGenInfo;
       bool doAllGenParticles;
-      bool doAllGenParticlesPythia8;
       unsigned doGenJetConstituentsNjets;
       double doGenJetConstituentsMinJetPt;
       bool doGenJetConstituents;

--- a/core/plugins/NtupleWriter.h
+++ b/core/plugins/NtupleWriter.h
@@ -63,7 +63,7 @@ class NtupleWriter : public edm::EDFilter {
       bool doGenMET;
       bool doPhotons;
       bool doGenInfo;
-      bool doAllGenParticles;
+      bool doStableGenParticles;
       unsigned doGenJetConstituentsNjets;
       double doGenJetConstituentsMinJetPt;
       bool doGenJetConstituents;

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -2317,16 +2317,25 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                     prefire_source=cms.string(prefire_source),
 
                                     # *** gen stuff:
-                                    doGenInfo=cms.bool(not useData),
+                                    doGenInfo=cms.bool(not useData),  # Master switch for geninfo, genparticles, etc
+
+                                    # Source to store (pruned) GenParticles from the genparticle history
+                                    # By default we try to store the Matrix Element genparticles only
+                                    # Note that this doesn't work for Herwig generators due to their
+                                    # weird status codes
                                     genparticle_source=cms.InputTag("prunedPrunedGenParticles"),
-                                    stablegenparticle_source=cms.InputTag("packedGenParticlesForJetsNoNu"),
-                                    # set to true if you want to store all gen particles, otherwise, only
-                                    # prunedPrunedGenParticles are stored (see above)
+
+                                    # Flag & source to store stable (i.e. packed) GenParticles
+                                    # Useful if you want to store final-state genparticles in the event
+                                    # If you only want GenJet constituents,
+                                    # you should use the appropriate options further down
                                     doAllGenParticles=cms.bool(False),
-                                    doAllGenParticlesPythia8=cms.bool(False),
+                                    stablegenparticle_source=cms.InputTag("packedGenParticlesForJetsNoNu"),
+
                                     #store PF constituents: doPFJetConstituentsNjets and doPFJetConstituentsMinJetPt are combined with OR
                                     doPFJetConstituentsNjets=cms.uint32(0),#store constituents for N leading jets, where N is parameter
                                     doPFJetConstituentsMinJetPt=cms.double(-1),#store constituence for all jets with pt above threshold, set to negative value if not used
+
                                     doGenJets=cms.bool(not useData),
                                     #store GEN constituents: doGenJetConstituentsNjets and doGenJetConstituentsMinJetPt are combined with OR
                                     doGenJetConstituentsNjets=cms.uint32(0),#store constituents for N leading genjets, where N is parameter

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -2329,7 +2329,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                     # Useful if you want to store final-state genparticles in the event
                                     # If you only want GenJet constituents,
                                     # you should use the appropriate options further down
-                                    doAllGenParticles=cms.bool(False),
+                                    doStableGenParticles=cms.bool(False),
                                     stablegenparticle_source=cms.InputTag("packedGenParticlesForJetsNoNu"),
 
                                     #store PF constituents: doPFJetConstituentsNjets and doPFJetConstituentsMinJetPt are combined with OR


### PR DESCRIPTION
- Rename `doAllGenParticles` to `doStableGenParticles` as better description, add some comments
- Remove `doAllGenParticlesPythia8` flag
- Remove extra filtering logic when storing all the PackedGenParticles

Since we now have the explicit genjet constituent options, this bit is now only useful if the user wants to store some curated list of final-state particle (i.e. packedGenParticles). All filtering logic should be kept explicitly in the python config. The `genparticles_source` covers prunedGenParticle collections (if the user wishes to store e.g. entire parton shower history).