### PR TITLE
[102X] Add rekey options to HOTVR & XCone producers, use it on PUPPI jets

### DIFF
--- a/core/plugins/RekeyJets.cc
+++ b/core/plugins/RekeyJets.cc
@@ -5,8 +5,12 @@
 //
 /**\class RekeyJets RekeyJets.cc UHH2/RekeyJets/plugins/RekeyJets.cc
 
- Description: Replace duaghters of jet with those matched by key from another collection
+ Description: Replace daughters of jet with those matched by key from another collection
   e.g. replace puppi jet daughters with equivalent particles from packedPFCandidates
+
+  NB do not attempt to do this to the subjets - you will get into difficulty,
+  because in 10_2_10 there is no way to "remove" the old subjets, only append
+  new ones. So you have to change subjet label, which may not be optimal.
 
 */
 //

--- a/core/plugins/XConeProducer.cc
+++ b/core/plugins/XConeProducer.cc
@@ -59,18 +59,19 @@ class XConeProducer : public edm::stream::EDProducer<> {
     explicit XConeProducer(const edm::ParameterSet&);
     ~XConeProducer();
 
-  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-  // This method copies the constituents from the fjConstituents method to an output of CandidatePtr's. 
-  virtual std::vector<reco::CandidatePtr> getConstituents(const std::vector<fastjet::PseudoJet>&fjConstituents);
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+    // This method copies the constituents from the fjConstituents method to an output of CandidatePtr's.
+    virtual std::vector<reco::CandidatePtr> getConstituents(const std::vector<fastjet::PseudoJet>&fjConstituents);
+    static pat::Jet rekeyJet(const pat::Jet & jet, edm::Handle<edm::View<reco::Candidate>> & candHandle);
 
   private:
   virtual void produce(edm::Event&, const edm::EventSetup&) override;
-  
+
   virtual pat::Jet createPatJet(const fastjet::PseudoJet &) const;
   virtual pat::Jet createPatJet(const fastjet::PseudoJet &, const edm::EventSetup&);
-  
+
   virtual void initPlugin(std::unique_ptr<NjettinessPlugin> & ptr, int N, double R0, double beta, bool usePseudoXCone) const;
-  
+
   // ----------member data ---------------------------
   edm::EDGetToken src_token_;
   const std::string subjetCollName_;
@@ -86,6 +87,8 @@ class XConeProducer : public edm::stream::EDProducer<> {
   reco::Particle::Point  vertex_;
   std::vector<edm::Ptr<reco::Candidate> > particles_;
   edm::EDGetTokenT<reco::VertexCollection> input_vertex_token_;
+  bool doRekey_;
+  edm::EDGetTokenT<edm::View<reco::Candidate>> rekeyCandSrcToken_;
 };
 
 //
@@ -110,12 +113,23 @@ XConeProducer::XConeProducer(const edm::ParameterSet& iConfig):
   NSubJets_(iConfig.getParameter<unsigned int>("NSubJets")),
   RSubJets_(iConfig.getParameter<double>("RSubJets")),
   BetaSubJets_(iConfig.getParameter<double>("BetaSubJets")),
-  printWarning_(iConfig.exists("printWarning") ? iConfig.getParameter<bool>("printWarning") : false)
+  printWarning_(iConfig.exists("printWarning") ? iConfig.getParameter<bool>("printWarning") : false),
+  doRekey_(iConfig.exists("doRekey") ? iConfig.getParameter<bool>("doRekey") : false)
 {
   // We make both the fat jets and subjets, and we must store them as separate collections
   produces<pat::JetCollection>();
   produces<pat::JetCollection>(subjetCollName_);
   input_vertex_token_ = consumes<reco::VertexCollection>(edm::InputTag("offlineSlimmedPrimaryVertices"));
+  if (doRekey_) {
+    // Add option to rekey fatjets & their subjets, i.e. make their duaghters point to the equivalent
+    // particle in another collection (the one specified by rekeyCandidateSrc)
+    // This is useful if you want to e.g. replace the PUPPI daughters with their packedPFCandidate equivalents
+    // for more compact constituent storage. This means the user then has to apply PUPPI weight
+    // when analysing constituents.
+    // Do it in this producer, because doing it afterwards is a massive pain - subjets of a pat::Jet
+    // are not replaceable
+    rekeyCandSrcToken_ = consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("rekeyCandidateSrc"));
+  }
 }
 
 
