### PR TITLE
[102X] Rekey PUPPI jet constituents

### DIFF
--- a/core/plugins/RekeyJets.cc
+++ b/core/plugins/RekeyJets.cc
@@ -1,0 +1,137 @@
+// -*- C++ -*-
+//
+// Package:    UHH2/RekeyJets
+// Class:      RekeyJets
+//
+/**\class RekeyJets RekeyJets.cc UHH2/RekeyJets/plugins/RekeyJets.cc
+
+ Description: Replace duaghters of jet with those matched by key from another collection
+  e.g. replace puppi jet daughters with equivalent particles from packedPFCandidates
+
+*/
+//
+// Original Author:  Robin Aggleton
+//         Created:  Tue, 23 Jan 2018 13:27:50 GMT
+//
+//
+
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include "DataFormats/PatCandidates/interface/Jet.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "DataFormats/Common/interface/RefToPtr.h"
+
+#include "vector"
+
+using std::cout;
+using std::endl;
+
+
+//
+// class declaration
+//
+
+class RekeyJets : public edm::stream::EDProducer<> {
+  public:
+    explicit RekeyJets(const edm::ParameterSet&);
+    ~RekeyJets();
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  private:
+    virtual void beginStream(edm::StreamID) override;
+    virtual void produce(edm::Event&, const edm::EventSetup&) override;
+    virtual void endStream() override;
+
+    edm::EDGetTokenT<pat::JetCollection> srcJetToken_;
+    edm::EDGetTokenT<edm::View<reco::Candidate>> srcCandToken_;
+};
+
+//
+// constructors and destructor
+//
+RekeyJets::RekeyJets(const edm::ParameterSet& iConfig):
+  srcJetToken_(consumes<pat::JetCollection>(iConfig.getParameter<edm::InputTag>("jetSrc"))),
+  srcCandToken_(consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("candidateSrc")))
+{
+  produces<pat::JetCollection>();
+}
+
+
+RekeyJets::~RekeyJets()
+{
+
+  // do anything here that needs to be done at destruction time
+  // (e.g. close files, deallocate resources etc.)
+
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+void
+RekeyJets::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+  edm::Handle<pat::JetCollection> jetHandle;
+  iEvent.getByToken(srcJetToken_, jetHandle);
+
+  edm::Handle<edm::View<reco::Candidate>> candHandle;
+  iEvent.getByToken(srcCandToken_, candHandle);
+
+  std::unique_ptr<pat::JetCollection> outJets = std::make_unique<pat::JetCollection>();
+
+  for (const auto & jetItr : *jetHandle) {
+    pat::Jet newJet(jetItr);
+    // setup daughters of new jet to be the equivalent ones from the candidateSrc
+    newJet.clearDaughters();
+    for (const auto & dauItr : jetItr.daughterPtrVector()) {
+      const unsigned long key = dauItr.key();
+      edm::Ptr<reco::Candidate> newDau = candHandle->ptrAt(key);
+      newJet.addDaughter(newDau);
+    }
+    outJets->push_back(newJet);
+  }
+
+  iEvent.put(std::move(outJets));
+
+}
+
+
+// ------------ method called once each stream before processing any runs, lumis or events  ------------
+void
+RekeyJets::beginStream(edm::StreamID)
+{
+}
+
+// ------------ method called once each stream after processing all runs, lumis and events  ------------
+void
+RekeyJets::endStream() {
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+RekeyJets::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("jetSrc");
+  desc.add<edm::InputTag>("candidateSrc");
+  descriptions.add("rekeyJets", desc);
+}
+
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(RekeyJets);

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -1393,7 +1393,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
     task.add(process.hotvrGen)
 
     usePseudoXCone = cms.bool(True)
