### PR TITLE
[102X] add b-taggers WPs for AK4 jets, rename Jet::btag_DeepFlavour() to Jet::btag_DeepJet(), specify era of process 

### DIFF
--- a/common/include/JetHists.h
+++ b/common/include/JetHists.h
@@ -132,7 +132,7 @@ public:
 protected:
   void do_fill(const std::vector<TopJet> & jets, const uhh2::Event & event);
 
-  const CSVBTag btag_;
+  CSVBTag btag_;
   TH2F * hist_b_passing_;
   TH2F * hist_b_total_;
   TH2F * hist_c_passing_;

--- a/common/include/JetIds.h
+++ b/common/include/JetIds.h
@@ -21,9 +21,10 @@ public:
     explicit CSVBTag(wp working_point);
     explicit CSVBTag(float float_point);
 
-    bool operator()(const Jet & jet, const uhh2::Event & event) const;
+    bool operator()(const Jet & jet, const uhh2::Event & event);
 private:
     float csv_threshold;
+    wp m_working_point;
 };
 
 class DeepCSVBTag {
@@ -33,10 +34,26 @@ public:
     explicit DeepCSVBTag(wp working_point);
     explicit DeepCSVBTag(float float_point);
 
-    bool operator()(const Jet & jet, const uhh2::Event & event) const;
+    bool operator()(const Jet & jet, const uhh2::Event & event);
 private:
     float deepcsv_threshold;
+    wp m_working_point;
 };
