### PR TITLE
[102X] generic callable electron IDs

### DIFF
--- a/common/include/ElectronIds.h
+++ b/common/include/ElectronIds.h
@@ -33,6 +33,21 @@ class PtEtaSCCut {
   float min_pt, max_etaSC;
 };
 
+// Generic selector for the stored Electron tags
+
+class ElectronTagID{
+ public:
+  ElectronTagID(Electron::tag sel_): sel(sel_) {}
+
+  bool operator()(const Electron & el, const uhh2::Event &) const {
+    return el.get_tag(sel); // no need to check, done in Tag class
+  }
+
+ private:
+  Electron::tag sel;
+
+};
+
 // Electron selector for PF MINI-Isolation ---------------------------
 class Electron_MINIIso {
 


### PR DESCRIPTION
Like for `MuonIDs`, add in a callable class so it can be used wherever one would use an `ElectronId`. also updated egamma example to show usage, although not enabled currently as it affects testing IDs are being stored

Should make using tags more trivial.

[only compile]