### PR TITLE
[102X] Handle extra 2017 year for JetIDs

### DIFF
--- a/common/src/JetIds.cxx
+++ b/common/src/JetIds.cxx
@@ -72,7 +72,7 @@ bool DeepCSVBTag::operator()(const Jet & jet, const Event &ev){
       throw invalid_argument("invalid working point passed to DeepCSVBTag");
     }
   }
-  if(ev.year == "2016v3"){
+  else if(ev.year == "2016v3"){
     //https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation2016Legacy
     switch(m_working_point){
     case WP_LOOSE:
@@ -88,8 +88,7 @@ bool DeepCSVBTag::operator()(const Jet & jet, const Event &ev){
       throw invalid_argument("invalid working point passed to DeepCSVBTag");
     }
   }
-
-  if(ev.year == "2017"){
+  else if(ev.year.find("2017") != std::string::npos){
     //https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X
     switch(m_working_point){
     case WP_LOOSE:
@@ -105,7 +104,7 @@ bool DeepCSVBTag::operator()(const Jet & jet, const Event &ev){
       throw invalid_argument("invalid working point passed to DeepCSVBTag");
     }
   }
-  if(ev.year == "2018"){
+  else if(ev.year == "2018"){
     //https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation102X
     switch(m_working_point){
     case WP_LOOSE:
@@ -120,6 +119,9 @@ bool DeepCSVBTag::operator()(const Jet & jet, const Event &ev){
     default:
       throw invalid_argument("invalid working point passed to DeepCSVBTag");
     }
+  } else {
+    cout << "Invalid year, DeepCSVBTag returning false" << endl;
+    return false;
   }
   return jet.btag_DeepCSV() > deepcsv_threshold;
 }

--- a/common/src/JetIds.cxx
+++ b/common/src/JetIds.cxx
@@ -27,7 +27,7 @@ bool CSVBTag::operator()(const Jet & jet, const Event & ev){
       throw invalid_argument("invalid working point passed to CSVBTag");
     }
   }
-  if(ev.year == "2017" || ev.year == "2018"){
+  if(ev.year.find("2017") != std::string::npos || ev.year.find("2018") != std::string::npos){
     //https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X
     //Note: CSV is not supported for 2018 analyses
     switch(m_working_point){
@@ -151,7 +151,7 @@ bool DeepJetBTag::operator()(const Jet & jet, const Event &ev){
             throw invalid_argument("invalid working point passed to DeepJetBTag");
     }
   }
-  if(ev.year == "2017"){
+  else if(ev.year.find("2017") != std::string::npos){
     //https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X
     switch(m_working_point){
         case WP_LOOSE:
@@ -167,7 +167,7 @@ bool DeepJetBTag::operator()(const Jet & jet, const Event &ev){
             throw invalid_argument("invalid working point passed to DeepJetBTag");
     }
   }
-  if(ev.year == "2018"){
+  else if(ev.year == "2018"){
     //https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation102X
     switch(m_working_point){
         case WP_LOOSE:
@@ -182,6 +182,9 @@ bool DeepJetBTag::operator()(const Jet & jet, const Event &ev){
         default:
             throw invalid_argument("invalid working point passed to DeepJetBTag");
     }
+  } else {
+    cout << "Invalid year, DeepJetBTag returning false" << endl;
+    return false;
   }
   return jet.btag_DeepJet() > deepjet_threshold;
 }

--- a/common/src/JetIds.cxx
+++ b/common/src/JetIds.cxx
@@ -188,7 +188,7 @@ bool DeepJetBTag::operator()(const Jet & jet, const Event &ev){
 JetPFID::JetPFID(wp working_point):m_working_point(working_point){}
 
 bool JetPFID::operator()(const Jet & jet, const Event & ev) const{
-  if(ev.year == "2016v2" || ev.year == "2016v3"){
+  if (ev.year.find("2016") != std::string::npos){
     switch(m_working_point){
     case WP_LOOSE_CHS:
       return looseID2016_CHS(jet);
@@ -201,11 +201,11 @@ bool JetPFID::operator()(const Jet & jet, const Event & ev) const{
     case  WP_TIGHT_LEPVETO:
       return tightLepVetoID2016(jet);
     default:
-      throw invalid_argument("invalid working point passed to CSVBTag");
+      throw invalid_argument("invalid working point passed to JetPFID");
     }
     return false;
   }
-  if(ev.year == "2017"){
+  else if (ev.year.find("2017") != std::string::npos){
    switch(m_working_point){
     case WP_TIGHT_CHS:
       return tightID2017_CHS(jet);
@@ -217,20 +217,20 @@ bool JetPFID::operator()(const Jet & jet, const Event & ev) const{
       throw invalid_argument("invalid working point passed to JetPFID");
     }
   }
- if(ev.year == "2018"){
-   switch(m_working_point){
-   case WP_TIGHT_CHS:
-     return tightID2018_CHS(jet);
-   case WP_TIGHT_PUPPI:
-     return tightID2018_CHS(jet);//placeholder
-   case  WP_TIGHT_LEPVETO:
-     return tightLepVetoID2018(jet);
-   default:
-     throw invalid_argument("invalid working point passed to JetPFID");
-   }
- }
- if(ev.year!= "2018" && ev.year!= "2017" && ev.year!= "2016v3" && ev.year!= "2016v2")
-   cout<<"Invalid year, JetID set to False"<<endl;
+  else if (ev.year.find("2018") != std::string::npos){
+    switch(m_working_point){
+    case WP_TIGHT_CHS:
+      return tightID2018_CHS(jet);
+    case WP_TIGHT_PUPPI:
+      return tightID2018_CHS(jet);//placeholder
+    case  WP_TIGHT_LEPVETO:
+      return tightLepVetoID2018(jet);
+    default:
+      throw invalid_argument("invalid working point passed to JetPFID");
+    }
+  } else {
+    cout<<"Invalid year, JetID set to False"<<endl;
+  }
   return false;
 }
 


### PR DESCRIPTION
Better handling of multiple 2017 years. Also make DeepCSVBTag and DeepJetBTag emit a message when the year is invalid, and return false explicitly.
[only compile]