### PR TITLE
[102X] add stuff for advanced trigger studies

### DIFF
--- a/core/include/Event.h
+++ b/core/include/Event.h
@@ -44,7 +44,9 @@ public:
   std::vector< TopJet >* toppuppijets;
   MET* met;
   MET* genmet;
-    
+  std::vector< L1EGamma>* L1EG_seeds;
+  std::vector< L1Jet>* L1J_seeds;
+
   GenInfo* genInfo;
   std::vector< GenTopJet >* gentopjets;
   std::vector< GenParticle >* genparticles;
@@ -112,6 +114,11 @@ public:
    * if \c lookup_trigger_index returns false.
    */
   int trigger_prescale(TriggerIndex & ti) const;
+
+  //L1 prescales, see for more details:
+  //https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2017#Trigger
+  int trigger_prescaleL1min(TriggerIndex & ti) const;
+  int trigger_prescaleL1max(TriggerIndex & ti) const;
   
   /** \brief Test whether a given trigger is available for the current event
    * 
@@ -142,6 +149,14 @@ public:
   std::vector<int>* & get_triggerPrescales(){
       return triggerPrescales;
   }
+
+  std::vector<int>* & get_triggerPrescalesL1min(){
+    return triggerPrescalesL1min;
+  }
+  std::vector<int>* & get_triggerPrescalesL1max(){
+    return triggerPrescalesL1max;
+  }
+
   
   void set_triggernames(std::vector<std::string> names){ // for the current run(!)
       triggerNames_currentrun = move(names);
@@ -160,6 +175,8 @@ public:
 private:
     std::vector<bool>* triggerResults;
     std::vector<int>* triggerPrescales;
+    std::vector<int>* triggerPrescalesL1min;
+    std::vector<int>* triggerPrescalesL1max;
 
     std::vector<std::string> triggerNames_currentrun;
     int triggerNames_currentrun_runid;

--- a/core/include/EventHelper.h
+++ b/core/include/EventHelper.h
@@ -63,7 +63,10 @@ public:
     void setup_genparticles(const std::string & bname);
     void setup_pfparticles(const std::string & bname);
     void setup_genjets(const std::string & bname);
-    
+
+    void setup_L1EG_seeds(const std::string & bname);
+    void setup_L1J_seeds(const std::string & bname);
+
     void setup_trigger();
     
     // note: event has to outlive this class. If creating a new event, also create a new EventHelper!
@@ -88,6 +91,7 @@ private:
     bool genInfo, gentopjets, genparticles, genjets;
     bool pfparticles;
     bool trigger;
+    bool L1EG_seeds, L1J_seeds;
     bool first_event_read;
     
     // trigger handling:
@@ -120,7 +124,11 @@ private:
     
     Event::Handle<std::vector<bool>> h_triggerResults;
     Event::Handle<std::vector<int>> h_triggerPrescales;
+    Event::Handle<std::vector<int>> h_triggerPrescalesL1min;
+    Event::Handle<std::vector<int>> h_triggerPrescalesL1max;
     Event::Handle<std::vector<std::string>> h_triggerNames;
+    Event::Handle<std::vector<L1EGamma>> h_L1EG_seeds;
+    Event::Handle<std::vector<L1Jet>> h_L1J_seeds;
 };
 
 

--- a/core/include/L1EGamma.h
+++ b/core/include/L1EGamma.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "Particle.h"
+#include <vector>
+
+// L1EGamma seeds 
+//see https://twiki.cern.ch/twiki/pub/CMS/HowToL1TriggerMenu/17.03.14_L1EG_parameters.pdf
+//see https://cmssdt.cern.ch/lxr/source/DataFormats/L1Trigger/interface/EGamma.h?v=CMSSW_8_4_0&%21v=CMSSW_9_4_0
+
+class L1EGamma : public Particle{
+public:
+  L1EGamma(){
+      m_bx = -100;
+      m_iso = -100;
+      m_Shape = 0; // cluster shape variable
+
+
+  }
+    
+  int bx() const{return m_bx;}
+  int iso() const{return m_iso;}
+  int shape() const{return m_Shape;}
+
+  void set_bx(int x){  m_bx=x;}
+  void set_iso(int x){  m_iso=x;}
+  void set_Shape(int x){ m_Shape=x;}
+
+private:
+  int m_bx, m_iso,  m_Shape;
+};
+

--- a/core/include/L1Jet.h
+++ b/core/include/L1Jet.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "Particle.h"
+#include <vector>
+
+// L1Jet seeds 
+//see https://cmssdt.cern.ch/lxr/source/DataFormats/L1Trigger/interface/Jet.h?v=CMSSW_8_4_0&%21v=CMSSW_9_4_0
+
+class L1Jet : public Particle{
+public:
+  L1Jet(){
+      m_bx = -100;
+      m_puEt = 0; // 
+      m_seedEt = 0; // 
+      m_rawEt = 0; // 
+
+
+  }
+    
+  int bx() const{return m_bx;}
+  int puEt()  const{return m_puEt;}
+  int seedEt() const{return m_seedEt;}
+  int rawEt() const{return m_rawEt;}
+
+  void set_bx(int x){  m_bx=x;}
+  void set_puEt(int x){ m_puEt=x;}
+  void set_seedEt(int x){ m_seedEt=x;}
+  void set_rawEt(int x){ m_rawEt=x;}
+
+private:
+  int m_bx, m_puEt, m_seedEt, m_rawEt;
+};
+

--- a/core/include/NtupleObjects.h
+++ b/core/include/NtupleObjects.h
@@ -13,3 +13,5 @@
 #include "UHH2/core/include/GenTopJet.h"
 #include "UHH2/core/include/source_candidate.h"
 #include "UHH2/core/include/PFParticle.h"
+#include "UHH2/core/include/L1EGamma.h"
+#include "UHH2/core/include/L1Jet.h"

--- a/core/include/SUHH2core_LinkDef.h
+++ b/core/include/SUHH2core_LinkDef.h
@@ -43,5 +43,8 @@
 #pragma link C++ class std::vector<PFParticle>+;
 #pragma link C++ class source_candidate+;
 #pragma link C++ class std::vector<source_candidate>+;
-
+#pragma link C++ class L1EGamma+;
+#pragma link C++ class std::vector<L1EGamma>+;
+#pragma link C++ class L1Jet+;
+#pragma link C++ class std::vector<L1Jet>+;
 #endif // __CINT__

--- a/core/plugins/NtupleWriter.h
+++ b/core/plugins/NtupleWriter.h
@@ -14,6 +14,11 @@
 #include "DataFormats/PatCandidates/interface/TriggerObjectStandAlone.h"
 #include "DataFormats/PatCandidates/interface/PackedTriggerPrescales.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"
+
+#include "DataFormats/L1TGlobal/interface/GlobalAlgBlk.h"
+#include "DataFormats/L1Trigger/interface/EGamma.h"
+#include "DataFormats/L1Trigger/interface/Jet.h"
+
 #include "UHH2/core/include/Event.h"
 #include "UHH2/core/include/AnalysisModule.h"
 #include "TTree.h"
@@ -94,6 +99,7 @@ class NtupleWriter : public edm::EDFilter {
 
       bool doPV;
       bool doTrigger;
+      bool doL1seed;
       bool doEcalBadCalib;
       bool doPrefire;
       bool runOnMiniAOD;
@@ -175,6 +181,8 @@ class NtupleWriter : public edm::EDFilter {
       edm::EDGetTokenT<edm::TriggerResults> triggerBits_;
       edm::EDGetTokenT<edm::TriggerResults>  metfilterBits_;
       edm::EDGetTokenT<pat::PackedTriggerPrescales> triggerPrescales_;
+      edm::EDGetTokenT<pat::PackedTriggerPrescales> triggerPrescalesL1min_;
+      edm::EDGetTokenT<pat::PackedTriggerPrescales> triggerPrescalesL1max_;
       edm::EDGetTokenT<pat::TriggerObjectStandAloneCollection> triggerObjects_;
 
       std::vector<std::vector<FlavorParticle> > triggerObjects_out;
@@ -198,6 +206,13 @@ class NtupleWriter : public edm::EDFilter {
 
       std::vector<edm::EDGetToken> genxcone_tokens_dijet;
       std::vector<std::vector<GenTopJet>> genxconeJets_dijet;
+
+      edm::EDGetTokenT<BXVector<GlobalAlgBlk>> l1GtToken_;
+      edm::EDGetTokenT<BXVector<l1t::EGamma>> l1EGToken_;
+      edm::EDGetTokenT<BXVector<l1t::Jet>> l1JetToken_;
+
+      std::vector<L1EGamma>  L1EG_seeds;
+      std::vector<L1Jet> L1Jet_seeds;
 
 };
 

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -2325,6 +2325,12 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                     #),
                                     trigger_objects=cms.InputTag("selectedPatTrigger" if year == "2016v2" else "slimmedPatTrigger"),
 
+                                    #For 2017 data with prefiring issue it might be usefull to store L1 seeds
+                                    doL1seed=cms.bool(True),
+                                    l1GtSrc = cms.InputTag("gtStage2Digis"),
+                                    l1EGSrc = cms.InputTag("caloStage2Digis:EGamma"),
+                                    l1JetSrc = cms.InputTag("caloStage2Digis:Jet"),
+
                                     doEcalBadCalib=cms.bool(bad_ecal),
                                     ecalBadCalib_source=cms.InputTag("ecalBadCalibReducedMINIAODFilter"),
 

--- a/core/src/AnalysisModuleRunner.cxx
+++ b/core/src/AnalysisModuleRunner.cxx
@@ -604,7 +604,9 @@ void AnalysisModuleRunner::AnalysisModuleRunnerImpl::begin_input_data(AnalysisMo
         eh->setup_toppuppijets(context->get("TopPuppiJetCollection", ""));
         eh->setup_met(context->get("METName", ""));
         eh->setup_pfparticles(context->get("PFParticleCollection", ""));
-       
+        eh->setup_L1EG_seeds(context->get("L1EGseedsCollection", ""));
+	eh->setup_L1J_seeds(context->get("L1JseedsCollection", ""));
+
         bool is_mc = context->get("dataset_type") == "MC";
         if (is_mc) {
 	  try{

--- a/core/src/EventHelper.cxx
+++ b/core/src/EventHelper.cxx
@@ -20,7 +20,7 @@ Event::Handle<T> declare_in_out(const std::string & branch_name, const std::stri
 
 EventHelper::EventHelper(uhh2::Context & ctx_): ctx(ctx_), event(0), pvs(false), electrons(false), muons(false), taus(false), photons(false), jets(false),
 						topjets(false), toppuppijets(false), met(false),  genmet(false), genInfo(false), gentopjets(false), 
-						genparticles(false), genjets(false), pfparticles(false), trigger(false), first_event_read(true){
+						genparticles(false), genjets(false), pfparticles(false), trigger(false),  L1EG_seeds(false), L1J_seeds(false), first_event_read(true){
     h_run = declare_in_out<int>("run", "run", ctx);
     h_lumi = declare_in_out<int>("luminosityBlock", "luminosityBlock", ctx);
     h_event = declare_in_out<int>("event", "event", ctx);
@@ -61,6 +61,8 @@ IMPL_SETUP(genparticles, vector<GenParticle>)
 IMPL_SETUP(pfparticles, vector<PFParticle>)
 IMPL_SETUP(genjets, vector<GenJet>)
 IMPL_SETUP(genmet, MET)
+IMPL_SETUP(L1EG_seeds, vector<L1EGamma>)
+IMPL_SETUP(L1J_seeds, vector<L1Jet>)
 
 
 
@@ -68,6 +70,8 @@ void EventHelper::setup_trigger(){
     trigger = true;
     h_triggerResults = declare_in_out<std::vector<bool>>("triggerResults", "triggerResults", ctx);
     h_triggerPrescales = declare_in_out<std::vector<int>>("triggerPrescales", "triggerPrescales", ctx);
+    h_triggerPrescalesL1min = declare_in_out<std::vector<int>>("triggerPrescalesL1min", "triggerPrescalesL1min", ctx);
+    h_triggerPrescalesL1max = declare_in_out<std::vector<int>>("triggerPrescalesL1max", "triggerPrescalesL1max", ctx);
     h_triggerNames = declare_in_out<std::vector<std::string>>("triggerNames", "triggerNames", ctx);
 }
 
@@ -153,7 +157,15 @@ void EventHelper::event_read(){
         if(trigger){
             event->get_triggerResults() = &event->get(h_triggerResults);
 	    event->get_triggerPrescales() = &event->get(h_triggerPrescales);
+	    event->get_triggerPrescalesL1min() = &event->get(h_triggerPrescalesL1min);
+	    event->get_triggerPrescalesL1max() = &event->get(h_triggerPrescalesL1max);
         }
+	if(L1EG_seeds){
+	  event->L1EG_seeds =  &event->get(h_L1EG_seeds);
+	}
+	if(L1J_seeds){
+	  event->L1J_seeds =  &event->get(h_L1J_seeds);
+	}
     }
 }
 

--- a/core/src/classes.h
+++ b/core/src/classes.h
@@ -16,6 +16,8 @@
 #include "UHH2/core/include/GenParticle.h"
 #include "UHH2/core/include/PFParticle.h"
 #include "UHH2/core/include/source_candidate.h"
+#include "UHH2/core/include/L1EGamma.h"
+#include "UHH2/core/include/L1Jet.h"
 
 #include <vector>
 #include <map>
@@ -58,5 +60,9 @@ namespace {
     std::vector<PFParticle> pfps;
     source_candidate sc;
     std::vector<source_candidate> scs;
+    L1EGamma L1EG_seed;
+    std::vector<L1EGamma> L1EG_seeds;
+    L1Jet L1Jet_seed;
+    std::vector<L1Jet> L1J_seeds;
   }
 }

--- a/core/src/classes_def.xml
+++ b/core/src/classes_def.xml
@@ -35,4 +35,8 @@
 <class name="std::vector<PFParticle>"/>
 <class name="source_candidate"/>
 <class name="std::vector<source_candidate>"/>
+<class name="L1EGamma"/>
+<class name="std::vector<L1EGamma>"/>
+<class name="L1Jet"/>
+<class name="std::vector<L1Jet>"/>
 </lcgdict>


### PR DESCRIPTION
Store L1 triggers prescales, because if your trigger prescaled it's most probably done at L1. 
Also copied "doL1seed"  code from 94X_v3, which might be useful for L1 prefiring studies with 2017 data. Enabled for testing, should switched off by default in the production.