### PR TITLE
[102X] electronID fixes

### DIFF
--- a/common/include/ElectronIds.h
+++ b/common/include/ElectronIds.h
@@ -54,45 +54,17 @@ class Electron_MINIIso {
 bool Electron_CutBasedID(const Electron&, const uhh2::Event&, const std::string&, const std::string&, const bool);
 bool Electron_CutBasedID(const Electron&, const uhh2::Event&, const std::string&, const std::string&, const int, const bool);
 
-// --- Cut-Based ID: PHYS14 25ns
-bool ElectronID_PHYS14_25ns_veto        (const Electron&, const uhh2::Event&);
-bool ElectronID_PHYS14_25ns_veto_noIso  (const Electron&, const uhh2::Event&);
-bool ElectronID_PHYS14_25ns_loose       (const Electron&, const uhh2::Event&);
-bool ElectronID_PHYS14_25ns_loose_noIso (const Electron&, const uhh2::Event&);
-bool ElectronID_PHYS14_25ns_medium      (const Electron&, const uhh2::Event&);
-bool ElectronID_PHYS14_25ns_medium_noIso(const Electron&, const uhh2::Event&);
-bool ElectronID_PHYS14_25ns_tight       (const Electron&, const uhh2::Event&);
-bool ElectronID_PHYS14_25ns_tight_noIso (const Electron&, const uhh2::Event&);
 
-// --- Cut-Based ID: Spring15 50ns
-bool ElectronID_Spring15_50ns_veto        (const Electron&, const uhh2::Event&);
-bool ElectronID_Spring15_50ns_veto_noIso  (const Electron&, const uhh2::Event&);
-bool ElectronID_Spring15_50ns_loose       (const Electron&, const uhh2::Event&);
-bool ElectronID_Spring15_50ns_loose_noIso (const Electron&, const uhh2::Event&);
-bool ElectronID_Spring15_50ns_medium      (const Electron&, const uhh2::Event&);
-bool ElectronID_Spring15_50ns_medium_noIso(const Electron&, const uhh2::Event&);
-bool ElectronID_Spring15_50ns_tight       (const Electron&, const uhh2::Event&);
-bool ElectronID_Spring15_50ns_tight_noIso (const Electron&, const uhh2::Event&);
 
-// --- Cut-Based ID: Spring15 25ns
-bool ElectronID_Spring15_25ns_veto        (const Electron&, const uhh2::Event&);
-bool ElectronID_Spring15_25ns_veto_noIso  (const Electron&, const uhh2::Event&);
-bool ElectronID_Spring15_25ns_loose       (const Electron&, const uhh2::Event&);
-bool ElectronID_Spring15_25ns_loose_noIso (const Electron&, const uhh2::Event&);
-bool ElectronID_Spring15_25ns_medium      (const Electron&, const uhh2::Event&);
-bool ElectronID_Spring15_25ns_medium_noIso(const Electron&, const uhh2::Event&);
-bool ElectronID_Spring15_25ns_tight       (const Electron&, const uhh2::Event&);
-bool ElectronID_Spring15_25ns_tight_noIso (const Electron&, const uhh2::Event&);
-
-// --- Cut-Based ID: Spring16
-bool ElectronID_Spring16_veto        (const Electron&, const uhh2::Event&);
-bool ElectronID_Spring16_veto_noIso  (const Electron&, const uhh2::Event&);
-bool ElectronID_Spring16_loose       (const Electron&, const uhh2::Event&);
-bool ElectronID_Spring16_loose_noIso (const Electron&, const uhh2::Event&);
-bool ElectronID_Spring16_medium      (const Electron&, const uhh2::Event&);
-bool ElectronID_Spring16_medium_noIso(const Electron&, const uhh2::Event&);
-bool ElectronID_Spring16_tight       (const Electron&, const uhh2::Event&);
-bool ElectronID_Spring16_tight_noIso (const Electron&, const uhh2::Event&);
+// --- Cut-Based ID: Summer16
+bool ElectronID_Summer16_veto        (const Electron&, const uhh2::Event&);
+bool ElectronID_Summer16_veto_noIso  (const Electron&, const uhh2::Event&);
+bool ElectronID_Summer16_loose       (const Electron&, const uhh2::Event&);
+bool ElectronID_Summer16_loose_noIso (const Electron&, const uhh2::Event&);
+bool ElectronID_Summer16_medium      (const Electron&, const uhh2::Event&);
+bool ElectronID_Summer16_medium_noIso(const Electron&, const uhh2::Event&);
+bool ElectronID_Summer16_tight       (const Electron&, const uhh2::Event&);
+bool ElectronID_Summer16_tight_noIso (const Electron&, const uhh2::Event&);
 
 // --- Cut-Based ID: Fall17
 bool ElectronID_Fall17_veto        (const Electron&, const uhh2::Event&);
@@ -110,128 +82,20 @@ namespace ElectronID {
 
   const std::unordered_map<std::string, std::unordered_map<std::string, std::unordered_map<std::string, std::vector<float> > > > CutBased_LUT = {
 
-  /** PHYS14_25ns **/
-    {"PHYS14_25ns", {
-
-      {"barrel", {
-                          /* Veto     , Loose    , Medium   , Tight    */
-        {"sigmaIetaIeta" , { 0.011586 , 0.010331 , 0.009996 , 0.009947 }},
-        {"|dEtaIn|"      , { 0.013625 , 0.009277 , 0.008925 , 0.006046 }},
-        {"|dPhiIn|"      , { 0.230374 , 0.094739 , 0.035973 , 0.028092 }},
-        {"HoverE"        , { 0.181130 , 0.093068 , 0.050537 , 0.045772 }},
-        {"relIsoEA"      , { 0.158721 , 0.130136 , 0.107587 , 0.069537 }},
-        {"|ooEmooP|"     , { 0.295751 , 0.189968 , 0.091942 , 0.020118 }},
-        {"|d0|"          , { 0.094095 , 0.035904 , 0.012235 , 0.008790 }},
-        {"|dz|"          , { 0.713070 , 0.075496 , 0.042020 , 0.021226 }},
-        {"missingHits"   , { 2        , 1        , 1        , 1        }},
-        {"passConvVeto"  , { 1        , 1        , 1        , 1        }},
-       },
-      },
-
-      {"endcap", {
-                          /* Veto     , Loose    , Medium   , Tight    */
-        {"sigmaIetaIeta" , { 0.031849 , 0.031838 , 0.030135 , 0.028237 }},
-        {"|dEtaIn|"      , { 0.011932 , 0.009833 , 0.007429 , 0.007057 }},
-        {"|dPhiIn|"      , { 0.255450 , 0.149934 , 0.067879 , 0.030159 }},
-        {"HoverE"        , { 0.223870 , 0.115754 , 0.086782 , 0.067778 }},
-        {"relIsoEA"      , { 0.177032 , 0.163368 , 0.113254 , 0.078265 }},
-        {"|ooEmooP|"     , { 0.155501 , 0.140662 , 0.100683 , 0.098919 }},
-        {"|d0|"          , { 0.342293 , 0.099266 , 0.036719 , 0.027984 }},
-        {"|dz|"          , { 0.953461 , 0.197897 , 0.138142 , 0.133431 }},
-        {"missingHits"   , { 3        , 1        , 1        , 1        }},
-        {"passConvVeto"  , { 1        , 1        , 1        , 1        }},
-       },
-
-      },
-     },
-    },
-  /*****************/
-
-  /** Spring15_50ns **/
-    {"Spring15_50ns", {
-
-      {"barrel", {
-                          /* Veto   , Loose   , Medium  , Tight   */
-        {"sigmaIetaIeta" , { 0.012  , 0.0105  , 0.0101  , 0.0101  }},
-        {"|dEtaIn|"      , { 0.0126 , 0.00976 , 0.0094  , 0.00864 }},
-        {"|dPhiIn|"      , { 0.107  , 0.0929  , 0.0296  , 0.0286  }},
-        {"HoverE"        , { 0.186  , 0.0765  , 0.0372  , 0.0342  }},
-        {"relIsoEA"      , { 0.161  , 0.118   , 0.0987  , 0.0591  }},
-        {"|ooEmooP|"     , { 0.239  , 0.184   , 0.118   , 0.0116  }},
-        {"|d0|"          , { 0.0621 , 0.0227  , 0.0151  , 0.0103  }},
-        {"|dz|"          , { 0.613  , 0.379   , 0.238   , 0.170   }},
-        {"missingHits"   , { 2      , 2       , 2       , 2       }},
-        {"passConvVeto"  , { 1      , 1       , 1       , 1       }},
-       },
-      },
-
-      {"endcap", {
-                          /* Veto   , Loose   , Medium  , Tight   */
-        {"sigmaIetaIeta" , { 0.0339 , 0.0318  , 0.0287  , 0.0287  }},
-        {"|dEtaIn|"      , { 0.0109 , 0.00952 , 0.00773 , 0.00762 }},
-        {"|dPhiIn|"      , { 0.219  , 0.181   , 0.148   , 0.0439  }},
-        {"HoverE"        , { 0.0962 , 0.0824  , 0.0546  , 0.0544  }},
-        {"relIsoEA"      , { 0.193  , 0.118   , 0.0902  , 0.0759  }},
-        {"|ooEmooP|"     , { 0.141  , 0.125   , 0.104   , 0.01    }},
-        {"|d0|"          , { 0.279  , 0.242   , 0.0535  , 0.0377  }},
-        {"|dz|"          , { 0.947  , 0.921   , 0.572   , 0.571   }},
-        {"missingHits"   , { 3      , 1       , 1       , 1       }},
-        {"passConvVeto"  , { 1      , 1       , 1       , 1       }},
-       },
-
-      },
-     },
-    },
-  /*******************/
-
-  /** Spring15_25ns **/
-    {"Spring15_25ns", {
-
-      {"barrel", {
-                          /* Veto   , Loose   , Medium  , Tight   */
-        {"sigmaIetaIeta" , { 0.0114 , 0.0103  , 0.0101  , 0.0101  }},
-        {"|dEtaIn|"      , { 0.0152 , 0.0105  , 0.0103  , 0.00926 }},
-        {"|dPhiIn|"      , { 0.216  , 0.115   , 0.0336  , 0.0336  }},
-        {"HoverE"        , { 0.181  , 0.104   , 0.0876  , 0.0597  }},
-        {"relIsoEA"      , { 0.126  , 0.0893  , 0.0766  , 0.0354  }},
-        {"|ooEmooP|"     , { 0.207  , 0.102   , 0.0174  , 0.012   }},
-        {"|d0|"          , { 0.0564 , 0.0261  , 0.0118  , 0.0111  }},
-        {"|dz|"          , { 0.472  , 0.41    , 0.373   , 0.0466  }},
-        {"missingHits"   , { 2      , 2       , 2       , 2       }},
-        {"passConvVeto"  , { 1      , 1       , 1       , 1       }},
-       },
-      },
-
-      {"endcap", {
-                          /* Veto   , Loose   , Medium  , Tight   */
-        {"sigmaIetaIeta" , { 0.0352 , 0.0301  , 0.0283  , 0.0279  }},
-        {"|dEtaIn|"      , { 0.0113 , 0.00814 , 0.00733 , 0.00724 }},
-        {"|dPhiIn|"      , { 0.237  , 0.182   , 0.114   , 0.0918  }},
-        {"HoverE"        , { 0.116  , 0.0897  , 0.0678  , 0.0615  }},
-        {"relIsoEA"      , { 0.144  , 0.121   , 0.0678  , 0.0646  }},
-        {"|ooEmooP|"     , { 0.174  , 0.126   , 0.0898  , 0.00999 }},
-        {"|d0|"          , { 0.222  , 0.118   , 0.0739  , 0.0351  }},
-        {"|dz|"          , { 0.921  , 0.822   , 0.602   , 0.417   }},
-        {"missingHits"   , { 3      , 1       , 1       , 1       }},
-        {"passConvVeto"  , { 1      , 1       , 1       , 1       }},
-       },
-
-      },
-     },
-    },
-  /*******************/
-
-
-    /** Spring16 **/
-    {"Spring16", {
+  
+    /** Summer16 **/
+    {"Summer16", {
  
 	{"barrel", {
                           /* Veto   , Loose   , Medium  , Tight   */
 	{"sigmaIetaIeta" , { 0.0115, 0.011, 	0.00998,   0.00998  }},
         {"|dEtaIn|"      , { 0.00749, 0.00477, 	0.00311,  0.00308 }},
         {"|dPhiIn|"      , { 0.228, 	0.222, 	0.103, 	0.0816  }},
-        {"HoverE"        , { 0.356, 	0.298, 	0.253, 	0.0414  }},
-        {"relIsoEA"      , { 0.175, 	0.0994, 0.0695, 0.0588  }},
+        {"HoverE_C0"     , { 0.356, 	0.298, 	0.253, 	0.0414  }},
+        {"HoverE_C1"     , { 0.0, 	0.0,    0.0,    0.0     }},
+        {"HoverE_C2"     , { 0.0, 	0.0,    0.0,    0.0     }},
+        {"relIsoEA_C0"   , { 0.175, 	0.0994, 0.0695, 0.0588  }},
+        {"relIsoEA_C1"   , { 0.0, 	0.0,    0.0,    0.0     }},
         {"|ooEmooP|"     , { 0.299, 	0.241, 	0.134, 	0.0129  }},
         {"|d0|"          , { float(uhh2::infinity), float(uhh2::infinity)  , float(uhh2::infinity)  , float(uhh2::infinity)  }},
         {"|dz|"          , { float(uhh2::infinity) , float(uhh2::infinity)    , float(uhh2::infinity)   , float(uhh2::infinity)  }},
@@ -245,8 +109,11 @@ namespace ElectronID {
 	{"sigmaIetaIeta" , { 0.037, 	0.0314,   0.0298,     0.0292 }},
         {"|dEtaIn|"      , { 0.00895, 	0.00868,  0.00609,    0.00605 }},
         {"|dPhiIn|"      , { 0.213, 	0.213, 	  0.045,      0.0394  }},
-        {"HoverE"        , { 0.211, 	0.101, 	  0.0878,     0.0641 }},
-        {"relIsoEA"      , { 0.159, 	0.107, 	  0.0821,     0.0571  }},
+        {"HoverE_C0"     , { 0.211, 	0.101, 	  0.0878,     0.0641 }},
+        {"HoverE_C1"     , { 0.0, 	0.0,    0.0,    0.0     }},
+        {"HoverE_C2"     , { 0.0, 	0.0,    0.0,    0.0     }},
+        {"relIsoEA_C0"   , { 0.159, 	0.107, 	  0.0821,     0.0571  }},
+        {"relIsoEA_C1"   , { 0.0, 	0.0,    0.0,    0.0     }},
         {"|ooEmooP|"     , { 0.15, 	0.14, 	  0.13,       0.0129}},
         {"|d0|"          , { float(uhh2::infinity)  , float(uhh2::infinity)   , float(uhh2::infinity)  , float(uhh2::infinity)  }},
         {"|dz|"          , { float(uhh2::infinity)  , float(uhh2::infinity)   , float(uhh2::infinity)   , float(uhh2::infinity)   }},
@@ -260,17 +127,20 @@ namespace ElectronID {
   /*******************/
 
 
-    /** Fall17 according to https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedElectronIdentificationRun2#Offline_selection_criteria **/
+    /** Fall17 according to https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedElectronIdentificationRun2#Working_points_for_94X_and_later **/
     {"Fall17", {
  
 	{"barrel", {
                           /* Veto   , Loose   , Medium  , Tight   */
-	{"sigmaIetaIeta" , { 0.0128 , 0.0105  , 0.0105  , 0.0104  }},
-        {"|dEtaIn|"      , { 0.00523, 0.00387 , 0.00365 , 0.00353 }},
-        {"|dPhiIn|"      , { 0.159  , 0.0716  , 0.0588  , 0.0499  }},
-        {"C0"            , { 0.05   , 0.05    , 0.026   , 0.026   }},
-        {"relIsoEA"      , { 0.168  , 0.133   , 0.0718  , 0.0361  }},
-        {"|ooEmooP|"     , { 0.193  , 0.129   , 0.0327  , 0.0278  }},
+	{"sigmaIetaIeta" , { 0.0126 , 0.0112  , 0.0106  , 0.0104  }},
+        {"|dEtaIn|"      , { 0.00463, 0.00377 , 0.0032 , 0.00255 }},
+        {"|dPhiIn|"      , { 0.148  , 0.0884  , 0.0547  , 0.022  }},
+        {"HoverE_C0"     , { 0.05   , 0.05    , 0.046   , 0.026   }},
+        {"HoverE_C1"     , { 1.16    , 1.16 , 1.16   , 1.15   }},
+        {"HoverE_C2"     , { 0.0324  , 0.0324 , 0.0324   , 0.0324   }},
+        {"relIsoEA_C0"   , { 0.198  , 0.112   , 0.0478  , 0.0287  }},
+        {"relIsoEA_C1"   , { 0.506  , 0.506   , 0.506  , 0.506  }},
+        {"|ooEmooP|"     , { 0.209  , 0.193   , 0.184  , 0.159  }},
         {"|d0|"          , { float(uhh2::infinity), float(uhh2::infinity)  , float(uhh2::infinity)  , float(uhh2::infinity)     }},
         {"|dz|"          , { float(uhh2::infinity) , float(uhh2::infinity)    , float(uhh2::infinity)   , float(uhh2::infinity) }},
         {"missingHits"   , { 2      , 1       , 1       , 1       }},
@@ -280,12 +150,15 @@ namespace ElectronID {
       
 	{"endcap", {
                           /* Veto   , Loose   , Medium  , Tight   */
-	{"sigmaIetaIeta" , { 0.0445  , 0.0356 , 0.0309  , 0.0305  }},
-	{"|dEtaIn|"      , { 0.00984 , 0.0072 , 0.00625 , 0.00567 }},
-	{"|dPhiIn|"      , { 0.157   , 0.147  , 0.0355  , 0.0165  }},
-        {"C0"            , { 0.05    , 0.0414 , 0.026   , 0.026   }},
-	{"relIsoEA"      , { 0.185   , 0.146  , 0.143   , 0.094   }},
-	{"|ooEmooP|"     , { 0.0962  , 0.0875 , 0.0335  , 0.0158  }},
+	{"sigmaIetaIeta" , { 0.0457  , 0.0425 , 0.0387  , 0.0353  }},
+	{"|dEtaIn|"      , { 0.00814 , 0.00674 , 0.00632 , 0.00501 }},
+	{"|dPhiIn|"      , { 0.19   , 0.169  , 0.0394  , 0.0236  }},
+        {"HoverE_C0"     , { 0.05    , 0.0441 , 0.0275   , 0.0188   }},
+        {"HoverE_C1"     , { 2.54    , 2.54 , 2.52   , 2.06   }},
+        {"HoverE_C2"     , { 0.183  , 0.183 , 0.183   , 0.183   }},
+	{"relIsoEA_C0"   , { 0.203   , 0.108  , 0.0658   , 0.0445   }},
+        {"relIsoEA_C1"   , { 0.963  , 0.963   , 0.963  , 0.963  }},
+	{"|ooEmooP|"     , { 0.132  , 0.111 , 0.0721  , 0.0197  }},
         {"|d0|"          , { float(uhh2::infinity)  , float(uhh2::infinity)   , float(uhh2::infinity)  , float(uhh2::infinity)  }},
         {"|dz|"          , { float(uhh2::infinity)  , float(uhh2::infinity)   , float(uhh2::infinity)   , float(uhh2::infinity) }},
         {"missingHits"   , { 3       , 1      , 1       , 1       }},

--- a/common/src/JetIds.cxx
+++ b/common/src/JetIds.cxx
@@ -54,24 +54,7 @@ bool DeepCSVBTag::operator()(const Jet & jet, const Event &) const{
 JetPFID::JetPFID(wp working_point):m_working_point(working_point){}
 
 bool JetPFID::operator()(const Jet & jet, const Event & ev) const{
-  if(ev.year == "2016v2"){
-    switch(m_working_point){
-    case WP_LOOSE_CHS:
-      return looseID2016_CHS(jet);
-    case WP_TIGHT_CHS:
-      return tightID2016_CHS(jet);
-    case WP_LOOSE_PUPPI:
-      return looseID2016_PUPPI(jet);
-    case WP_TIGHT_PUPPI:
-      return tightID2016_PUPPI(jet);
-    case  WP_TIGHT_LEPVETO:
-      return tightLepVetoID2016(jet);
-    default:
-      throw invalid_argument("invalid working point passed to CSVBTag");
-    }
-    return false;
-  }
-  if(ev.year == "2016v3"){
+  if(ev.year == "2016v2" || ev.year == "2016v3"){
     switch(m_working_point){
     case WP_LOOSE_CHS:
       return looseID2016_CHS(jet);

--- a/common/test/test_JLCkey.cpp
+++ b/common/test/test_JLCkey.cpp
@@ -46,7 +46,7 @@ test_JLCkey::test_JLCkey(uhh2::Context& ctx){
 
   //// OBJ CLEANING
   const     MuonId muo(AndId<Muon>    (PtEtaCut  (50., 2.1), MuonID(Muon::CutBasedIdMedium)));
-  const ElectronId ele(AndId<Electron>(PtEtaSCCut(50., 2.5), ElectronID_Spring15_25ns_tight_noIso));
+  const ElectronId ele(AndId<Electron>(PtEtaSCCut(50., 2.5), ElectronID_Summer16_tight_noIso));
 
   muo_cleaner.reset(new     MuonCleaner(muo));
   ele_cleaner.reset(new ElectronCleaner(ele));

--- a/core/include/Electron.h
+++ b/core/include/Electron.h
@@ -21,6 +21,8 @@ class Electron : public RecParticle {
     cutBasedElectronID_Summer16_80X_V1_medium,
     cutBasedElectronID_Summer16_80X_V1_tight,
     cutBasedElectronHLTPreselection_Summer16_V1,
+    mvaEleID_Spring16_GeneralPurpose_V1_wp90,
+    mvaEleID_Spring16_GeneralPurpose_V1_wp80,
     // 2017 & 2018
     cutBasedElectronID_Fall17_94X_V2_veto,
     cutBasedElectronID_Fall17_94X_V2_loose,
@@ -42,6 +44,9 @@ class Electron : public RecParticle {
     if(tagname == "cutBasedElectronID_Summer16_80X_V1_medium") return cutBasedElectronID_Summer16_80X_V1_medium;
     if(tagname == "cutBasedElectronID_Summer16_80X_V1_tight") return cutBasedElectronID_Summer16_80X_V1_tight;
     if(tagname == "cutBasedElectronHLTPreselection_Summer16_V1") return cutBasedElectronHLTPreselection_Summer16_V1;
+    if(tagname == "mvaEleID_Spring16_GeneralPurpose_V1_wp90") return mvaEleID_Spring16_GeneralPurpose_V1_wp90;
+    if(tagname == "mvaEleID_Spring16_GeneralPurpose_V1_wp80") return mvaEleID_Spring16_GeneralPurpose_V1_wp80;
+
     if(tagname == "cutBasedElectronID_Fall17_94X_V2_veto") return cutBasedElectronID_Fall17_94X_V2_veto;
     if(tagname == "cutBasedElectronID_Fall17_94X_V2_loose") return cutBasedElectronID_Fall17_94X_V2_loose;
     if(tagname == "cutBasedElectronID_Fall17_94X_V2_medium") return cutBasedElectronID_Fall17_94X_V2_medium;

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -1776,6 +1776,10 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                                           'egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-tight'),
                                                       cutBasedElectronHLTPreselection_Summer16_V1=cms.InputTag(
                                                           'egmGsfElectronIDs:cutBasedElectronHLTPreselection-Summer16-V1'),
+                                                      mvaEleID_Spring16_GeneralPurpose_V1_wp80=cms.InputTag(
+                                                          'egmGsfElectronIDs:mvaEleID-Spring16-GeneralPurpose-V1-wp80'),
+                                                      mvaEleID_Spring16_GeneralPurpose_V1_wp90=cms.InputTag(
+                                                          'egmGsfElectronIDs:mvaEleID-Spring16-GeneralPurpose-V1-wp90'),
                                                       # 2017 & 2018
                                                       cutBasedElectronID_Fall17_94X_V2_veto=cms.InputTag(
                                                           'egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V2-veto'),
@@ -2021,6 +2025,8 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                         'cutBasedElectronID_Summer16_80X_V1_medium',
                                         'cutBasedElectronID_Summer16_80X_V1_tight',
                                         'cutBasedElectronHLTPreselection_Summer16_V1',
+                                        'mvaEleID_Spring16_GeneralPurpose_V1_wp90',
+                                        'mvaEleID_Spring16_GeneralPurpose_V1_wp80',
                                         # 2017 & 2018
                                         'cutBasedElectronID_Fall17_94X_V2_veto',
                                         'cutBasedElectronID_Fall17_94X_V2_loose',

--- a/examples/src/ExampleModule2.cxx
+++ b/examples/src/ExampleModule2.cxx
@@ -50,7 +50,7 @@ ExampleModule2::ExampleModule2(Context & ctx): ele_selection(ctx, "ele"), mu_sel
     jet_kinematic = PtEtaCut(30.0, 2.4);
     btag = CSVBTag(CSVBTag::WP_LOOSE);
     muid = AndId<Muon>(MuonID(Muon::CutBasedIdTight), PtEtaCut(20.0, 2.4));
-    eleid = AndId<Electron>(ElectronID_PHYS14_25ns_medium, PtEtaCut(20.0, 2.5));
+    eleid = AndId<Electron>(ElectronID_Summer16_tight, PtEtaCut(20.0, 2.5));
     
     // clean the objects:
     modules.emplace_back(new JetCleaner(ctx, jet_kinematic));

--- a/examples/src/ExampleModuleEGammaID.cxx
+++ b/examples/src/ExampleModuleEGammaID.cxx
@@ -142,7 +142,9 @@ private:
         "mvaEleID_Fall17_noIso_V2_wpLoose",
         "mvaEleID_Fall17_iso_V2_wp90",
         "mvaEleID_Fall17_iso_V2_wp80",
-        "mvaEleID_Fall17_iso_V2_wpLoose"
+        "mvaEleID_Fall17_iso_V2_wpLoose",
+	"mvaEleID_Spring16_GeneralPurpose_V1_wp90",
+	"mvaEleID_Spring16_GeneralPurpose_V1_wp80"
     };
     unique_ptr<ExampleElectronIDHists> eleHists;
 


### PR DESCRIPTION
add MVA 2016 electronID tags; 
remove outdated electron IDs; 
update cut-based without iso, which might be useful for some analyses, e.g with boosted semileptonic top
