### PR TITLE
[102X] cleanup HOTVR headers from XCone producers

### DIFF
--- a/core/plugins/GenHOTVRProducer.cc
+++ b/core/plugins/GenHOTVRProducer.cc
@@ -49,6 +49,7 @@
 
 using namespace fastjet;
 using namespace contrib;
+using namespace std;
 
 //
 // class declaration

--- a/core/plugins/GenXConeProducer.cc
+++ b/core/plugins/GenXConeProducer.cc
@@ -41,8 +41,6 @@
 
 #include "fastjet/ClusterSequence.hh"
 #include "fastjet/ClusterSequenceArea.hh"
-#include "fastjet/contrib/HOTVR.hh"
-#include "fastjet/contrib/HOTVRinfo.hh"
 #include "fastjet/contrib/Nsubjettiness.hh"
 #include "fastjet/contrib/XConePlugin.hh"
 
@@ -50,6 +48,7 @@
 
 using namespace fastjet;
 using namespace contrib;
+using namespace std;
 
 //
 // class declaration

--- a/core/plugins/HOTVRProducer.cc
+++ b/core/plugins/HOTVRProducer.cc
@@ -51,6 +51,7 @@
 
 using namespace fastjet;
 using namespace contrib;
+using namespace std;
 
 //
 // class declaration

--- a/core/plugins/XConeProducer.cc
+++ b/core/plugins/XConeProducer.cc
@@ -40,8 +40,6 @@
 #include "RecoJets/JetProducers/interface/JetSpecific.h"
 #include "fastjet/ClusterSequence.hh"
 #include "fastjet/ClusterSequenceArea.hh"
-#include "fastjet/contrib/HOTVR.hh"
-#include "fastjet/contrib/HOTVRinfo.hh"
 #include "fastjet/contrib/Nsubjettiness.hh"
 #include "fastjet/contrib/XConePlugin.hh"
 #include "fastjet/contrib/SoftDrop.hh"
@@ -50,6 +48,7 @@
 
 using namespace fastjet;
 using namespace contrib;
+using namespace std;
 
 //
 // class declaration


### PR DESCRIPTION
Dunno why they were in there, not necessary. Also had to add in std namespace because the HOTVR.hh had it in (see https://github.com/UHH2/HOTVRContrib/pull/2)

[only compile]