@@ -167,9 +181,14 @@ void XConeProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   edm::Handle<reco::VertexCollection> pvCollection;
   iEvent.getByToken(input_vertex_token_ , pvCollection);
   if (!pvCollection->empty()) vertex_=pvCollection->begin()->position();
-  else vertex_ = reco::Particle::Point(0,0,0);  
+  else vertex_ = reco::Particle::Point(0,0,0);
 
-  particles_.clear(); 
+  edm::Handle<edm::View<reco::Candidate>> rekeyCandHandle;
+  if (doRekey_) {
+    iEvent.getByToken(rekeyCandSrcToken_, rekeyCandHandle);
+  }
+
+  particles_.clear();
   edm::Handle<edm::View<reco::Candidate>> particles;
   iEvent.getByToken(src_token_, particles);
   // Convert particles to PseudoJets
@@ -265,8 +284,8 @@ void XConeProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     for (unsigned int ipart=0; ipart < _psj.size(); ++ipart) {
       if (list_fat[ipart] < 0) continue;
       else if (abs(list_fat[ipart])==i) {
-	PseudoJet tmp_particle = _psj.at(ipart);
-	tmp_particle.set_user_index(_psj.at(ipart).user_index());//important: store index for later linking between clustered jet and constituence
+        PseudoJet tmp_particle = _psj.at(ipart);
+        tmp_particle.set_user_index(_psj.at(ipart).user_index());//important: store index for later linking between clustered jet and constituence
         particle_in_fatjet.push_back(tmp_particle);
       }
     }
@@ -283,16 +302,17 @@ void XConeProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
       ClusterSequenceArea clust_seq_sub(particle_in_fatjet, jet_def_sub, area_def);
       subjets = sorted_by_pt(clust_seq_sub.inclusive_jets(0));
       for (unsigned int j = 0; j < subjets.size(); ++j) {
-	if(subjets[j].has_area())
-	  subjet_area.push_back(subjets[j].area());
-	else subjet_area.push_back(0);
+        if(subjets[j].has_area())
+          subjet_area.push_back(subjets[j].area());
+        else subjet_area.push_back(0);
 
-	indices[i].push_back(subjetCollection->size()); // store index of subjet in the whole subjet collection
-	//	cout<<"subjets["<<j<<"] energy = "<<subjets[j].E()<<endl;
-	auto subjet = createPatJet(subjets[j], iSetup);
-	//	cout<<"PAT sub-jet is created for sub-jet #"<<j<<" of jet #"<<i<<endl;
-	subjet.setJetArea(subjet_area[j]);
-	subjetCollection->push_back(subjet);
+        indices[i].push_back(subjetCollection->size()); // store index of subjet in the whole subjet collection
+        pat::Jet subjet = createPatJet(subjets[j], iSetup);
+        if (doRekey_) {
+          subjet = rekeyJet(subjet, rekeyCandHandle);
+        }
+        subjet.setJetArea(subjet_area[j]);
+        subjetCollection->push_back(subjet);
       }
     }
 
@@ -304,11 +324,14 @@ void XConeProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
     // jet area for fat jet
     double jet_area = 0;
-    if(fatjets[i].has_area()) 
+    if(fatjets[i].has_area())
       jet_area = fatjets[i].area();
 
     // pat-ify fatjets
-    auto patJet = createPatJet(fatjets[i], iSetup);
+    pat::Jet patJet = createPatJet(fatjets[i], iSetup);
+    if (doRekey_) {
+      patJet = rekeyJet(patJet, rekeyCandHandle);
+    }
     patJet.setJetArea(jet_area);
     patJet.addUserFloat("softdropmass", sd_mass[i]);
     jetCollection->push_back(patJet);
@@ -358,11 +381,11 @@ pat::Jet XConeProducer::createPatJet(const PseudoJet & fjJet, const edm::EventSe
     // write the specifics to the jet (simultaneously sets 4-vector, vertex).
     // These are overridden functions that will call the appropriate
     // specific allocator.
-    reco::Particle::LorentzVector jet4v = reco::Particle::LorentzVector(fjJet.px(), fjJet.py(), fjJet.pz(),fjJet.E());  
+    reco::Particle::LorentzVector jet4v = reco::Particle::LorentzVector(fjJet.px(), fjJet.py(), fjJet.pz(),fjJet.E());
     reco::PFJet pfjet;
     reco::writeSpecific(pfjet,jet4v,vertex_,constituents, iSetup);// https://github.com/ahlinist/cmssw/blob/master/RecoJets/JetProducers/src/JetSpecific.cc#L91
     patjet = pat::Jet(pfjet);
-   
+
   }
   return patjet;
 }
