### PR TITLE
[102X] copy most of slimmed b-taggers from miniAOD

### DIFF
--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -1188,9 +1188,12 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
         if useData:
             jetcorr_list.append("L2L3Residual")
 
-        discriminators = bTagDiscriminators[:]
-        discriminators.extend(ak4btagDiscriminators)
-#        discriminators = ak4btagDiscriminators[:]
+        if year == "2016v2":
+            discriminators = bTagDiscriminators[:]
+            discriminators.extend(ak4btagDiscriminators)
+        else:
+            discriminators = ak4btagDiscriminators[:]
+
         if is_ak8 and is_topjet:
             discriminators.extend(ak8btagDiscriminators)
 


### PR DESCRIPTION
update pfDeepFlavourJetTags for all years as before and the rest only for 2016v2. For other years it should be copied from miniAOD. This should "fix" issue with changed DeepCSV for 2017 discussed in https://github.com/UHH2/UHH2/pull/1163

Note for the future: BTV POG does not proved support for b-taggers in PUPPI jets yet, therefore we store discriminators calculated in miniAOD for PUPPI jets if it's possible (i.e 2017 and 2018) and add it only for 2016v2, where it isn't calculated yet. However one should be careful with using it in 2016, since it isn't clear if the DNN training is applicable to 2016v2 data.