-    process.xconePuppi = cms.EDProducer("XConeProducer",
+    process.xconePuppiOrigDau = cms.EDProducer("XConeProducer",
         src=cms.InputTag("puppi"),
         usePseudoXCone=usePseudoXCone,  # use PseudoXCone (faster) or XCone
         NJets = cms.uint32(2),          # number of fatjets
@@ -1403,6 +1403,12 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
         RSubJets = cms.double(0.4),     # cone radius of subjetSrc
         BetaSubJets = cms.double(2.0),  # conical mesure for subjets
         printWarning = cms.bool(False)  # set True if you want warnings about missing jets
+    )
+    task.add(process.xconePuppiOrigDau)
+
+    process.xconePuppi = cms.EDProducer("RekeyJets",
+        jetSrc=cms.InputTag("xconePuppiOrigDau"),
+        candidateSrc=cms.InputTag("packedPFCandidates")
     )
     task.add(process.xconePuppi)
 

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -1376,9 +1376,15 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
     ###############################################
     # HOTVR & XCONE
     #
-    process.hotvrPuppi = cms.EDProducer("HOTVRProducer",
+    process.hotvrPuppiOrigDau = cms.EDProducer("HOTVRProducer",
                                         src=cms.InputTag("puppi")
                                         )
+    task.add(process.hotvrPuppiOrigDau)
+
+    process.hotvrPuppi = cms.EDProducer("RekeyJets",
+        jetSrc=cms.InputTag("hotvrPuppiOrigDau"),
+        candidateSrc=cms.InputTag("packedPFCandidates")
+    )
     task.add(process.hotvrPuppi)
 
     process.hotvrGen = cms.EDProducer("GenHOTVRProducer",

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -1488,7 +1488,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                              BetaSubJets = cms.double(2.0)   # conical mesure for subjets
                                              )
     task.add(process.xconeCHS2jets04)
-    process.xconePUPPI4jets04 = cms.EDProducer("XConeProducer",
+    process.xconePUPPI4jets04OrigDau = cms.EDProducer("XConeProducer",
                                              src=cms.InputTag("puppi"),
                                              usePseudoXCone=usePseudoXCone,  # use PseudoXCone (faster) or XCone
                                              NJets = cms.uint32(4),          # number of fatjets
@@ -1498,9 +1498,9 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                              RSubJets = cms.double(0.2),     # cone radius of subjetSrc
                                              BetaSubJets = cms.double(2.0)   # conical mesure for subjets
                                              )
-    task.add(process.xconePUPPI4jets04)
+    task.add(process.xconePUPPI4jets04OrigDau)
 
-    process.xconePUPPI3jets04 = cms.EDProducer("XConeProducer",
+    process.xconePUPPI3jets04OrigDau = cms.EDProducer("XConeProducer",
                                              src=cms.InputTag("puppi"),
                                              usePseudoXCone=usePseudoXCone,  # use PseudoXCone (faster) or XCone
                                              NJets = cms.uint32(3),          # number of fatjets
@@ -1510,9 +1510,9 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                              RSubJets = cms.double(0.2),     # cone radius of subjetSrc
                                              BetaSubJets = cms.double(2.0)   # conical mesure for subjets
                                              )
-    task.add(process.xconePUPPI3jets04)
+    task.add(process.xconePUPPI3jets04OrigDau)
 
-    process.xconePUPPI2jets04 = cms.EDProducer("XConeProducer",
+    process.xconePUPPI2jets04OrigDau = cms.EDProducer("XConeProducer",
                                              src=cms.InputTag("puppi"),
                                              usePseudoXCone=usePseudoXCone,  # use PseudoXCone (faster) or XCone
                                              NJets = cms.uint32(2),          # number of fatjets
@@ -1522,7 +1522,17 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                              RSubJets = cms.double(0.2),     # cone radius of subjetSrc
                                              BetaSubJets = cms.double(2.0)   # conical mesure for subjets
                                              )
-    task.add(process.xconePUPPI2jets04)
+    task.add(process.xconePUPPI2jets04OrigDau)
+
+    # Rekey XCONE R=0.4 puppi jets to replace daughters
+    for njets in [2, 3, 4]:
+        new_module = cms.EDProducer("RekeyJets",
+            jetSrc=cms.InputTag("xconePUPPI%djets04OrigDau" % (njets)),
+            candidateSrc=cms.InputTag("packedPFCandidates")
+        )
+        new_name = "xconePUPPI%djets04" % (njets)
+        setattr(process, new_name, new_module)
+        task.add(getattr(process, new_name))
 
 
     process.genXCone4jets04 = cms.EDProducer("GenXConeProducer",
@@ -1607,7 +1617,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                              )
     task.add(process.xconeCHS2jets08)
 
-    process.xconePUPPI4jets08 = cms.EDProducer("XConeProducer",
+    process.xconePUPPI4jets08OrigDau = cms.EDProducer("XConeProducer",
                                              src=cms.InputTag("puppi"),
                                              usePseudoXCone=usePseudoXCone,  # use PseudoXCone (faster) or XCone
                                              NJets = cms.uint32(4),          # number of fatjets
@@ -1617,9 +1627,9 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                              RSubJets = cms.double(0.4),     # cone radius of subjetSrc
                                              BetaSubJets = cms.double(2.0)   # conical mesure for subjets
                                              )
-    task.add(process.xconePUPPI4jets08)
+    task.add(process.xconePUPPI4jets08OrigDau)
 
-    process.xconePUPPI3jets08 = cms.EDProducer("XConeProducer",
+    process.xconePUPPI3jets08OrigDau = cms.EDProducer("XConeProducer",
                                              src=cms.InputTag("puppi"),
                                              usePseudoXCone=usePseudoXCone,  # use PseudoXCone (faster) or XCone
                                              NJets = cms.uint32(3),          # number of fatjets
@@ -1629,9 +1639,9 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                              RSubJets = cms.double(0.4),     # cone radius of subjetSrc
                                              BetaSubJets = cms.double(2.0)   # conical mesure for subjets
                                              )
-    task.add(process.xconePUPPI3jets08)
+    task.add(process.xconePUPPI3jets08OrigDau)
 
-    process.xconePUPPI2jets08 = cms.EDProducer("XConeProducer",
+    process.xconePUPPI2jets08OrigDau = cms.EDProducer("XConeProducer",
                                              src=cms.InputTag("puppi"),
                                              usePseudoXCone=usePseudoXCone,  # use PseudoXCone (faster) or XCone
                                              NJets = cms.uint32(2),          # number of fatjets
@@ -1641,7 +1651,17 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                              RSubJets = cms.double(0.4),     # cone radius of subjetSrc
                                              BetaSubJets = cms.double(2.0)   # conical mesure for subjets
                                              )
-    task.add(process.xconePUPPI2jets08)
+    task.add(process.xconePUPPI2jets08OrigDau)
+
+    # Rekey XCONE R=0.8 puppi jets to replace daughters
+    for njets in [2, 3, 4]:
+        new_module = cms.EDProducer("RekeyJets",
+            jetSrc=cms.InputTag("xconePUPPI%djets08OrigDau" % (njets)),
+            candidateSrc=cms.InputTag("packedPFCandidates")
+        )
+        new_name = "xconePUPPI%djets08" % (njets)
+        setattr(process, new_name, new_module)
+        task.add(getattr(process, new_name))
 
     process.genXCone4jets08 = cms.EDProducer("GenXConeProducer",
                                              src=cms.InputTag("packedGenParticlesForJetsNoNu"),

--- a/examples/config/ExampleJetConstituents.xml
+++ b/examples/config/ExampleJetConstituents.xml
@@ -8,15 +8,8 @@
 
    <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="./" PostFix="" TargetLumi="1" >
 
-<!--          <In FileName="../../core/python/Ntuple.root" Lumi="0.0"/> -->
-<!--        <InputData Lumi="1" NEventsMax="-1" Type="DATA" Version="JetConstit" Cacheable="False">
-            <In FileName="/nfs/dust/cms/user/karavdia/RunII_102X_v1_TEST/JetHT2018/Run2018A_all/DATA_JetHT_Run2018A_4399_Ntuple.root" Lumi="0.0"/>
-            <In FileName="/nfs/dust/cms/user/karavdia/RunII_102X_v1_TEST/JetHT2018/Run2018A_all/DATA_JetHT_Run2018A_7091_Ntuple.root" Lumi="0.0"/> 
-            <InputTree Name="AnalysisTree" />
-        </InputData>
--->
         <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="JetConstit" Cacheable="False">
-            <In FileName="/nfs/dust/cms/user/karavdia/CMSSW_10_2_10/src/UHH2/core/python/Ntuple_2018_dijet.root" Lumi="0.0"/>
+            <In FileName="Ntuple.root" Lumi="0.0"/>
             <InputTree Name="AnalysisTree" />
         </InputData>
 
@@ -24,14 +17,19 @@
 
         <UserConfig>
             <!-- define which collections to read from the input. Only specify what you need to save I/O time -->
-            <Item Name="JetCollection" Value="jetsAk4CHS" />
+            <!-- <Item Name="JetCollection" Value="jetsAk4CHS" /> -->
+            <Item Name="JetCollection" Value="jetsAk4Puppi" />
             <!-- <Item Name="JetCollection" Value="jetsAk8Puppi" /> -->
+            <Item Name="usePuppiWeightJets" Value="false" />
+
             <Item Name="TopJetCollection" Value="jetsAk8PuppiSubstructure_SoftDropPuppi" />
             <!-- <Item Name="TopJetCollection" Value="jetsAk8CHSSubstructure_SoftDropCHS" /> -->
+            <Item Name="usePuppiWeightTopJets" Value="true" />
+
             <!-- <Item Name="GenJetCollection" Value="slimmedGenJets" /> -->
-            <Item Name="GenJetCollection" Value="slimmedGenJets" />
-            <!-- <Item Name="GenTopJetCollection" Value="ak8GenJetsFat" /> -->
-            <Item Name="GenTopJetCollection" Value="genjetsAk8SubstructureSoftDrop" />
+            <!-- <Item Name="GenJetCollection" Value="slimmedGenJets" /> -->
+
+            <!-- <Item Name="GenTopJetCollection" Value="genjetsAk8SubstructureSoftDrop" /> -->
 
             <Item Name="PFParticleCollection" Value="PFParticles" />
             <Item Name="GenParticleCollection" Value="GenParticles" /> 


### PR DESCRIPTION
This "rekeys" the constituents of PUPPI jets to replace them with their equivalent from the packedPFCandidates (this is what is done for slimmedJetsPuppi in MiniAOD). This way, when we come to store the jet constituents, we do not end up storing "duplicate" PUPPI & PF particles that differ only in whether they have the PUPPI weight applied. Since we now also store PUPPI weight (#1190) the user can still do things with the jet constituents, so long as they remember to use the PUPPI weight.

Have done for jetsAk8Puppi, jetsAk8PuppiSubstructure_SoftDropPuppi, xconePuppi, hotvrPuppi, and all the xconeDijetPuppi collections. 

- Pros: now uniform behaviour across all PUPPI jet collections, save space by not duplicating particles.
- Cons: now people have to choose to apply PUPPI weight or not.

Technical note: for the TopJets, I have only rekeyed the subjets and the ungroomed fatjet (and actually I rekey CHS as well inside `add_fatjet_subjets()`). This is because these are the only jet constituent we care about. Additionally, I have left re-keying as late as possible so that e.g. b-tagging calculations are not affected.

NB in MINIAOD production this is done by either `PATJetSlimmer` or `JetSubstructurePacker`. These require a map to PF particles, which we don't have, so I had to write a small producer to handle this instead. On the plus side, it actually allows rekeying from PUPPI to PF, or vice-versa, incase we ever want to convert the slimmedJetsPuppi constituents to PUPPI particles.

NB2 also updated ExampleJetConstituents to add in flags to apply PUPPI weights or not.