+
+class DeepJetBTag {
+public:
+    enum wp {WP_LOOSE, WP_MEDIUM, WP_TIGHT };
+    
+    explicit DeepJetBTag(wp working_point);
+    explicit DeepJetBTag(float float_point);
+
+    bool operator()(const Jet & jet, const uhh2::Event & event);
+private:
+    float deepjet_threshold;
+    wp m_working_point;
+};
+
+
 
 /**
  * Jet Id following recomendations from JetMET for RunII

--- a/common/include/MCWeight.h
+++ b/common/include/MCWeight.h
@@ -237,7 +237,7 @@ class MCBTagScaleFactor: public uhh2::AnalysisModule {
                                                   uhh2::Event & event);
   std::pair<float, float> get_SF_btag(float pt, float abs_eta, int flav);
 
-  const CSVBTag btag_;
+  CSVBTag btag_;
   std::unique_ptr<BTagCalibrationReader> calib_up_;
   std::unique_ptr<BTagCalibrationReader> calib_;
   std::unique_ptr<BTagCalibrationReader> calib_down_;

--- a/common/src/JetIds.cxx
+++ b/common/src/JetIds.cxx
@@ -4,51 +4,185 @@ using namespace std;
 using namespace uhh2;
 
 CSVBTag::CSVBTag(wp working_point) {
-    switch(working_point){
-        case WP_LOOSE:
-            csv_threshold = 0.5426f;
-            break;
-        case WP_MEDIUM:
-            csv_threshold = 0.8484f;
-            break;
-        case WP_TIGHT:
-            csv_threshold = 0.9535f;
-            break;
-        default:
-            throw invalid_argument("invalid working point passed to CSVBTag");
-    }
+  m_working_point = working_point;
 }
 
 CSVBTag::CSVBTag(float float_point):csv_threshold(float_point) {}
 
 
-bool CSVBTag::operator()(const Jet & jet, const Event &) const{
-    return jet.btag_combinedSecondaryVertex() > csv_threshold;
+bool CSVBTag::operator()(const Jet & jet, const Event & ev){
+  if(ev.year == "2016v2" || ev.year == "2016v3"){
+    //  https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation80XReReco
+    switch(m_working_point){
+    case WP_LOOSE:
+      csv_threshold = 0.5426;
+      break;
+    case WP_MEDIUM:
+      csv_threshold = 0.8484;
+      break;
+    case WP_TIGHT:
+      csv_threshold = 0.9535;
+      break;
+    default:
+      throw invalid_argument("invalid working point passed to CSVBTag");
+    }
+  }
+  if(ev.year == "2017" || ev.year == "2018"){
+    //https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X
+    //Note: CSV is not supported for 2018 analyses
+    switch(m_working_point){
+    case WP_LOOSE:
+      csv_threshold = 0.5803;
+      break;
+    case WP_MEDIUM:
+      csv_threshold = 0.8838;
+      break;
+    case WP_TIGHT:
+      csv_threshold = 0.9693;
+      break;
+    default:
+      throw invalid_argument("invalid working point passed to CSVBTag");
+    }
+  }
+  return jet.btag_combinedSecondaryVertex() > csv_threshold;
 }
+
 ///
 DeepCSVBTag::DeepCSVBTag(wp working_point) {
-    switch(working_point){
-        case WP_LOOSE:
-            deepcsv_threshold = 0.1522f;
-            break;
-        case WP_MEDIUM:
-            deepcsv_threshold = 0.4941f;
-            break;
-        case WP_TIGHT:
-            deepcsv_threshold = 0.8001f;
-            break;
-        default:
-            throw invalid_argument("invalid working point passed to DeepCSVBTag");
-    }
+   m_working_point = working_point;
 }
 
 DeepCSVBTag::DeepCSVBTag(float float_point):deepcsv_threshold(float_point) {}
 
 
-bool DeepCSVBTag::operator()(const Jet & jet, const Event &) const{
-    return jet.btag_DeepCSV() > deepcsv_threshold;
+bool DeepCSVBTag::operator()(const Jet & jet, const Event &ev){
+  if(ev.year == "2016v2"){
+    //https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation80XReReco
+    switch(m_working_point){
+    case WP_LOOSE:
+      deepcsv_threshold = 0.2219;
+      break;
+    case WP_MEDIUM:
+      deepcsv_threshold = 0.6324;
+      break;
+    case WP_TIGHT:
+      deepcsv_threshold = 0.8958;
+      break;
+    default:
+      throw invalid_argument("invalid working point passed to DeepCSVBTag");
+    }
+  }
+  if(ev.year == "2016v3"){
+    //https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation2016Legacy
+    switch(m_working_point){
+    case WP_LOOSE:
+      deepcsv_threshold = 0.2217;
+      break;
+    case WP_MEDIUM:
+      deepcsv_threshold = 0.6321;
+      break;
+    case WP_TIGHT:
+      deepcsv_threshold = 0.8953;
+      break;
+    default:
+      throw invalid_argument("invalid working point passed to DeepCSVBTag");
+    }
+  }
+
+  if(ev.year == "2017"){
+    //https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X
+    switch(m_working_point){
+    case WP_LOOSE:
+      deepcsv_threshold = 0.1522;
+      break;
+    case WP_MEDIUM:
+      deepcsv_threshold = 0.4941;
+      break;
+    case WP_TIGHT:
+      deepcsv_threshold = 0.8001;
+      break;
+    default:
+      throw invalid_argument("invalid working point passed to DeepCSVBTag");
+    }
+  }
+  if(ev.year == "2018"){
+    //https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation102X
+    switch(m_working_point){
+    case WP_LOOSE:
+      deepcsv_threshold = 0.1241;
+      break;
+    case WP_MEDIUM:
+      deepcsv_threshold = 0.4184;
+      break;
+    case WP_TIGHT:
+      deepcsv_threshold = 0.7527;
+      break;
+    default:
+      throw invalid_argument("invalid working point passed to DeepCSVBTag");
+    }
+  }
+  return jet.btag_DeepCSV() > deepcsv_threshold;
 }
 
+//DeepJet (=DeepFlavor)
+DeepJetBTag::DeepJetBTag(wp working_point) {
+  m_working_point = working_point;
+}
+
+DeepJetBTag::DeepJetBTag(float float_point):deepjet_threshold(float_point) {}
+
+bool DeepJetBTag::operator()(const Jet & jet, const Event &ev){
+  if(ev.year == "2016v2" || ev.year == "2016v3"){
+  //https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation2016Legacy
+  //Note: wp are provided for 2016 legacy only, i.e 2016v3
+    switch(m_working_point){
+        case WP_LOOSE:
+            deepjet_threshold = 0.0614;
+            break;
+        case WP_MEDIUM:
+            deepjet_threshold = 0.3093;
+            break;
+        case WP_TIGHT:
+            deepjet_threshold = 0.7221;
+            break;
+        default:
+            throw invalid_argument("invalid working point passed to DeepJetBTag");
+    }
+  }
+  if(ev.year == "2017"){
+    //https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X
+    switch(m_working_point){
+        case WP_LOOSE:
+            deepjet_threshold = 0.0521;
+            break;
+        case WP_MEDIUM:
+            deepjet_threshold = 0.3033;
+            break;
+        case WP_TIGHT:
+            deepjet_threshold = 0.7489;
+            break;
+        default:
+            throw invalid_argument("invalid working point passed to DeepJetBTag");
+    }
+  }
+  if(ev.year == "2018"){
+    //https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation102X
+    switch(m_working_point){
+        case WP_LOOSE:
+            deepjet_threshold = 0.0494;
+            break;
+        case WP_MEDIUM:
+            deepjet_threshold = 0.2770;
+            break;
+        case WP_TIGHT:
+            deepjet_threshold = 0.7264;
+            break;
+        default:
+            throw invalid_argument("invalid working point passed to DeepJetBTag");
+    }
+  }
+  return jet.btag_DeepJet() > deepjet_threshold;
+}
 
 ///
 JetPFID::JetPFID(wp working_point):m_working_point(working_point){}

--- a/core/include/AnalysisModule.h
+++ b/core/include/AnalysisModule.h
@@ -58,8 +58,8 @@ public:
  * The configuration of a module is represented as key/value pairs of strings, to pass small (configuration) data to
  * the modules. A number of dataset-related keys are always present when running via SFrame:
  *  - "dataset_type" is the type as given in the SFrame xml file, should be either "MC" or "DATA"
- *  - "dataset_version" is the 'Version' of the dataset as given in the SFrame xml file
  *  - "dataset_lumi" is the integrated luminosity ('Lumi') of the dataset in pb^-1, as given in the SFrame xml file
+ *  - "dataset_year" is the year of data/MC set as 'Year' parameter in xml file
  *  - "target_lumi" is the target luminosity in pb^-1 for MC reweighting, as specified in the SFrame xml in Cycle in 'TargetLumi'
  * 
  * Also, all the dataset-metadata is added with the prefix "meta_" (refer to the Metadata documentation for details).

--- a/core/include/Jet.h
+++ b/core/include/Jet.h
@@ -94,7 +94,7 @@ class Jet : public FlavorParticle {
   float btag_DeepFlavour_uds() const{return m_btag_DeepFlavour_probuds;}
   float btag_DeepFlavour_g() const{return m_btag_DeepFlavour_probg;}
   float btag_DeepFlavour_c() const{return m_btag_DeepFlavour_probc;}
-  float btag_DeepFlavour() const{return m_btag_DeepFlavour_probbb+m_btag_DeepFlavour_probb+m_btag_DeepFlavour_problepb;}
+  float btag_DeepJet() const{return m_btag_DeepFlavour_probbb+m_btag_DeepFlavour_probb+m_btag_DeepFlavour_problepb;}
  
 
   float JEC_factor_raw() const{return m_JEC_factor_raw;} // This takes you from corrected -> uncorrected

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -1161,9 +1161,9 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
         if useData:
             jetcorr_list.append("L2L3Residual")
 
-#        discriminators = bTagDiscriminators[:]
-#        discriminators.extend(ak4btagDiscriminators)
-        discriminators = ak4btagDiscriminators[:]
+        discriminators = bTagDiscriminators[:]
+        discriminators.extend(ak4btagDiscriminators)
+#        discriminators = ak4btagDiscriminators[:]
         if is_ak8 and is_topjet:
             discriminators.extend(ak8btagDiscriminators)
 

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -71,11 +71,11 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
     #try eras for correct b-tagging
     from Configuration.StandardSequences.Eras import eras
     if year == "2018":
-        Process = cms.Process("DUMMY", eras.Run2_2018) 
+        process = cms.Process("USER", eras.Run2_2018) 
     if year == "2017":
-        Process = cms.Process("DUMMY", eras.Run2_2017) 
+        process = cms.Process("USER", eras.Run2_2017) 
     if year == "2016v3" or year =="2016v2":
-        Process = cms.Process("DUMMY", eras.Run2_2016) 
+        process = cms.Process("USER", eras.Run2_2016) 
 
     bTagDiscriminators = [
         'pfJetProbabilityBJetTags',
@@ -168,7 +168,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
         'pfImpactParameterTagInfos', 'pfSecondaryVertexTagInfos', 'pfInclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos'
     ]
 
-    process = cms.Process("USER")
+#    process = cms.Process("USER")
 
     task = cms.Task()
 

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -68,7 +68,14 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
     if (year=="2016v2" or year=="2016v3"):
         met_sources_GL.extend(['slMETsCHS'])
 
-
+    #try eras for correct b-tagging
+    from Configuration.StandardSequences.Eras import eras
+    if year == "2018":
+        Process = cms.Process("DUMMY", eras.Run2_2018) 
+    if year == "2017":
+        Process = cms.Process("DUMMY", eras.Run2_2017) 
+    if year == "2016v3" or year =="2016v2":
+        Process = cms.Process("DUMMY", eras.Run2_2016) 
 
     bTagDiscriminators = [
         'pfJetProbabilityBJetTags',

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -73,12 +73,12 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
     if year == "2018":
         process = cms.Process("USER", eras.Run2_2018) 
     if year == "2017":
-        process = cms.Process("USER", eras.run2_miniAOD_94XFall17) 
-#        process = cms.Process("USER", eras.Run2_2017, eras.run2_miniAOD_94XFall17) 
+        process = cms.Process("USER", eras.Run2_2017, eras.run2_miniAOD_94XFall17)  #v2
+#       process = cms.Process("USER", eras.Run2_2017)  #v1
     if year == "2016v2":
         process = cms.Process("USER", eras.Run2_2016) 
     if year == "2016v3":
-        process = cms.Process("USER", eras.run2_miniAOD_80XLegacy) 
+        process = cms.Process("USER", eras.Run2_2016, eras.run2_miniAOD_80XLegacy) 
 
     bTagDiscriminators = [
         'pfJetProbabilityBJetTags',

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -73,11 +73,12 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
     if year == "2018":
         process = cms.Process("USER", eras.Run2_2018) 
     if year == "2017":
-        process = cms.Process("USER", eras.Run2_2017,eras.run2_miniAOD_94XFall17) 
+        process = cms.Process("USER", eras.run2_miniAOD_94XFall17) 
+#        process = cms.Process("USER", eras.Run2_2017, eras.run2_miniAOD_94XFall17) 
     if year == "2016v2":
         process = cms.Process("USER", eras.Run2_2016) 
     if year == "2016v3":
-        process = cms.Process("USER", eras.Run2_2016, eras.run2_miniAOD_80XLegacy) 
+        process = cms.Process("USER", eras.run2_miniAOD_80XLegacy) 
 
     bTagDiscriminators = [
         'pfJetProbabilityBJetTags',

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -73,9 +73,11 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
     if year == "2018":
         process = cms.Process("USER", eras.Run2_2018) 
     if year == "2017":
-        process = cms.Process("USER", eras.Run2_2017) 
-    if year == "2016v3" or year =="2016v2":
+        process = cms.Process("USER", eras.Run2_2017,eras.run2_miniAOD_94XFall17) 
+    if year == "2016v2":
         process = cms.Process("USER", eras.Run2_2016) 
+    if year == "2016v3":
+        process = cms.Process("USER", eras.Run2_2016, eras.run2_miniAOD_80XLegacy) 
 
     bTagDiscriminators = [
         'pfJetProbabilityBJetTags',

--- a/scripts/compare_hists.C
+++ b/scripts/compare_hists.C
@@ -1,0 +1,71 @@
+//investigation of difference between two hists from AnalysisTree
+// author: A.Karavdina
+// date: 22.02.2019
+// Run it with following command:
+// root -l -b -q compare_hists.C
+
+void compare_hists(){
+  gStyle->SetOptStat(0);
+  gStyle->SetTitleSize(0.045,"x");  
+  gStyle->SetTitleSize(0.045,"y");
+  gStyle->SetTitleYOffset(0.9);
+
+  Double_t w = 600;
+  Double_t h = 600;
+
+  // bool isWeights = true;
+  bool isWeights = false;
+
+  //Files with Analysis tree, e.g after UHH2 ntuple-writer
+  //file1, hist 1
+  TString path1 = "/nfs/dust/cms/user/karavdia/CMSSW_10_2_11/src/UHH2/core/python/";
+  TString name1 = "Ntuple_tthad2018_NotredoBslimmed_10GeV.root";
+  TString gl_label1 = "DeepCSV, jet pt>100GeV (original)";
+
+  TFile *input1 = TFile::Open(path1+name1);
+  TTree *TTreeAna1 = (TTree*)input1->Get("AnalysisTree");
+  TTreeAna1->SetAlias("DeepCSV", "jetsAk4Puppi.m_btag_DeepCSV_probb+jetsAk4Puppi.m_btag_DeepCSV_probbb");
+  TTreeAna1->SetAlias("jetPt", "jetsAk4Puppi.m_pt");
+
+  TH1F *hist1 = new TH1F("hist1",";DeepCSV",88,-2,1.2);
+  TTreeAna1->Project("hist1","DeepCSV","jetPt>100");
+  //  hist1 ->SetMarkerColor(kBlack);
+  hist1 ->SetLineColor(kBlack);
+  // hist1 ->SetMarkerSize(1.1);
+  // hist1 ->SetMarkerStyle(20);
+
+  //file2, hist 2
+  TString path2 = "/nfs/dust/cms/user/karavdia/CMSSW_10_2_11/src/UHH2/core/python/";
+  TString name2 = "Ntuple_tthad2018_redoBslimmed_10GeV.root";
+  TString gl_label2 = "DeepCSV, jet pt>100GeV (redone)";
+
+  TFile *input2 = TFile::Open(path2+name2);
+  TTree *TTreeAna2 = (TTree*)input2->Get("AnalysisTree");
+  TTreeAna2->SetAlias("DeepCSV", "jetsAk4Puppi.m_btag_DeepCSV_probb+jetsAk4Puppi.m_btag_DeepCSV_probbb");
+  TTreeAna2->SetAlias("jetPt", "jetsAk4Puppi.m_pt");
+
+  TH1F *hist2 = new TH1F("hist2",";DeepCSV",88,-2,1.2);
+  TTreeAna2->Project("hist2","DeepCSV","jetPt>100");
+  //  hist2 ->SetMarkerColor(kRed);
+  hist2 ->SetLineColor(kRed);
+  hist2 ->SetLineWidth(3);
+  // hist2 ->SetMarkerSize(1.1);
+  // hist2 ->SetMarkerStyle(21);
+
+  //  hist2 ->GetYaxis()->SetRangeUser(0, 4500);
+  hist2 ->GetYaxis()->SetRangeUser(0, 1000);
+
+  
+  TCanvas * c1 = new TCanvas("cplot", "c", w, h);
+  TLegend *leg = new TLegend(0.17,0.78,0.88,0.88);
+  leg->SetHeader();
+  leg->AddEntry(hist1,gl_label1,"lep");
+  leg->AddEntry(hist2,gl_label2,"lep");
+  leg->SetTextSize(0.04);
+  hist2 ->Draw("");
+  hist1 ->Draw("same");
+  leg->Draw();
+  c1->SaveAs("BtaggersTest_100GeV.pdf");
+  c1->SaveAs("BtaggersTest_100GeV.png");
+
+}


### PR DESCRIPTION
add working points for b-taggers for 2016, 2017 and 2018;
change list of discriminators to enable storage of DeepCSV for AK4PUPPI in 2016v2
rename `Jet::btag_DeepFlavour()` to `Jet::btag_DeepJet()`

Check with Z'->ttbar selection for tight WP of each b-tagger on AK4PUPPI for samples of different years:
![b_taggers_zprime](https://user-images.githubusercontent.com/5495937/53187118-b372f200-3602-11e9-8e90-649e8d53dd48.png)