@@ -379,7 +402,7 @@ XConeProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
 
 
 
-// ----------- Copied from 
+// ----------- Copied from
 // --------- https://github.com/cms-sw/cmssw/blob/CMSSW_10_2_X/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
 vector<reco::CandidatePtr> XConeProducer::getConstituents(const vector<fastjet::PseudoJet>&fjConstituents)
 {
@@ -398,6 +421,17 @@ vector<reco::CandidatePtr> XConeProducer::getConstituents(const vector<fastjet::
 }
 
 
+// Rekey a jet with equivalent constituents from another collection
+pat::Jet XConeProducer::rekeyJet(const pat::Jet & jet, edm::Handle<edm::View<reco::Candidate>> & candHandle) {
+  pat::Jet newJet(jet);
+  newJet.clearDaughters();
+  for (const auto & dauItr : jet.daughterPtrVector()) {
+    const unsigned long key = dauItr.key();
+    edm::Ptr<reco::Candidate> newDau = candHandle->ptrAt(key);
+    newJet.addDaughter(newDau);
+  }
+  return newJet;
+}
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(XConeProducer);

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -1397,14 +1397,10 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
     ###############################################
     # HOTVR & XCONE
     #
-    process.hotvrPuppiOrigDau = cms.EDProducer("HOTVRProducer",
-                                        src=cms.InputTag("puppi")
-                                        )
-    task.add(process.hotvrPuppiOrigDau)
-
-    process.hotvrPuppi = cms.EDProducer("RekeyJets",
-        jetSrc=cms.InputTag("hotvrPuppiOrigDau"),
-        candidateSrc=cms.InputTag("packedPFCandidates")
+    process.hotvrPuppi = cms.EDProducer("HOTVRProducer",
+        src=cms.InputTag("puppi"),
+        doRekey = cms.bool(True),       # set True if you want to rekey jet & subjets so that
+        rekeyCandidateSrc = cms.InputTag("packedPFCandidates") # constituents point to rekeyCandidateSrc
     )
     task.add(process.hotvrPuppi)
 
@@ -1420,7 +1416,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
     task.add(process.hotvrGen)
 
     usePseudoXCone = cms.bool(True)
-    process.xconePuppiOrigDau = cms.EDProducer("XConeProducer",
+    process.xconePuppi = cms.EDProducer("XConeProducer",
         src=cms.InputTag("puppi"),
         usePseudoXCone=usePseudoXCone,  # use PseudoXCone (faster) or XCone
         NJets = cms.uint32(2),          # number of fatjets
@@ -1429,13 +1425,9 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
         NSubJets = cms.uint32(3),       # number of subjets in each fatjet
         RSubJets = cms.double(0.4),     # cone radius of subjetSrc
         BetaSubJets = cms.double(2.0),  # conical mesure for subjets
-        printWarning = cms.bool(False)  # set True if you want warnings about missing jets
-    )
-    task.add(process.xconePuppiOrigDau)
-
-    process.xconePuppi = cms.EDProducer("RekeyJets",
-        jetSrc=cms.InputTag("xconePuppiOrigDau"),
-        candidateSrc=cms.InputTag("packedPFCandidates")
+        printWarning = cms.bool(False), # set True if you want warnings about missing jets
+        doRekey = cms.bool(True),       # set True if you want to rekey jet & subjets so that
+        rekeyCandidateSrc = cms.InputTag("packedPFCandidates") # constituents point to rekeyCandidateSrc
     )
     task.add(process.xconePuppi)
 
@@ -1515,7 +1507,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                              BetaSubJets = cms.double(2.0)   # conical mesure for subjets
                                              )
     task.add(process.xconeCHS2jets04)
-    process.xconePUPPI4jets04OrigDau = cms.EDProducer("XConeProducer",
+    process.xconePUPPI4jets04 = cms.EDProducer("XConeProducer",
                                              src=cms.InputTag("puppi"),
                                              usePseudoXCone=usePseudoXCone,  # use PseudoXCone (faster) or XCone
                                              NJets = cms.uint32(4),          # number of fatjets
@@ -1523,11 +1515,13 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                              BetaJets = cms.double(2.0),     # conical mesure (beta = 2.0 is XCone default)
                                              NSubJets = cms.uint32(1),       # number of subjets in each fatjet
                                              RSubJets = cms.double(0.2),     # cone radius of subjetSrc
-                                             BetaSubJets = cms.double(2.0)   # conical mesure for subjets
+                                             BetaSubJets = cms.double(2.0),   # conical mesure for subjets
+                                             doRekey = cms.bool(True),       # set True if you want to rekey jet & subjets so that
+                                             rekeyCandidateSrc = cms.InputTag("packedPFCandidates") # constituents point to rekeyCandidateSrc
                                              )
-    task.add(process.xconePUPPI4jets04OrigDau)
+    task.add(process.xconePUPPI4jets04)
 
-    process.xconePUPPI3jets04OrigDau = cms.EDProducer("XConeProducer",
+    process.xconePUPPI3jets04 = cms.EDProducer("XConeProducer",
                                              src=cms.InputTag("puppi"),
                                              usePseudoXCone=usePseudoXCone,  # use PseudoXCone (faster) or XCone
                                              NJets = cms.uint32(3),          # number of fatjets
@@ -1535,11 +1529,13 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                              BetaJets = cms.double(2.0),     # conical mesure (beta = 2.0 is XCone default)
                                              NSubJets = cms.uint32(1),       # number of subjets in each fatjet
                                              RSubJets = cms.double(0.2),     # cone radius of subjetSrc
-                                             BetaSubJets = cms.double(2.0)   # conical mesure for subjets
+                                             BetaSubJets = cms.double(2.0),   # conical mesure for subjets
+                                             doRekey = cms.bool(True),       # set True if you want to rekey jet & subjets so that
+                                             rekeyCandidateSrc = cms.InputTag("packedPFCandidates") # constituents point to rekeyCandidateSrc
                                              )
-    task.add(process.xconePUPPI3jets04OrigDau)
+    task.add(process.xconePUPPI3jets04)
 
-    process.xconePUPPI2jets04OrigDau = cms.EDProducer("XConeProducer",
+    process.xconePUPPI2jets04 = cms.EDProducer("XConeProducer",
                                              src=cms.InputTag("puppi"),
                                              usePseudoXCone=usePseudoXCone,  # use PseudoXCone (faster) or XCone
                                              NJets = cms.uint32(2),          # number of fatjets
@@ -1547,20 +1543,11 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                              BetaJets = cms.double(2.0),     # conical mesure (beta = 2.0 is XCone default)
                                              NSubJets = cms.uint32(1),       # number of subjets in each fatjet
                                              RSubJets = cms.double(0.2),     # cone radius of subjetSrc
-                                             BetaSubJets = cms.double(2.0)   # conical mesure for subjets
+                                             BetaSubJets = cms.double(2.0),   # conical mesure for subjets
+                                             doRekey = cms.bool(True),       # set True if you want to rekey jet & subjets so that
+                                             rekeyCandidateSrc = cms.InputTag("packedPFCandidates") # constituents point to rekeyCandidateSrc
                                              )
-    task.add(process.xconePUPPI2jets04OrigDau)
-
-    # Rekey XCONE R=0.4 puppi jets to replace daughters
-    for njets in [2, 3, 4]:
-        new_module = cms.EDProducer("RekeyJets",
-            jetSrc=cms.InputTag("xconePUPPI%djets04OrigDau" % (njets)),
-            candidateSrc=cms.InputTag("packedPFCandidates")
-        )
-        new_name = "xconePUPPI%djets04" % (njets)
-        setattr(process, new_name, new_module)
-        task.add(getattr(process, new_name))
-
+    task.add(process.xconePUPPI2jets04)
 
     process.genXCone4jets04 = cms.EDProducer("GenXConeProducer",
                                              src=cms.InputTag("packedGenParticlesForJetsNoNu"),
@@ -1644,7 +1631,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                              )
     task.add(process.xconeCHS2jets08)
 
-    process.xconePUPPI4jets08OrigDau = cms.EDProducer("XConeProducer",
+    process.xconePUPPI4jets08 = cms.EDProducer("XConeProducer",
                                              src=cms.InputTag("puppi"),
                                              usePseudoXCone=usePseudoXCone,  # use PseudoXCone (faster) or XCone
                                              NJets = cms.uint32(4),          # number of fatjets
@@ -1652,11 +1639,13 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                              BetaJets = cms.double(2.0),     # conical mesure (beta = 2.0 is XCone default)
                                              NSubJets = cms.uint32(1),       # number of subjets in each fatjet
                                              RSubJets = cms.double(0.4),     # cone radius of subjetSrc
-                                             BetaSubJets = cms.double(2.0)   # conical mesure for subjets
+                                             BetaSubJets = cms.double(2.0),   # conical mesure for subjets
+                                             doRekey = cms.bool(True),       # set True if you want to rekey jet & subjets so that
+                                             rekeyCandidateSrc = cms.InputTag("packedPFCandidates") # constituents point to rekeyCandidateSrc
                                              )
-    task.add(process.xconePUPPI4jets08OrigDau)
+    task.add(process.xconePUPPI4jets08)
 
-    process.xconePUPPI3jets08OrigDau = cms.EDProducer("XConeProducer",
+    process.xconePUPPI3jets08 = cms.EDProducer("XConeProducer",
                                              src=cms.InputTag("puppi"),
                                              usePseudoXCone=usePseudoXCone,  # use PseudoXCone (faster) or XCone
                                              NJets = cms.uint32(3),          # number of fatjets
@@ -1664,11 +1653,13 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                              BetaJets = cms.double(2.0),     # conical mesure (beta = 2.0 is XCone default)
                                              NSubJets = cms.uint32(1),       # number of subjets in each fatjet
                                              RSubJets = cms.double(0.4),     # cone radius of subjetSrc
-                                             BetaSubJets = cms.double(2.0)   # conical mesure for subjets
+                                             BetaSubJets = cms.double(2.0),   # conical mesure for subjets
+                                             doRekey = cms.bool(True),       # set True if you want to rekey jet & subjets so that
+                                             rekeyCandidateSrc = cms.InputTag("packedPFCandidates") # constituents point to rekeyCandidateSrc
                                              )
-    task.add(process.xconePUPPI3jets08OrigDau)
+    task.add(process.xconePUPPI3jets08)
 
-    process.xconePUPPI2jets08OrigDau = cms.EDProducer("XConeProducer",
+    process.xconePUPPI2jets08 = cms.EDProducer("XConeProducer",
                                              src=cms.InputTag("puppi"),
                                              usePseudoXCone=usePseudoXCone,  # use PseudoXCone (faster) or XCone
                                              NJets = cms.uint32(2),          # number of fatjets
@@ -1676,19 +1667,11 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                              BetaJets = cms.double(2.0),     # conical mesure (beta = 2.0 is XCone default)
                                              NSubJets = cms.uint32(1),       # number of subjets in each fatjet
                                              RSubJets = cms.double(0.4),     # cone radius of subjetSrc
-                                             BetaSubJets = cms.double(2.0)   # conical mesure for subjets
+                                             BetaSubJets = cms.double(2.0),   # conical mesure for subjets
+                                             doRekey = cms.bool(True),       # set True if you want to rekey jet & subjets so that
+                                             rekeyCandidateSrc = cms.InputTag("packedPFCandidates") # constituents point to rekeyCandidateSrc
                                              )
-    task.add(process.xconePUPPI2jets08OrigDau)
-
-    # Rekey XCONE R=0.8 puppi jets to replace daughters
-    for njets in [2, 3, 4]:
-        new_module = cms.EDProducer("RekeyJets",
-            jetSrc=cms.InputTag("xconePUPPI%djets08OrigDau" % (njets)),
-            candidateSrc=cms.InputTag("packedPFCandidates")
-        )
-        new_name = "xconePUPPI%djets08" % (njets)
-        setattr(process, new_name, new_module)
-        task.add(getattr(process, new_name))
+    task.add(process.xconePUPPI2jets08)
 
     process.genXCone4jets08 = cms.EDProducer("GenXConeProducer",
                                              src=cms.InputTag("packedGenParticlesForJetsNoNu"),

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -196,6 +196,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
 
         process.SimpleMemoryCheck = cms.Service("SimpleMemoryCheck",
                                                 ignoreTotal=cms.untracked.int32(2),
+                                                oncePerEventMode=cms.untracked.bool(True),
                                                 moduleMemorySummary=cms.untracked.bool(True)
                                                 )
 


### PR DESCRIPTION
Instead of using RekeyJets producer + messy hacks, move rekeying for HOTVR & XCone into their respective producers. The now actually rekeys their subjets as well, which was missing from #1199 .
Rekeying subjets is easiest for these collections done in their producers, due to the fact that a pat::Jet does not allow you to remove subjets once added, so you end up with a messy set of subjets.

With this, all PUPPI jet collections (& their subjets) should be correctly rekeyed against packedPFCandidates.