### PR TITLE
[102X] Remove unused or nonexistent trigger objects

### DIFF
--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -2330,12 +2330,8 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                         'hltDiPFJetAve260',
                                         'hltDiPFJetAve320',
                                         'hltDiPFJetAve400',
-                                        'hltDiPFJetAve450',
                                         'hltDiPFJetAve500',
 
-                                        'hltDiPFJetAve15ForHFJEC',
-                                        'hltDiPFJetAve25ForHFJEC',
-                                        'hltDiPFJetAve35ForHFJEC',
                                         'hltDiPFJetAve60ForHFJEC',
                                         'hltDiPFJetAve80ForHFJEC',
                                         'hltDiPFJetAve100ForHFJEC',


### PR DESCRIPTION
DiPFJetAve450 doesn't exist. The HF ones we only on for special runs and were heavily prescaled, not useful.