### PR TITLE
[102X] Puppi weights + tidying for jet constituents

### DIFF
--- a/core/include/Utils.h
+++ b/core/include/Utils.h
@@ -85,4 +85,7 @@ private:
     std::vector<std::vector<std::string> > rows;
 };
 
+/// Compare 2 floats - better than == does to floating-point issues
+bool closeFloat(float a, float b, float maxRelDiff=1E-6);
+
 }

--- a/core/include/Utils.h
+++ b/core/include/Utils.h
@@ -86,6 +86,6 @@ private:
 };
 
 /// Compare 2 floats - better than == does to floating-point issues
-bool closeFloat(float a, float b, float maxRelDiff=1E-6);
+bool closeFloat(float a, float b, float maxRelDiff=1E-6, float maxAbsDiff=1E-6);
 
 }

--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -77,12 +77,15 @@ size_t add_pfpart(const reco::Candidate & pf, vector<PFParticle> & pfparts){
        return j;
      }
    }
+   const pat::PackedCandidate* iter = dynamic_cast<const pat::PackedCandidate*>(&pf);
    PFParticle part;
    part.set_pt(pf.pt());
    part.set_eta(pf.eta());
    part.set_phi(pf.phi());
    part.set_energy(pf.energy());
    part.set_charge(pf.charge());
