### PR TITLE
[102X] Split 2017 config settings into 2017v1 & 2017v2

### DIFF
--- a/core/python/ntuplewriter_data_2017v2.py
+++ b/core/python/ntuplewriter_data_2017v2.py
@@ -3,23 +3,25 @@ from UHH2.core.ntuple_generator import generate_process  # use CMSSW type path f
 from UHH2.core.optionsParse import setup_opts, parse_apply_opts
 
 
-"""NTuple config for 2017 MC datasets.
+"""NTuple config for 2017v2 Data datasets.
 
 You should try and put any centralised changes in generate_process(), not here.
 """
 
 
-process = generate_process(year="2017", useData=False)
+process = generate_process(year="2017v2", useData=True)
 
 # Please do not commit changes to source filenames - used for consistency testing
 process.source.fileNames = cms.untracked.vstring([
-    # '/store/mc/RunIIFall17MiniAOD/TTJets_TuneCP5_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/94X_mc2017_realistic_v10-v1/40000/2657B2FF-650D-E811-99F6-0025905A6060.root'
-    '/store/mc/RunIIFall17MiniAODv2/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/30000/D221F074-FF58-E811-958D-509A4C78138B.root'
+    '/store/data/Run2017D/JetHT/MINIAOD/31Mar2018-v1/70000/DAAA92B6-8044-E811-9E9E-0CC47A4D7638.root',
+    # '/store/data/Run2017D/SingleMuon/MINIAOD/31Mar2018-v1/80000/1E703527-F436-E811-80A7-E0DB55FC1055.root',
+    # '/store/data/Run2017D/SingleElectron/MINIAOD/31Mar2018-v1/80000/4899B9E7-F038-E811-8012-00000065FE80.root',
+    # '/store/data/Run2017D/MET/MINIAOD/31Mar2018-v1/00000/88C7FC3D-FD38-E811-97D5-0CC47A7C340C.root',
 ])
 
 # Do this after setting process.source.fileNames, since we want the ability to override it on the commandline
 options = setup_opts()
 parse_apply_opts(process, options)
 
-with open('pydump_mc_2017.py', 'w') as f:
+with open('pydump_data_2017v2.py', 'w') as f:
     f.write(process.dumpPython())

--- a/core/python/ntuplewriter_mc_2017v1.py
+++ b/core/python/ntuplewriter_mc_2017v1.py
@@ -1,0 +1,24 @@
+import FWCore.ParameterSet.Config as cms
+from UHH2.core.ntuple_generator import generate_process  # use CMSSW type path for CRAB
+from UHH2.core.optionsParse import setup_opts, parse_apply_opts
+
+
+"""NTuple config for 2017v1 MC datasets.
+
+You should try and put any centralised changes in generate_process(), not here.
+"""
+
+
+process = generate_process(year="2017v1", useData=False)
+
+# Please do not commit changes to source filenames - used for consistency testing
+process.source.fileNames = cms.untracked.vstring([
+    '/store/mc/RunIIFall17MiniAOD/TTJets_TuneCP5_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/94X_mc2017_realistic_v10-v1/40000/2657B2FF-650D-E811-99F6-0025905A6060.root'
+])
+
+# Do this after setting process.source.fileNames, since we want the ability to override it on the commandline
+options = setup_opts()
+parse_apply_opts(process, options)
+
+with open('pydump_mc_2017v1.py', 'w') as f:
+    f.write(process.dumpPython())

--- a/core/python/ntuplewriter_mc_2017v2.py
+++ b/core/python/ntuplewriter_mc_2017v2.py
@@ -3,25 +3,22 @@ from UHH2.core.ntuple_generator import generate_process  # use CMSSW type path f
 from UHH2.core.optionsParse import setup_opts, parse_apply_opts
 
 
-"""NTuple config for 2017 Data datasets.
+"""NTuple config for 2017v2 MC datasets.
 
 You should try and put any centralised changes in generate_process(), not here.
 """
 
 
-process = generate_process(year="2017", useData=True)
+process = generate_process(year="2017v2", useData=False)
 
 # Please do not commit changes to source filenames - used for consistency testing
 process.source.fileNames = cms.untracked.vstring([
-    '/store/data/Run2017D/JetHT/MINIAOD/31Mar2018-v1/70000/DAAA92B6-8044-E811-9E9E-0CC47A4D7638.root',
-    # '/store/data/Run2017D/SingleMuon/MINIAOD/31Mar2018-v1/80000/1E703527-F436-E811-80A7-E0DB55FC1055.root',
-    # '/store/data/Run2017D/SingleElectron/MINIAOD/31Mar2018-v1/80000/4899B9E7-F038-E811-8012-00000065FE80.root',
-    # '/store/data/Run2017D/MET/MINIAOD/31Mar2018-v1/00000/88C7FC3D-FD38-E811-97D5-0CC47A7C340C.root',
+    '/store/mc/RunIIFall17MiniAODv2/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/30000/D221F074-FF58-E811-958D-509A4C78138B.root'
 ])
 
 # Do this after setting process.source.fileNames, since we want the ability to override it on the commandline
 options = setup_opts()
 parse_apply_opts(process, options)
 
-with open('pydump_data_2017.py', 'w') as f:
+with open('pydump_mc_2017v2.py', 'w') as f:
     f.write(process.dumpPython())


### PR DESCRIPTION
Since we need separate GTs & Eras for 2017v1 and v2, this adds extra parameters `2017v1` &`2017v2` for `generate_process()`, and retires `2017` argument.
Also add in corresponding configs. Purposely excluded data 2017v1 config since it is not really useful as people will be using the 31Mar18 dataset, which is counts as 2017v2 for us.

Updated bits in `generate_process()` that are conditional on year arg, e.g. MET EE fix.

So now:
- RunIIFall17MiniAODv2 MC and 31Mar2018 data should use `2017v2` configs
- RunIIFall17MiniAOD MC should use `2017v1` config