### PR TITLE
[102X] Move pfparticle storage earlier to avoid double filling

### DIFF
--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -732,8 +732,44 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
    print_times(timer, "rho");
 
-   if(doPFJetConstituents || doPFTopJetConstituents || doPFxconeJetConstituents || doPFhotvrJetConstituents || doPFxconeDijetJetConstituents){
-     event->pfparticles->clear();
+   // ------------- PF constituents --------------
+   // must do before handling jet collections, since they may store constituents,
+   // which lookup against event->pfparticles
+   if (event->pfparticles != nullptr) event->pfparticles->clear();
+   if(doAllPFParticles){
+     edm::Handle<vector<pat::PackedCandidate> > pfColl_handle;
+     iEvent.getByToken(pf_collection_token, pfColl_handle);
+
+     const std::vector<pat::PackedCandidate>& pf_coll = *(pfColl_handle.product());
+
+     for ( unsigned int j = 0; j<pf_coll.size(); ++j){
+       const pat::PackedCandidate pf = pf_coll.at(j);
+
+       PFParticle part;
+       part.set_pt(pf.pt());
+       part.set_eta(pf.eta());
+       part.set_phi(pf.phi());
+       part.set_energy(pf.energy());
+       part.set_charge(pf.charge());
+       part.set_puppiWeight(pf.puppiWeight());
+       part.set_puppiWeightNoLep(pf.puppiWeightNoLep());
+       PFParticle::EParticleID id = PFParticle::eX;
+       reco::PFCandidate reco_pf;
+       switch ( reco_pf.translatePdgIdToType(pf.pdgId()) ){
+       case reco::PFCandidate::X : id = PFParticle::eX; break;
+       case reco::PFCandidate::h : id = PFParticle::eH; break;
+       case reco::PFCandidate::e : id = PFParticle::eE; break;
+       case reco::PFCandidate::mu : id = PFParticle::eMu; break;
+       case reco::PFCandidate::gamma : id = PFParticle::eGamma; break;
+       case reco::PFCandidate::h0 : id = PFParticle::eH0; break;
+       case reco::PFCandidate::h_HF : id = PFParticle::eH_HF; break;
+       case reco::PFCandidate::egamma_HF : id = PFParticle::eEgamma_HF; break;
+       }
+       part.set_particleID(id);
+
+       event->pfparticles->push_back(part);
+     }
+
    }
 
    // ------------- primary vertices and beamspot  -------------
@@ -1046,48 +1082,6 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
    }
 
    print_times(timer, "met");
-
-   // ------------- PF constituents --------------
-  
-   if(doAllPFParticles){
-     if(!doPFJetConstituents && !doPFTopJetConstituents && !doPFxconeJetConstituents && !doPFhotvrJetConstituents && !doPFxconeDijetJetConstituents) event->pfparticles->clear();
-     edm::Handle<vector<pat::PackedCandidate> > pfColl_handle;
-     iEvent.getByToken(pf_collection_token, pfColl_handle);
-
-     const std::vector<pat::PackedCandidate>& pf_coll = *(pfColl_handle.product());
-
-     for ( unsigned int j = 0; j<pf_coll.size(); ++j){
-       const pat::PackedCandidate pf = pf_coll.at(j);
-
-       PFParticle part;
-       part.set_pt(pf.pt());
-       part.set_eta(pf.eta());
-       part.set_phi(pf.phi());
-       part.set_energy(pf.energy());
-       part.set_charge(pf.charge());
-       part.set_puppiWeight(pf.puppiWeight());
-       part.set_puppiWeightNoLep(pf.puppiWeightNoLep());
-       PFParticle::EParticleID id = PFParticle::eX;
-       reco::PFCandidate reco_pf;
-       switch ( reco_pf.translatePdgIdToType(pf.pdgId()) ){
-       case reco::PFCandidate::X : id = PFParticle::eX; break;
-       case reco::PFCandidate::h : id = PFParticle::eH; break;
-       case reco::PFCandidate::e : id = PFParticle::eE; break;
-       case reco::PFCandidate::mu : id = PFParticle::eMu; break;
-       case reco::PFCandidate::gamma : id = PFParticle::eGamma; break;
-       case reco::PFCandidate::h0 : id = PFParticle::eH0; break;
-       case reco::PFCandidate::h_HF : id = PFParticle::eH_HF; break;
-       case reco::PFCandidate::egamma_HF : id = PFParticle::eEgamma_HF; break;
-       }
-       part.set_particleID(id);
-
-       event->pfparticles->push_back(part);
-     }
-
-   }
-
-  
-
 
    // ------------- trigger -------------
 


### PR DESCRIPTION
Move pfparticle storage to before we run through all the jet modules.

Before, if you enabled `doAllPFParticles` and you also stored jet constituents, it would store all the pfparticles again after the jets' constituents as no duplicate checking. This way we fill it up first, then do the duplicate checking in `add_pfpart()`.

Unfortunately we don't test with `doAllPFParticles = True`, so the change won't be visible. Maybe need to add a test in with it enabled? 