### PR TITLE
[102X] Fix bug when deciding to store jet PFcands; add test plots

### DIFF
--- a/core/plugins/NtupleWriterJets.cxx
+++ b/core/plugins/NtupleWriterJets.cxx
@@ -162,7 +162,7 @@ void NtupleWriterJets::process(const edm::Event & event, uhh2::Event & uevent,  
 
 
 	bool storePFcands = false;
-	if(i<NPFJetwConstituents_ || jet.pt()>MinPtJetwConstituents_) storePFcands = true;
+	if(i<NPFJetwConstituents_ || pat_jet.pt()>MinPtJetwConstituents_) storePFcands = true;
         try {
           fill_jet_info(uevent,pat_jet, jet, true, false, jet_puppiSpecificProducer,storePFcands);
         }
@@ -939,7 +939,7 @@ void NtupleWriterTopJets::process(const edm::Event & event, uhh2::Event & uevent
         topjets.emplace_back();
         TopJet & topjet = topjets.back();
 	bool storePFcands = false;
-	if(i<NPFJetwConstituents_ || topjet.pt()>MinPtJetwConstituents_) storePFcands = true;
+	if(i<NPFJetwConstituents_ || pat_topjet.pt()>MinPtJetwConstituents_) storePFcands = true;
         try{
           uhh2::NtupleWriterJets::fill_jet_info(uevent,pat_topjet, topjet, do_btagging, false, topjet_puppiSpecificProducer,storePFcands);
         }catch(runtime_error &){

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -2089,6 +2089,10 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                     jet_ptmin=cms.double(10.0),
                                     jet_etamax=cms.double(999.0),
 
+                                    #store PF constituents for jet_sources: doPFJetConstituentsNjets and doPFJetConstituentsMinJetPt are combined with OR
+                                    doPFJetConstituentsNjets=cms.uint32(0),#store constituents for N leading jets, where N is parameter
+                                    doPFJetConstituentsMinJetPt=cms.double(-1),#store constituence for all jets with pt above threshold, set to negative value if not used
+
                                     doMET=cms.bool(True),
                                     met_sources=met_sources_GL,
 
@@ -2101,7 +2105,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                     # be smaller than topjet_ptmin to account for JECs
                                     topjet_ptmin=cms.double(150.0),
                                     topjet_etamax=cms.double(5.0),
-                                    #store PF constituents: doPFJetConstituentsNjets and doPFJetConstituentsMinJetPt are combined with OR
+                                    #store PF constituents for TopJets: doPFJetConstituentsNjets and doPFJetConstituentsMinJetPt are combined with OR
                                     doPFTopJetConstituentsNjets=cms.uint32(0),#store constituents for N leading topjets, where N is parameter
                                     doPFTopJetConstituentsMinJetPt=cms.double(-1),#store constituence for all topjets with pt above threshold, set to negative value if not used
 
@@ -2347,12 +2351,8 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                     doStableGenParticles=cms.bool(False),
                                     stablegenparticle_source=cms.InputTag("packedGenParticlesForJetsNoNu"),
 
-                                    #store PF constituents: doPFJetConstituentsNjets and doPFJetConstituentsMinJetPt are combined with OR
-                                    doPFJetConstituentsNjets=cms.uint32(0),#store constituents for N leading jets, where N is parameter
-                                    doPFJetConstituentsMinJetPt=cms.double(-1),#store constituence for all jets with pt above threshold, set to negative value if not used
-
                                     doGenJets=cms.bool(not useData),
-                                    #store GEN constituents: doGenJetConstituentsNjets and doGenJetConstituentsMinJetPt are combined with OR
+                                    #store GEN constituents for genjet_sources: doGenJetConstituentsNjets and doGenJetConstituentsMinJetPt are combined with OR
                                     doGenJetConstituentsNjets=cms.uint32(0),#store constituents for N leading genjets, where N is parameter
                                     doGenJetConstituentsMinJetPt=cms.double(-1),#store constituence for all genjets with pt above threshold, set to negative value if not used
                                     genjet_sources=cms.vstring(
@@ -2362,10 +2362,9 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                     genjet_etamax=cms.double(5.0),
 
                                     doGenTopJets=cms.bool(not useData),
-                                    #store GEN constituents: doGenJetConstituentsNjets and doGenJetConstituentsMinJetPt are combined with OR
+                                    #store GEN constituents for topjet_sources: doGenJetConstituentsNjets and doGenJetConstituentsMinJetPt are combined with OR
                                     doGenTopJetConstituentsNjets=cms.uint32(0),#store constituents for N leading genjets, where N is parameter
                                     doGenTopJetConstituentsMinJetPt=cms.double(-1),#store constituence for all genjets with pt above threshold, set to negative value if not used
-
 
                                     gentopjet_sources=cms.VInputTag(
                                         cms.InputTag("ak8GenJetsFat"),
@@ -2393,7 +2392,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
 
                                     # *** HOTVR & XCone stuff
                                     doXCone=cms.bool(True),
-                                    #store PF constituents: doPFJetConstituentsNjets and doPFJetConstituentsMinJetPt are combined with OR
+                                    #store PF constituents for XCone_sources: doPFJetConstituentsNjets and doPFJetConstituentsMinJetPt are combined with OR
                                     doPFxconeJetConstituentsNjets=cms.uint32(0),#store constituents for N leading topjets, where N is parameter
                                     doPFxconeJetConstituentsMinJetPt=cms.double(-1),#store constituence for all topjets with pt above threshold, set to negative value if not used
                                     XCone_sources=cms.VInputTag(
@@ -2401,7 +2400,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                         cms.InputTag("xconeCHS"),
                                     ),
                                     doHOTVR=cms.bool(True),
-                                    #store PF constituents: doPFJetConstituentsNjets and doPFJetConstituentsMinJetPt are combined with OR
+                                    #store PF constituents for HOTVR_sources: doPFJetConstituentsNjets and doPFJetConstituentsMinJetPt are combined with OR
                                     doPFhotvrJetConstituentsNjets=cms.uint32(0),#store constituents for N leading topjets, where N is parameter
                                     doPFhotvrJetConstituentsMinJetPt=cms.double(-1),#store constituence for all topjets with pt above threshold, set to negative value if not used
                                     HOTVR_sources=cms.VInputTag(
@@ -2424,7 +2423,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                         cms.InputTag("genXCone33TopJets"),
                                     ),
                                     doXCone_dijet=cms.bool(False), #XCone for dijet (JERC) studies, should be stored for QCD MC and JetHT DATA
-                                    #store PF constituents: doPFJetConstituentsNjets and doPFJetConstituentsMinJetPt are combined with OR
+                                    #store PF constituents for XCone_dijet_sources: doPFJetConstituentsNjets and doPFJetConstituentsMinJetPt are combined with OR
                                     doPFxconeDijetJetConstituentsNjets=cms.uint32(0),#store constituents for N leading topjets, where N is parameter
                                     doPFxconeDijetJetConstituentsMinJetPt=cms.double(-1),#store constituence for all topjets with pt above threshold, set to negative value if not used
 
@@ -2445,7 +2444,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                     ),
 #                                    doGenXCone_dijet=cms.bool(not useData),
                                     doGenXCone_dijet=cms.bool(False),
-                                    #store GEN constituents: doGenJetConstituentsNjets and doGenJetConstituentsMinJetPt are combined with OR
+                                    #store GEN constituents for GenXCone_dijet_sources: doGenJetConstituentsNjets and doGenJetConstituentsMinJetPt are combined with OR
                                     doGenxconeDijetJetConstituentsNjets=cms.uint32(0),#store constituents for N leading topjets, where N is parameter
                                     doGenxconeDijetJetConstituentsMinJetPt=cms.double(-1),#store constituence for all topjets with pt above threshold, set to negative value if not 
                                     GenXCone_dijet_sources=cms.VInputTag(

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -2362,7 +2362,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                     genjet_etamax=cms.double(5.0),
 
                                     doGenTopJets=cms.bool(not useData),
-                                    #store GEN constituents for topjet_sources: doGenJetConstituentsNjets and doGenJetConstituentsMinJetPt are combined with OR
+                                    #store GEN constituents for gentopjet_sources: doGenJetConstituentsNjets and doGenJetConstituentsMinJetPt are combined with OR
                                     doGenTopJetConstituentsNjets=cms.uint32(0),#store constituents for N leading genjets, where N is parameter
                                     doGenTopJetConstituentsMinJetPt=cms.double(-1),#store constituence for all genjets with pt above threshold, set to negative value if not used
 


### PR DESCRIPTION
Was cutting on wrong object's pT for Jets & TopJets since the uhh2 class hadn't been set yet. Doesn't affect XCone or HOTVR, nor GenJets or GenTopJets.
To test this in future, I've added more hists to plot constituents.size() vs jet pt, eta, and index.

Also reshuffled & expanded comments about `do*JetConstituent*` options to make it clearer.

[only compile] since the current config doesn't store constituents at the moment so plotting wouldn't be useful