+   part.set_puppiWeight(iter->puppiWeight());
+   part.set_puppiWeightNoLep(iter->puppiWeightNoLep());
    PFParticle::EParticleID id = PFParticle::eX;
    reco::PFCandidate reco_pf;
    switch ( reco_pf.translatePdgIdToType(pf.pdgId()) ){

--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -3,6 +3,7 @@
 #include "FWCore/Common/interface/TriggerNames.h"
 
 #include "UHH2/core/include/root-utils.h"
+#include "UHH2/core/include/Utils.h"
 #include "UHH2/core/plugins/NtupleWriter.h"
 #include "UHH2/core/plugins/NtupleWriterJets.h"
 #include "UHH2/core/plugins/NtupleWriterLeptons.h"
@@ -12,6 +13,7 @@
 #include "DataFormats/PatCandidates/interface/PackedGenParticle.h"
 #include "DataFormats/PatCandidates/interface/Photon.h"
 #include "DataFormats/PatCandidates/interface/MET.h"
+#include "DataFormats/Math/interface/deltaR.h"
 
 #include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
@@ -21,8 +23,6 @@
 #include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h"
 #include "SimDataFormats/JetMatching/interface/JetFlavourInfo.h"
 #include "SimDataFormats/JetMatching/interface/JetFlavourInfoMatching.h"
-//#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
-//#include "DataFormats/HepMCCandidate/interface/GenParticleFwd.h"
 #include "DataFormats/Common/interface/EDCollection.h"
 
 
@@ -43,9 +43,8 @@ namespace{
  size_t add_genpart(const reco::Candidate & jetgenp, vector<GenParticle> & genparts){
    for(size_t j=0; j<genparts.size();j++){
      const GenParticle & sgenpart = genparts[j];
-     auto r = fabs(static_cast<float>(jetgenp.eta()-sgenpart.eta()))+fabs(static_cast<float>(jetgenp.phi()-sgenpart.phi()));
-     auto dpt = fabs(static_cast<float>(jetgenp.pt()-sgenpart.pt()));
-     if (r == 0.0f && dpt == 0.0f){
+     auto r = reco::deltaR(jetgenp.eta(), jetgenp.phi(), sgenpart.eta(), sgenpart.phi());
+     if (uhh2::closeFloat(r, 0.0f) && uhh2::closeFloat(jetgenp.pt(), sgenpart.pt())){
        return j;
      }
    }
@@ -73,9 +72,8 @@ size_t add_pfpart(const reco::Candidate & pf, vector<PFParticle> & pfparts){
 
    for(size_t j=0; j<pfparts.size();j++){
      const PFParticle & spfcandart = pfparts[j];
-     auto r = fabs(static_cast<float>(pf.eta()-spfcandart.eta()))+fabs(static_cast<float>(pf.phi()-spfcandart.phi()));
-     auto dpt = fabs(static_cast<float>(pf.pt()-spfcandart.pt()));
-     if (r == 0.0f && dpt == 0.0f){
+     auto r = reco::deltaR(pf.eta(), pf.phi(), spfcandart.eta(), spfcandart.phi());
+     if (uhh2::closeFloat(r, 0.0f) && uhh2::closeFloat(pf.pt(), spfcandart.pt())){
        return j;
      }
    }

--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -3,7 +3,6 @@
 #include "FWCore/Common/interface/TriggerNames.h"
 
 #include "UHH2/core/include/root-utils.h"
-#include "UHH2/core/include/Utils.h"
 #include "UHH2/core/plugins/NtupleWriter.h"
 #include "UHH2/core/plugins/NtupleWriterJets.h"
 #include "UHH2/core/plugins/NtupleWriterLeptons.h"
@@ -13,7 +12,6 @@
 #include "DataFormats/PatCandidates/interface/PackedGenParticle.h"
 #include "DataFormats/PatCandidates/interface/Photon.h"
 #include "DataFormats/PatCandidates/interface/MET.h"
-#include "DataFormats/Math/interface/deltaR.h"
 
 #include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"

--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -40,69 +40,6 @@ using namespace std;
 
 namespace{
 
- size_t add_genpart(const reco::Candidate & jetgenp, vector<GenParticle> & genparts){
-   for(size_t j=0; j<genparts.size();j++){
-     const GenParticle & sgenpart = genparts[j];
-     auto r = reco::deltaR(jetgenp.eta(), jetgenp.phi(), sgenpart.eta(), sgenpart.phi());
-     if (uhh2::closeFloat(r, 0.0f) && uhh2::closeFloat(jetgenp.pt(), sgenpart.pt())){
-       return j;
-     }
-   }
-   GenParticle genp;
-   genp.set_charge(jetgenp.charge());
-   genp.set_pt(jetgenp.p4().pt());
-   genp.set_eta(jetgenp.p4().eta());
-   genp.set_phi(jetgenp.p4().phi());
-   genp.set_energy(jetgenp.p4().E());
-   genp.set_index(genparts.size());
-   genp.set_status(jetgenp.status());
-   genp.set_pdgId(jetgenp.pdgId());
-
-   genp.set_mother1(-1);
-   genp.set_mother2(-1);
-   genp.set_daughter1(-1);
-   genp.set_daughter2(-1);
-  
-   genparts.push_back(genp);
-   return genparts.size()-1;
-}
-
-
-size_t add_pfpart(const reco::Candidate & pf, vector<PFParticle> & pfparts){
-
-   for(size_t j=0; j<pfparts.size();j++){
-     const PFParticle & spfcandart = pfparts[j];
-     auto r = reco::deltaR(pf.eta(), pf.phi(), spfcandart.eta(), spfcandart.phi());
-     if (uhh2::closeFloat(r, 0.0f) && uhh2::closeFloat(pf.pt(), spfcandart.pt())){
-       return j;
-     }
-   }
-   const pat::PackedCandidate* iter = dynamic_cast<const pat::PackedCandidate*>(&pf);
-   PFParticle part;
-   part.set_pt(pf.pt());
-   part.set_eta(pf.eta());
-   part.set_phi(pf.phi());
-   part.set_energy(pf.energy());
-   part.set_charge(pf.charge());
-   part.set_puppiWeight(iter->puppiWeight());
-   part.set_puppiWeightNoLep(iter->puppiWeightNoLep());
-   PFParticle::EParticleID id = PFParticle::eX;
-   reco::PFCandidate reco_pf;
-   switch ( reco_pf.translatePdgIdToType(pf.pdgId()) ){
-   case reco::PFCandidate::X : id = PFParticle::eX; break;
-   case reco::PFCandidate::h : id = PFParticle::eH; break;
-   case reco::PFCandidate::e : id = PFParticle::eE; break;
-   case reco::PFCandidate::mu : id = PFParticle::eMu; break;
-   case reco::PFCandidate::gamma : id = PFParticle::eGamma; break;
-   case reco::PFCandidate::h0 : id = PFParticle::eH0; break;
-   case reco::PFCandidate::h_HF : id = PFParticle::eH_HF; break;
-   case reco::PFCandidate::egamma_HF : id = PFParticle::eEgamma_HF; break;
-   }
-   part.set_particleID(id);
-
-   pfparts.push_back(part);
-   return pfparts.size()-1;
-}
 
 template<typename T>
 void branch(TTree * tree, const char * bname, T t){
@@ -1416,7 +1353,7 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 	if(storePFparts){
 	  const auto& jet_daughter_ptrs = patJet.daughterPtrVector();
 	  for(const auto & daughter_p : jet_daughter_ptrs){
-	    size_t pfparticles_index = add_pfpart(*daughter_p,*event->pfparticles);
+	    size_t pfparticles_index = uhh2::add_pfpart(*daughter_p,*event->pfparticles);
 	    thisJet.add_pfcand_index(pfparticles_index);
 	  }
 	}
@@ -1450,7 +1387,7 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 	  if(storePFparts){
 	    const auto& jet_daughter_ptrs = subItr->daughterPtrVector();
 	    for(const auto & daughter_p : jet_daughter_ptrs){
-	      size_t pfparticles_index = add_pfpart(*daughter_p,*event->pfparticles);
+	      size_t pfparticles_index = uhh2::add_pfpart(*daughter_p,*event->pfparticles);
 	      subjet.add_pfcand_index(pfparticles_index);
 	    }
 	  }
@@ -1500,7 +1437,7 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 	if(storePFparts){
 	  const auto& jet_daughter_ptrs = patJet.daughterPtrVector();
 	  for(const auto & daughter_p : jet_daughter_ptrs){
-	    size_t pfparticles_index = add_pfpart(*daughter_p,*event->pfparticles);
+	    size_t pfparticles_index = uhh2::add_pfpart(*daughter_p,*event->pfparticles);
 	    thisJet.add_pfcand_index(pfparticles_index);
 	  }
 	}
@@ -1534,7 +1471,7 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 	  if(storePFparts){
 	    const auto& jet_daughter_ptrs = subItr->daughterPtrVector();
 	    for(const auto & daughter_p : jet_daughter_ptrs){
-	      size_t pfparticles_index = add_pfpart(*daughter_p,*event->pfparticles);
+	      size_t pfparticles_index = uhh2::add_pfpart(*daughter_p,*event->pfparticles);
 	      subjet.add_pfcand_index(pfparticles_index);
 	    }
 	  }
@@ -1584,7 +1521,7 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 	if(storePFparts){
 	  const auto& jet_daughter_ptrs = patJet.daughterPtrVector();
 	  for(const auto & daughter_p : jet_daughter_ptrs){
-	    size_t pfparticles_index = add_pfpart(*daughter_p,*event->pfparticles);
+	    size_t pfparticles_index = uhh2::add_pfpart(*daughter_p,*event->pfparticles);
 	    thisJet.add_pfcand_index(pfparticles_index);
 	  }
 	}
@@ -1618,7 +1555,7 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 	  if(storePFparts){
 	    const auto& jet_daughter_ptrs = subItr->daughterPtrVector();
 	    for(const auto & daughter_p : jet_daughter_ptrs){
-	      size_t pfparticles_index = add_pfpart(*daughter_p,*event->pfparticles);
+	      size_t pfparticles_index = uhh2::add_pfpart(*daughter_p,*event->pfparticles);
 	      subjet.add_pfcand_index(pfparticles_index);
 	    }
 	  }
@@ -1822,7 +1759,7 @@ void NtupleWriter::fill_geninfo_patjet(const pat::Jet& pat_genjet, GenJet& genje
    const reco::Candidate* constituent =  pat_genjet.daughter(l);
    jet_charge += constituent->charge();
    if(add_genparts){
-     size_t genparticles_index = add_genpart(*constituent, *event->genparticles);
+     size_t genparticles_index = uhh2::add_genpart(*constituent, *event->genparticles);
      genjet.add_genparticles_index(genparticles_index);
    }
 

--- a/core/plugins/NtupleWriterJets.cxx
+++ b/core/plugins/NtupleWriterJets.cxx
@@ -1,5 +1,6 @@
 #include "UHH2/core/plugins/NtupleWriterJets.h"
 #include "UHH2/core/include/AnalysisModule.h"
+#include "UHH2/core/include/Utils.h"
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -29,18 +30,18 @@
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
 #include "RecoBTag/SecondaryVertex/interface/TrackKinematics.h"
 #include "DataFormats/BTauReco/interface/BoostedDoubleSVTagInfo.h"
+#include "DataFormats/Math/interface/deltaR.h"
+
 using namespace uhh2;
 using namespace std;
 
 bool btag_warning;
 
 size_t add_pfpart(const reco::Candidate & pf, vector<PFParticle> & pfparts){
-
    for(size_t j=0; j<pfparts.size();j++){
      const PFParticle & spfcandart = pfparts[j];
-     auto r = fabs(static_cast<float>(pf.eta()-spfcandart.eta()))+fabs(static_cast<float>(pf.phi()-spfcandart.phi()));
-     auto dpt = fabs(static_cast<float>(pf.pt()-spfcandart.pt()));
-     if (r == 0.0f && dpt == 0.0f){
+     auto r = reco::deltaR(pf.eta(), pf.phi(), spfcandart.eta(), spfcandart.phi());
+     if (closeFloat(r, 0.0f) && closeFloat(pf.pt(), spfcandart.pt())){
        return j;
      }
    }
@@ -1547,9 +1548,8 @@ void NtupleWriterGenTopJets::process(const edm::Event & event, uhh2::Event & uev
  size_t NtupleWriterGenTopJets::add_genpart(const reco::Candidate & jetgenp, vector<GenParticle> & genparts) {
    for(size_t j=0; j<genparts.size();j++){
      const GenParticle & sgenpart = genparts[j];
-     auto r = fabs(static_cast<float>(jetgenp.eta()-sgenpart.eta()))+fabs(static_cast<float>(jetgenp.phi()-sgenpart.phi()));
-     auto dpt = fabs(static_cast<float>(jetgenp.pt()-sgenpart.pt()));
-     if (r == 0.0f && dpt == 0.0f){
+     auto r = reco::deltaR(jetgenp.eta(), jetgenp.phi(), sgenpart.eta(), sgenpart.phi());
+     if (closeFloat(r, 0.0f) && closeFloat(jetgenp.pt(), sgenpart.pt())){
        return j;
      }
    }

--- a/core/plugins/NtupleWriterJets.cxx
+++ b/core/plugins/NtupleWriterJets.cxx
@@ -45,12 +45,15 @@ size_t add_pfpart(const reco::Candidate & pf, vector<PFParticle> & pfparts){
        return j;
      }
    }
+   const pat::PackedCandidate* iter = dynamic_cast<const pat::PackedCandidate*>(&pf);
    PFParticle part;
    part.set_pt(pf.pt());
    part.set_eta(pf.eta());
    part.set_phi(pf.phi());
    part.set_energy(pf.energy());
    part.set_charge(pf.charge());
+   part.set_puppiWeight(iter->puppiWeight());
+   part.set_puppiWeightNoLep(iter->puppiWeightNoLep());
    PFParticle::EParticleID id = PFParticle::eX;
    reco::PFCandidate reco_pf;
    switch ( reco_pf.translatePdgIdToType(pf.pdgId()) ){

--- a/core/plugins/NtupleWriterJets.cxx
+++ b/core/plugins/NtupleWriterJets.cxx
@@ -37,7 +37,34 @@ using namespace std;
 
 bool btag_warning;
 
-size_t add_pfpart(const reco::Candidate & pf, vector<PFParticle> & pfparts){
+size_t uhh2::add_genpart(const reco::Candidate & jetgenp, vector<GenParticle> & genparts) {
+   for(size_t j=0; j<genparts.size();j++){
+     const GenParticle & sgenpart = genparts[j];
+     auto r = reco::deltaR(jetgenp.eta(), jetgenp.phi(), sgenpart.eta(), sgenpart.phi());
+     if (closeFloat(r, 0.0f) && closeFloat(jetgenp.pt(), sgenpart.pt())){
+       return j;
+     }
+   }
+   GenParticle genp;
+   genp.set_charge(jetgenp.charge());
+   genp.set_pt(jetgenp.p4().pt());
+   genp.set_eta(jetgenp.p4().eta());
+   genp.set_phi(jetgenp.p4().phi());
+   genp.set_energy(jetgenp.p4().E());
+   genp.set_index(genparts.size());
+   genp.set_status(jetgenp.status());
+   genp.set_pdgId(jetgenp.pdgId());
+
+   genp.set_mother1(-1);
+   genp.set_mother2(-1);
+   genp.set_daughter1(-1);
+   genp.set_daughter2(-1);
+
+   genparts.push_back(genp);
+   return genparts.size()-1;
+}
+
+size_t uhh2::add_pfpart(const reco::Candidate & pf, vector<PFParticle> & pfparts){
    for(size_t j=0; j<pfparts.size();j++){
      const PFParticle & spfcandart = pfparts[j];
      auto r = reco::deltaR(pf.eta(), pf.phi(), spfcandart.eta(), spfcandart.phi());
@@ -1546,33 +1573,6 @@ void NtupleWriterGenTopJets::process(const edm::Event & event, uhh2::Event & uev
   if(gentopjets_handle){
     EventAccess_::set_unmanaged(uevent, *gentopjets_handle, &uevent.get(handle));
   }
-}
-
- size_t NtupleWriterGenTopJets::add_genpart(const reco::Candidate & jetgenp, vector<GenParticle> & genparts) {
-   for(size_t j=0; j<genparts.size();j++){
-     const GenParticle & sgenpart = genparts[j];
-     auto r = reco::deltaR(jetgenp.eta(), jetgenp.phi(), sgenpart.eta(), sgenpart.phi());
-     if (closeFloat(r, 0.0f) && closeFloat(jetgenp.pt(), sgenpart.pt())){
-       return j;
-     }
-   }
-   GenParticle genp;
-   genp.set_charge(jetgenp.charge());
-   genp.set_pt(jetgenp.p4().pt());
-   genp.set_eta(jetgenp.p4().eta());
-   genp.set_phi(jetgenp.p4().phi());
-   genp.set_energy(jetgenp.p4().E());
-   genp.set_index(genparts.size());
-   genp.set_status(jetgenp.status());
-   genp.set_pdgId(jetgenp.pdgId());
-
-   genp.set_mother1(-1);
-   genp.set_mother2(-1);
-   genp.set_daughter1(-1);
-   genp.set_daughter2(-1);
-
-   genparts.push_back(genp);
-   return genparts.size()-1;
 }
 
 void NtupleWriterGenTopJets::fill_genjet_info(uhh2::Event & event, const reco::Candidate & reco_genjet, GenJet & genjet, bool add_genparts) {

--- a/core/plugins/NtupleWriterJets.h
+++ b/core/plugins/NtupleWriterJets.h
@@ -16,9 +16,14 @@
 #include "TrackingTools/IPTools/interface/IPTools.h"
 #include "fastjet/PseudoJet.hh"
 #include "RecoBTag/SecondaryVertex/interface/TrackKinematics.h"
+
+
 class GenericMVAJetTagComputer;
 
 namespace uhh2 {
+
+size_t add_genpart(const reco::Candidate & jetgenp, std::vector<GenParticle> & genparts);
+size_t add_pfpart(const reco::Candidate & pf, std::vector<PFParticle> & pfparts);
 
 class NtupleWriterJets: public NtupleWriterModule {
 public:
@@ -120,7 +125,6 @@ public:
 
     explicit NtupleWriterGenTopJets(Config & cfg, bool set_jets_member, unsigned int NGenJetwConstituents, double MinPtJetwConstituents);
     static void fill_genjet_info(uhh2::Event & event, const reco::Candidate & reco_genjet, GenJet & jet, bool add_genparts=false);
-    static size_t add_genpart(const reco::Candidate & jetgenp, std::vector<GenParticle> & genparts);
     virtual void process(const edm::Event &, uhh2::Event &,  const edm::EventSetup&);
     virtual ~NtupleWriterGenTopJets();
 

--- a/core/src/Utils.cxx
+++ b/core/src/Utils.cxx
@@ -168,6 +168,6 @@ void TableOutput::add_row(const vector<string> & row){
 }
 
 
-bool uhh2::closeFloat(float a, float b, float maxRelDiff) {
-  return fabs(a-b) <= (maxRelDiff * max(fabs(a), fabs(b)));
+bool uhh2::closeFloat(float a, float b, float maxRelDiff, float maxAbsDiff) {
+  return fabs(a-b) <= max(maxRelDiff * max(fabs(a), fabs(b)), maxAbsDiff);
 }

--- a/core/src/Utils.cxx
+++ b/core/src/Utils.cxx
@@ -168,3 +168,6 @@ void TableOutput::add_row(const vector<string> & row){
 }
 
 
+bool uhh2::closeFloat(float a, float b, float maxRelDiff) {
+  return fabs(a-b) <= (maxRelDiff * max(fabs(a), fabs(b)));
+}


### PR DESCRIPTION
Store PUPPI weights for jet constituents. Also tidied up the duplicate methods used for (gen)jet constituent storage, now only one copy in NtupleWriterJets.cxx.

Also improved on constituent check - previous checked deltaR and deltapT == 0f, which often fails for floats. Now checks relative difference is < 1E-6 OR absolute difference is < 1E-6, whichever is larger. The latter absolute diff is necessary for deltaR == 0 comparison, since both the absolute and relative differences are ~1E-7 or so, but the relative diff condition must be < 1E-13, which is never satisfied.

This should hopefully shave off some duplicates when storing constituents.