### PR TITLE
[102X] Simplify genparticle pruning into 1 module to possibly save some RSS memory

### DIFF
--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -302,11 +302,11 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
     # GEN PARTICLES
     #
     # The 13TeV samples mainly use Pythia8 for showering, which stores information in another way compared to Pythia6; in particular,
-    # many intermediate particles are stored such as top quarks or W bosons, which are not required for the analyses and makle the code more complicated.
+    # many intermediate particles are stored such as top quarks or W bosons, which are not required for the analyses and make the code more complicated.
     # Therefore, the 'prunedGenParticles' collection is pruned again; see UHH2/core/python/testgenparticles.py for a test for this pruning
     # and more comments.
-
-    process.prunedTmp = cms.EDProducer("GenParticlePruner",
+    # Note that separate instances of GenParticlePruner should be avoided - each contributes to more RSS memory overhead
+    process.prunedPrunedGenParticles = cms.EDProducer("GenParticlePruner",
                                        src=cms.InputTag("prunedGenParticles"),
                                        select=cms.vstring(
                                            'drop *',
@@ -314,20 +314,12 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                            'keep 20 <= status <= 30',
                                            'keep 11 <= abs(pdgId) <= 16 && numberOfMothers()==1 && abs(mother().pdgId()) >= 23 && abs(mother().pdgId()) <= 25',
                                            'keep 11 <= abs(pdgId) <= 16 && numberOfMothers()==1 && abs(mother().pdgId()) == 6',
-                                           'keep 11 <= abs(pdgId) <= 16 && numberOfMothers()==1 && abs(mother().pdgId()) == 42'
+                                           'keep 11 <= abs(pdgId) <= 16 && numberOfMothers()==1 && abs(mother().pdgId()) == 42',
+                                           'drop 11 <= abs(pdgId) <= 16 && numberOfMothers() == 1 && abs(mother().pdgId())==6',
+                                           'keep 11 <= abs(pdgId) <= 16 && numberOfMothers() == 1 && abs(mother().pdgId())==6 ' \
+                                           '&& mother().numberOfDaughters() > 2 && abs(mother().daughter(0).pdgId()) != 24 ' \
+                                           '&& abs(mother().daughter(1).pdgId()) != 24 && abs(mother().daughter(2).pdgId()) != 24',
                                        )
-    )
-    task.add(process.prunedTmp)
-
-    process.prunedPrunedGenParticles = cms.EDProducer("GenParticlePruner",
-                                                      src=cms.InputTag("prunedTmp"),
-                                                      select=cms.vstring(
-                                                          'keep *',
-                                                          'drop 11 <= abs(pdgId) <= 16 && numberOfMothers() == 1 && abs(mother().pdgId())==6',
-                                                          'keep 11 <= abs(pdgId) <= 16 && numberOfMothers() == 1 && abs(mother().pdgId())==6 ' \
-                                                          '&& mother().numberOfDaughters() > 2 && abs(mother().daughter(0).pdgId()) != 24 ' \
-                                                          '&& abs(mother().daughter(1).pdgId()) != 24 && abs(mother().daughter(2).pdgId()) != 24',
-                                                      )
     )
     task.add(process.prunedPrunedGenParticles)
 


### PR DESCRIPTION
So I _think_ compactifying all our gen particle pruning into 1 module instead of 2 may save us some memory. The content should be identical. I don't think it saves any processing time unfortunately.

All tests were done with TTHadronic 2018 MC with the "allConstits" config. I did it twice for the default config, and twice for this PR.  The two "default" runs are on different machines at different times, the compact pruning lines were done one after the other.

RSS does show some differences: here is the RSS **relative** to the 1st recorded event:

![image](https://user-images.githubusercontent.com/3728382/54756988-9a516700-4be9-11e9-9328-01fa43962927.png)

Note that it doesn't even agree in repeated running (e.g. blue & orange, red&green)...a very tricky metric 😕 

Looking at absolute RSS:

![image](https://user-images.githubusercontent.com/3728382/54757038-b48b4500-4be9-11e9-88e8-fc599d1faaed.png)

Not quite sure what to take away from the absolute values - running the same default config, the RSS drop by 100MB (blue  & orange) for no obvious reason?!

VSIZE doesn't change, although I think RSS is the real limitation for CRAB jobs:

![image](https://user-images.githubusercontent.com/3728382/54756860-5fe7ca00-4be9-11e9-9457-038b19c7fa50.png)


I think overall though it _might_ help save anywhere from 50 to 100 MB ? It doesn't look like it does any harm anyway. 🤷‍♂️ Not quite the magic fix we need unfortunately