### PR TITLE
[102X] Fix jet L1 correction factor stored in ntuplewriter

### DIFF
--- a/core/include/Jet.h
+++ b/core/include/Jet.h
@@ -97,8 +97,8 @@ class Jet : public FlavorParticle {
   float btag_DeepFlavour() const{return m_btag_DeepFlavour_probbb+m_btag_DeepFlavour_probb+m_btag_DeepFlavour_problepb;}
  
 
-  float JEC_factor_raw() const{return m_JEC_factor_raw;}
-  float JEC_L1factor_raw() const{return m_JEC_L1factor_raw;}
+  float JEC_factor_raw() const{return m_JEC_factor_raw;} // This takes you from corrected -> uncorrected
+  float JEC_L1factor_raw() const{return m_JEC_L1factor_raw;} // This takes you from uncorrected -> L1 corrected
   float genjet_index() const{return m_genjet_index;}
   float get_tag(tag t) const { return tags.get_tag(static_cast<int>(t)); }
   float has_tag(tag t) const { return tags.has_tag(static_cast<int>(t)); }

--- a/core/plugins/NtupleWriterJets.cxx
+++ b/core/plugins/NtupleWriterJets.cxx
@@ -244,9 +244,12 @@ void NtupleWriterJets::fill_jet_info(uhh2::Event & uevent, const pat::Jet & pat_
     //L1 factor needed for JEC propagation to MET
     const std::vector< std::string > factors_jet = pat_jet.availableJECLevels();
     bool isL1 = false;
-    for(unsigned int i=0;i<factors_jet.size();i++)
-      if(factors_jet[i]=="L1FastJet")
+    for(unsigned int i=0;i<factors_jet.size();i++) {
+      if(factors_jet[i]=="L1FastJet") {
         isL1 = true;
+        break;
+      }
+    }
     if(isL1) jet.set_JEC_L1factor_raw(pat_jet.jecFactor("L1FastJet"));
     else jet.set_JEC_L1factor_raw(1.);//PUPPI jets don't have L1 factor
 

--- a/core/plugins/NtupleWriterJets.cxx
+++ b/core/plugins/NtupleWriterJets.cxx
@@ -250,7 +250,7 @@ void NtupleWriterJets::fill_jet_info(uhh2::Event & uevent, const pat::Jet & pat_
         break;
       }
     }
-    if(isL1) jet.set_JEC_L1factor_raw(pat_jet.jecFactor("L1FastJet"));
+    if(isL1) jet.set_JEC_L1factor_raw(pat_jet.correctedJet("L1FastJet").pt() / pat_jet.correctedJet("Uncorrected").pt());
     else jet.set_JEC_L1factor_raw(1.);//PUPPI jets don't have L1 factor
 
   } else {


### PR DESCRIPTION
`Jet::JEC_L1factor_raw()` is designed to go from uncorrected -> L1 corrected (at least, that's what it's used for in `correct_MET()`, and how it's set in `correct_jet()`). We store it incorrectly when making ntuples.

This value is overwritten once the user applies their own JECs, so no analyses should be affected. It just makes it all consistent from the start.