### PR TITLE
[102X] Add Year enum; update MET filters in CommonModules; fixes for JetResolutionSmearer

### DIFF
--- a/common/include/CommonModules.h
+++ b/common/include/CommonModules.h
@@ -9,6 +9,7 @@
 #include "UHH2/common/include/JetCorrections.h"
 #include "UHH2/common/include/CleaningModules.h"
 
+
 /** \brief Run a configurable list commonly used modules
  *
  * This is a convenience class which runs a number of commonly-used
@@ -115,10 +116,11 @@ private:
     const int runnr_F = 306462;
 
     bool mclumiweight = true, mcpileupreweight = true, jersmear = true, jec = true, lumisel=true, jetlepcleaner = false, topjetlepcleaner =false, jetptsort = false, metfilters = true, pvfilter = true, jetpfidcleaner=true, do_metcorrection = false;
-
     double topjetcleanerDR;
     bool is_mc;
     bool init_done = false;
+
+    Year year;
 
     std::unique_ptr<Selection> lumi_selection;
     std::unique_ptr<AndSelection> metfilters_selection;

--- a/common/include/Utils.h
+++ b/common/include/Utils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "UHH2/core/include/AnalysisModule.h"
 #include "UHH2/core/include/Event.h"
 #include <limits>
 
@@ -25,30 +26,30 @@ const T * closestParticle(const Particle  & p, const std::vector<T> & particles)
 const Jet * nextJet(const Particle  & p, const std::vector<Jet> & jets);
 
 /** Relative transverse momentum of the particle p with respect to reference_axis
- * 
+ *
  * note: can use reference_axis = nextJet(p, *event.jets) for the 'usual' ptrel, assuming that the
  * jets have the correct filter(!).
- * 
+ *
  * In case reference_axis is NULL or the 0-three-vector, 0.0 is returned.
  */
 double pTrel(const Particle  & p, const Particle * reference_axis);
 
 
 /** return a pair of (Delta R, pt_rel) values for Particle p w.r.t. the next jet in jets.
- * 
+ *
  * Returns (infinity, infinity) if jets is empty.
  */
 std::pair<double, double> drmin_pTrel(const Particle & p, const std::vector<Jet> & jets);
 
 
 /** Locate a file, searching in several standard locations.
- * 
+ *
  * If the file is not found, a runtime_error is thrown with a detailed error
  * message.
- * 
+ *
  * If fname is an absolute name (=starting with '/'), no file resolution is done, just the check
  * whether the file exists (and exception throwing if not).
- * 
+ *
  * If fname is a relative path, these directories are tried and the first wins:
  *  1. $CMSSW_BASE/src/UHH2/
  *  2. $CMSSW_BASE/src/
@@ -59,7 +60,7 @@ std::string locate_file(const std::string & fname);
 
 
 
-/** Sort vector of Particles descndeing in pT 
+/** Sort vector of Particles descndeing in pT
  *
  */
 template<typename P>
@@ -90,3 +91,27 @@ inline void clean_collection(std::vector<T> & objects, const uhh2::Event & event
  *
  */
 float inv_mass_safe(const LorentzVector&);
+
+/**
+ * Year enum to handle generic switching of year-specific bits of code
+ */
+enum class Year {
+    is2016v2,
+    is2016v3,
+    is2017v1,
+    is2017v2,
+    is2018
+};
+
+/* Map from Year to string */
+const std::map<Year, std::string> year_str_map = {
+    {Year::is2016v2, "2016v2"},
+    {Year::is2016v3, "2016v3"},
+    {Year::is2017v1, "2017v1"},
+    {Year::is2017v2, "2017v2"},
+    {Year::is2018,   "2018"},
+};
+// TODO: inverse map?
+
+/* Get Year enum from dataset_version in XML config */
+Year extract_year(const uhh2::Context & ctx);

--- a/common/src/CommonModules.cxx
+++ b/common/src/CommonModules.cxx
@@ -31,6 +31,8 @@ void CommonModules::init(Context & ctx, const std::string & SysType_PU){
   init_done = true;
 
   is_mc = ctx.get("dataset_type") == "MC";
+  year = extract_year(ctx);
+
   //set default PV id;
   PrimaryVertexId pvid=StandardPrimaryVertexId();
   if(pvfilter) modules.emplace_back(new PrimaryVertexCleaner(pvid));
@@ -61,10 +63,9 @@ void CommonModules::init(Context & ctx, const std::string & SysType_PU){
     metfilters_selection->add<TriggerSelection>("EcalDeadCellTriggerPrimitiveFilter", "Flag_EcalDeadCellTriggerPrimitiveFilter");
     if(!is_mc) metfilters_selection->add<TriggerSelection>("eeBadScFilter", "Flag_eeBadScFilter");  // Not recommended for MC, but do check
     // metfilters_selection->add<TriggerSelection>("BadChargedCandidateFilter", "Flag_BadChargedCandidateFilter"); // Not recommended, under review. Already applied in 2016v2
-    metfilters_selection->add<TriggerSelection>("BadPFMuonFilter", "Flag_BadPFMuonFilter");
+    if (year != Year::is2016v2) metfilters_selection->add<TriggerSelection>("BadPFMuonFilter", "Flag_BadPFMuonFilter"); // Already filter BadPFMuon events in ntuple production
     metfilters_selection->add<TriggerSelection>("goodVertices", "Flag_goodVertices");
-    metfilters_selection->add<TriggerSelection>("ecalBadCalibFilter", "Flag_ecalBadCalibFilter"); // for 2017 and 2018 is always 1. need a EcalBadCalibSelection for the recalculated value.
-    metfilters_selection->add<EcalBadCalibSelection>("EcalBadCalibSelection");
+    metfilters_selection->add<EcalBadCalibSelection>("EcalBadCalibSelection"); // Use this instead of Flag_ecalBadCalibFilter
     if(pvfilter) metfilters_selection->add<NPVSelection>("1 good PV",1,-1,pvid);
   }
   if(eleid) modules.emplace_back(new ElectronCleaner(eleid));

--- a/common/src/CommonModules.cxx
+++ b/common/src/CommonModules.cxx
@@ -13,9 +13,9 @@ using namespace uhh2;
 using namespace std;
 
 void CommonModules::fail_if_init() const{
-    if(init_done){
-        throw invalid_argument("CommonModules::init already called!");
-    }
+  if(init_done){
+    throw invalid_argument("CommonModules::init already called!");
+  }
 }
 
 
@@ -25,182 +25,183 @@ CommonModules::CommonModules(){
 
 
 void CommonModules::init(Context & ctx, const std::string & SysType_PU){
-    if(init_done){
-        throw invalid_argument("CommonModules::init called twice!");
+  if(init_done){
+    throw invalid_argument("CommonModules::init called twice!");
+  }
+  init_done = true;
+
+  is_mc = ctx.get("dataset_type") == "MC";
+  //set default PV id;
+  PrimaryVertexId pvid=StandardPrimaryVertexId();
+  if(pvfilter) modules.emplace_back(new PrimaryVertexCleaner(pvid));
+  if(is_mc){
+    if(mclumiweight)  modules.emplace_back(new MCLumiWeight(ctx));
+    if(mcpileupreweight) modules.emplace_back(new MCPileupReweight(ctx,SysType_PU));
+    if(jec){
+      jet_corrector_MC.reset(new JetCorrector(ctx, JERFiles::Fall17_17Nov2017_V32_L123_AK4PFchs_MC));
     }
-    init_done = true;
-    is_mc = ctx.get("dataset_type") == "MC";
-    //set default PV id;
-    PrimaryVertexId pvid=StandardPrimaryVertexId();
-    if(pvfilter) modules.emplace_back(new PrimaryVertexCleaner(pvid));
-    if(is_mc){
-        if(mclumiweight)  modules.emplace_back(new MCLumiWeight(ctx));
-        if(mcpileupreweight) modules.emplace_back(new MCPileupReweight(ctx,SysType_PU));
-        if(jec){
-	  jet_corrector_MC.reset(new JetCorrector(ctx, JERFiles::Fall17_17Nov2017_V32_L123_AK4PFchs_MC));
-	}
-        if(jersmear) jet_resolution_smearer.reset(new JetResolutionSmearer(ctx));
+    if(jersmear) jet_resolution_smearer.reset(new JetResolutionSmearer(ctx));
+  }
+  else{
+    if(lumisel) lumi_selection.reset(new LumiSelection(ctx));
+    if(jec){
+      jet_corrector_B.reset(new JetCorrector(ctx, JERFiles::Fall17_17Nov2017_V32_B_L123_AK4PFchs_DATA));
+      jet_corrector_C.reset(new JetCorrector(ctx, JERFiles::Fall17_17Nov2017_V32_C_L123_AK4PFchs_DATA));
+      jet_corrector_D.reset(new JetCorrector(ctx, JERFiles::Fall17_17Nov2017_V32_D_L123_AK4PFchs_DATA));
+      jet_corrector_E.reset(new JetCorrector(ctx, JERFiles::Fall17_17Nov2017_V32_E_L123_AK4PFchs_DATA));
+      jet_corrector_F.reset(new JetCorrector(ctx, JERFiles::Fall17_17Nov2017_V32_F_L123_AK4PFchs_DATA));
     }
+  }
+  if(metfilters){
+    // https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETOptionalFiltersRun2
+    metfilters_selection.reset(new AndSelection(ctx, "metfilters"));
+    metfilters_selection->add<TriggerSelection>("HBHENoiseFilter", "Flag_HBHENoiseFilter");
+    metfilters_selection->add<TriggerSelection>("HBHENoiseIsoFilter", "Flag_HBHENoiseIsoFilter");
+    metfilters_selection->add<TriggerSelection>("globalSuperTightHalo2016Filter", "Flag_globalSuperTightHalo2016Filter");
+    metfilters_selection->add<TriggerSelection>("EcalDeadCellTriggerPrimitiveFilter", "Flag_EcalDeadCellTriggerPrimitiveFilter");
+    if(!is_mc) metfilters_selection->add<TriggerSelection>("eeBadScFilter", "Flag_eeBadScFilter");  // Not recommended for MC, but do check
+    metfilters_selection->add<TriggerSelection>("BadChargedCandidateFilter", "Flag_BadChargedCandidateFilter");
+    metfilters_selection->add<TriggerSelection>("BadPFMuonFilter", "Flag_BadPFMuonFilter");
+    metfilters_selection->add<TriggerSelection>("goodVertices", "Flag_goodVertices");
+    metfilters_selection->add<TriggerSelection>("ecalBadCalibFilter", "Flag_ecalBadCalibFilter"); // for 2017 and 2018 is always 1. need a EcalBadCalibSelection for the recalculated value.
+    metfilters_selection->add<EcalBadCalibSelection>("EcalBadCalibSelection");
+    if(pvfilter) metfilters_selection->add<NPVSelection>("1 good PV",1,-1,pvid);
+  }
+  if(eleid) modules.emplace_back(new ElectronCleaner(eleid));
+  if(muid)  modules.emplace_back(new MuonCleaner(muid));
+  if(tauid) modules.emplace_back(new TauCleaner(tauid));
+  if(jetpfidcleaner){
+    modules.emplace_back(new JetCleaner(ctx, JetPFID(working_point)));
+  }
+  if(jetlepcleaner) {
+    if(is_mc) JLC_MC.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::Fall17_17Nov2017_V32_L123_AK4PFchs_MC));
     else{
-       if(lumisel) lumi_selection.reset(new LumiSelection(ctx));
-       if(jec){
-	 jet_corrector_B.reset(new JetCorrector(ctx, JERFiles::Fall17_17Nov2017_V32_B_L123_AK4PFchs_DATA));
-	 jet_corrector_C.reset(new JetCorrector(ctx, JERFiles::Fall17_17Nov2017_V32_C_L123_AK4PFchs_DATA));
-	 jet_corrector_D.reset(new JetCorrector(ctx, JERFiles::Fall17_17Nov2017_V32_D_L123_AK4PFchs_DATA));
-	 jet_corrector_E.reset(new JetCorrector(ctx, JERFiles::Fall17_17Nov2017_V32_E_L123_AK4PFchs_DATA));
-	 jet_corrector_F.reset(new JetCorrector(ctx, JERFiles::Fall17_17Nov2017_V32_F_L123_AK4PFchs_DATA));
-       }
+      JLC_B.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::Fall17_17Nov2017_V32_B_L123_AK4PFchs_DATA));
+      JLC_C.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::Fall17_17Nov2017_V32_C_L123_AK4PFchs_DATA));
+      JLC_D.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::Fall17_17Nov2017_V32_D_L123_AK4PFchs_DATA));
+      JLC_E.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::Fall17_17Nov2017_V32_E_L123_AK4PFchs_DATA));
+      JLC_F.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::Fall17_17Nov2017_V32_F_L123_AK4PFchs_DATA));
     }
-    if(metfilters){
-      // https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETOptionalFiltersRun2
-       metfilters_selection.reset(new AndSelection(ctx, "metfilters"));
-       metfilters_selection->add<TriggerSelection>("HBHENoiseFilter", "Flag_HBHENoiseFilter");
-       metfilters_selection->add<TriggerSelection>("HBHENoiseIsoFilter", "Flag_HBHENoiseIsoFilter");
-       metfilters_selection->add<TriggerSelection>("globalSuperTightHalo2016Filter", "Flag_globalSuperTightHalo2016Filter");
-       metfilters_selection->add<TriggerSelection>("EcalDeadCellTriggerPrimitiveFilter", "Flag_EcalDeadCellTriggerPrimitiveFilter");
-       if (!is_mc) metfilters_selection->add<TriggerSelection>("eeBadScFilter", "Flag_eeBadScFilter");  // Not recommended for MC, but do check
-       metfilters_selection->add<TriggerSelection>("BadChargedCandidateFilter", "Flag_BadChargedCandidateFilter");
-       metfilters_selection->add<TriggerSelection>("BadPFMuonFilter", "Flag_BadPFMuonFilter");
-       metfilters_selection->add<TriggerSelection>("goodVertices", "Flag_goodVertices");
-       metfilters_selection->add<TriggerSelection>("ecalBadCalibFilter", "Flag_ecalBadCalibFilter"); // for 2017 and 2018 is always 1. need a EcalBadCalibSelection for the recalculated value.
-       metfilters_selection->add<EcalBadCalibSelection>("EcalBadCalibSelection");
-       if(pvfilter) metfilters_selection->add<NPVSelection>("1 good PV",1,-1,pvid);
-    }
-    if(eleid) modules.emplace_back(new ElectronCleaner(eleid));
-    if(muid)  modules.emplace_back(new MuonCleaner(muid));
-    if(tauid) modules.emplace_back(new TauCleaner(tauid));
-    if(jetpfidcleaner){
-      modules.emplace_back(new JetCleaner(ctx, JetPFID(working_point)));
-    }
-    if(jetlepcleaner) {
-      if(is_mc)	JLC_MC.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::Fall17_17Nov2017_V32_L123_AK4PFchs_MC));
-      else{
-	JLC_B.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::Fall17_17Nov2017_V32_B_L123_AK4PFchs_DATA));
-	JLC_C.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::Fall17_17Nov2017_V32_C_L123_AK4PFchs_DATA));
-	JLC_D.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::Fall17_17Nov2017_V32_D_L123_AK4PFchs_DATA));
-	JLC_E.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::Fall17_17Nov2017_V32_E_L123_AK4PFchs_DATA));
-	JLC_F.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::Fall17_17Nov2017_V32_F_L123_AK4PFchs_DATA));
-      }
-    }
-    modules.emplace_back(new HTCalculator(ctx,HT_jetid));
-    if(jetid) jet_cleaner.reset(new JetCleaner(ctx, jetid));
+  }
+  modules.emplace_back(new HTCalculator(ctx,HT_jetid));
+  if(jetid) jet_cleaner.reset(new JetCleaner(ctx, jetid));
 }
 
 bool CommonModules::process(uhh2::Event & event){
-    if(!init_done){
-        throw runtime_error("CommonModules::init not called (has to be called in AnalysisModule constructor)");
-    }
-    if(event.isRealData && lumisel){
-        if(!lumi_selection->passes(event)) return false;
-    }
-    for(auto & m : modules){
-        m->process(event);
-    }
-    if(metfilters){
-        if(!metfilters_selection->passes(event)) return false;
-    }
+  if(!init_done){
+    throw runtime_error("CommonModules::init not called (has to be called in AnalysisModule constructor)");
+  }
+  if(event.isRealData && lumisel){
+    if(!lumi_selection->passes(event)) return false;
+  }
+  for(auto & m : modules){
+    m->process(event);
+  }
+  if(metfilters){
+    if(!metfilters_selection->passes(event)) return false;
+  }
 
-    if(jetlepcleaner){
-      if(is_mc) JLC_MC->process(event);
-      else{
-	if(event.run <= runnr_B)      JLC_B->process(event);
-	else if(event.run <= runnr_C) JLC_C->process(event);
-	else if(event.run <= runnr_D) JLC_D->process(event);
-	else if(event.run <= runnr_E) JLC_E->process(event);
-        else if(event.run <= runnr_F) JLC_F->process(event);
-	else throw runtime_error("CommonModules.cxx: run number not covered by if-statements in process-routine.");
-      }
+  if(jetlepcleaner){
+    if(is_mc) JLC_MC->process(event);
+    else{
+      if(event.run <= runnr_B)      JLC_B->process(event);
+      else if(event.run <= runnr_C) JLC_C->process(event);
+      else if(event.run <= runnr_D) JLC_D->process(event);
+      else if(event.run <= runnr_E) JLC_E->process(event);
+      else if(event.run <= runnr_F) JLC_F->process(event);
+      else throw runtime_error("CommonModules.cxx: run number not covered by if-statements in process-routine.");
     }
+  }
 
-    if(jec){
-      if(is_mc)jet_corrector_MC->process(event);
-      else{
-	if(event.run <= runnr_B)      jet_corrector_B->process(event);
-	else if(event.run <= runnr_C) jet_corrector_C->process(event);
-	else if(event.run <= runnr_D) jet_corrector_D->process(event);
-	else if(event.run <= runnr_E) jet_corrector_E->process(event);
-	else if(event.run <= runnr_F) jet_corrector_F->process(event);
-	else throw runtime_error("CommonModules.cxx: run number not covered by if-statements in process-routine.");
-      }
+  if(jec){
+    if(is_mc)jet_corrector_MC->process(event);
+    else{
+      if(event.run <= runnr_B)      jet_corrector_B->process(event);
+      else if(event.run <= runnr_C) jet_corrector_C->process(event);
+      else if(event.run <= runnr_D) jet_corrector_D->process(event);
+      else if(event.run <= runnr_E) jet_corrector_E->process(event);
+      else if(event.run <= runnr_F) jet_corrector_F->process(event);
+      else throw runtime_error("CommonModules.cxx: run number not covered by if-statements in process-routine.");
     }
+  }
 
-    if(jersmear && is_mc) jet_resolution_smearer->process(event);
+  if(jersmear && is_mc) jet_resolution_smearer->process(event);
 
-    //set do_metcorrection = true in case you applied jet lepton cleaning by yourself and before calling common modules
-    if((jetlepcleaner && jec) || (do_metcorrection && jec)){
-      if(is_mc) jet_corrector_MC->correct_met(event);
-      else{
-	if(event.run <= runnr_B)      jet_corrector_B->correct_met(event);
-	else if(event.run <= runnr_C) jet_corrector_C->correct_met(event);
-	else if(event.run <= runnr_D) jet_corrector_D->correct_met(event);
-	else if(event.run <= runnr_E) jet_corrector_E->correct_met(event);
-	else if(event.run <= runnr_F) jet_corrector_F->correct_met(event);
-	else throw runtime_error("CommonModules.cxx: run number not covered by if-statements in process-routine.");
-      }
+  //set do_metcorrection = true in case you applied jet lepton cleaning by yourself and before calling common modules
+  if((jetlepcleaner && jec) || (do_metcorrection && jec)){
+    if(is_mc) jet_corrector_MC->correct_met(event);
+    else{
+      if(event.run <= runnr_B)      jet_corrector_B->correct_met(event);
+      else if(event.run <= runnr_C) jet_corrector_C->correct_met(event);
+      else if(event.run <= runnr_D) jet_corrector_D->correct_met(event);
+      else if(event.run <= runnr_E) jet_corrector_E->correct_met(event);
+      else if(event.run <= runnr_F) jet_corrector_F->correct_met(event);
+      else throw runtime_error("CommonModules.cxx: run number not covered by if-statements in process-routine.");
     }
-    else if(jec || jetlepcleaner) cout <<"WARNING: You used CommonModules for either JEC or jet-lepton-cleaning but MET is not corrected. Please be aware of this." << endl;
+  }
+  else if(jec || jetlepcleaner) cout <<"WARNING: You used CommonModules for either JEC or jet-lepton-cleaning but MET is not corrected. Please be aware of this." << endl;
 
-    if(jetid) jet_cleaner->process(event);
+  if(jetid) jet_cleaner->process(event);
 
-    if(jetptsort){
-      sort_by_pt(*event.jets);
-    }
-    return true;
+  if(jetptsort){
+    sort_by_pt(*event.jets);
+  }
+  return true;
 }
 
 
 void CommonModules::disable_mclumiweight(){
-    fail_if_init();
-    mclumiweight = false;
+  fail_if_init();
+  mclumiweight = false;
 }
 
 void CommonModules::disable_mcpileupreweight(){
-    fail_if_init();
-    mcpileupreweight = false;
+  fail_if_init();
+  mcpileupreweight = false;
 }
 
 void CommonModules::disable_jec(){
-    fail_if_init();
-    jec = false;
+  fail_if_init();
+  jec = false;
 }
 
 void CommonModules::disable_jersmear(){
-    fail_if_init();
-    jersmear = false;
+  fail_if_init();
+  jersmear = false;
 }
 
 void CommonModules::disable_lumisel(){
-    fail_if_init();
-    lumisel = false;
+  fail_if_init();
+  lumisel = false;
 }
 
 void CommonModules::disable_metfilters(){
-    fail_if_init();
-    metfilters = false;
+  fail_if_init();
+  metfilters = false;
 }
 
 void CommonModules::disable_pvfilter(){
-    fail_if_init();
-    pvfilter = false;
+  fail_if_init();
+  pvfilter = false;
 }
 
 class TestCommonModules: public AnalysisModule {
 public:
-    TestCommonModules(uhh2::Context & ctx){
-        common.reset(new CommonModules());
-        // in a non-trivial usage, would call
-        // common->set_*_id   and
-        // common->disable_*  here.
-	common->init(ctx);
-    }
+  TestCommonModules(uhh2::Context & ctx){
+    common.reset(new CommonModules());
+    // in a non-trivial usage, would call
+    // common->set_*_id   and
+    // common->disable_*  here.
+    common->init(ctx);
+  }
 
-    virtual bool process(Event & event) override {
-         bool pass_cm = common->process(event);
- 	if(!pass_cm) std::cout << "Event rejected by common modules" << std::endl;
-	return pass_cm;
-    }
+  virtual bool process(Event & event) override {
+    bool pass_cm = common->process(event);
+    if(!pass_cm) std::cout << "Event rejected by common modules" << std::endl;
+    return pass_cm;
+  }
 private:
-    std::unique_ptr<CommonModules> common;
+  std::unique_ptr<CommonModules> common;
 };
 
 UHH2_REGISTER_ANALYSIS_MODULE(TestCommonModules)

--- a/common/src/CommonModules.cxx
+++ b/common/src/CommonModules.cxx
@@ -61,7 +61,7 @@ void CommonModules::init(Context & ctx, const std::string & SysType_PU){
     metfilters_selection->add<TriggerSelection>("HBHENoiseIsoFilter", "Flag_HBHENoiseIsoFilter");
     metfilters_selection->add<TriggerSelection>("globalSuperTightHalo2016Filter", "Flag_globalSuperTightHalo2016Filter");
     metfilters_selection->add<TriggerSelection>("EcalDeadCellTriggerPrimitiveFilter", "Flag_EcalDeadCellTriggerPrimitiveFilter");
-    if(!is_mc) metfilters_selection->add<TriggerSelection>("eeBadScFilter", "Flag_eeBadScFilter");  // Not recommended for MC, but do check
+    // metfilters_selection->add<TriggerSelection>("eeBadScFilter", "Flag_eeBadScFilter");  // Not recommended
     // metfilters_selection->add<TriggerSelection>("BadChargedCandidateFilter", "Flag_BadChargedCandidateFilter"); // Not recommended, under review. Already applied in 2016v2
     if (year != Year::is2016v2) metfilters_selection->add<TriggerSelection>("BadPFMuonFilter", "Flag_BadPFMuonFilter"); // Already filter BadPFMuon events in ntuple production
     metfilters_selection->add<TriggerSelection>("goodVertices", "Flag_goodVertices");

--- a/common/src/CommonModules.cxx
+++ b/common/src/CommonModules.cxx
@@ -60,7 +60,7 @@ void CommonModules::init(Context & ctx, const std::string & SysType_PU){
     metfilters_selection->add<TriggerSelection>("globalSuperTightHalo2016Filter", "Flag_globalSuperTightHalo2016Filter");
     metfilters_selection->add<TriggerSelection>("EcalDeadCellTriggerPrimitiveFilter", "Flag_EcalDeadCellTriggerPrimitiveFilter");
     if(!is_mc) metfilters_selection->add<TriggerSelection>("eeBadScFilter", "Flag_eeBadScFilter");  // Not recommended for MC, but do check
-    metfilters_selection->add<TriggerSelection>("BadChargedCandidateFilter", "Flag_BadChargedCandidateFilter");
+    // metfilters_selection->add<TriggerSelection>("BadChargedCandidateFilter", "Flag_BadChargedCandidateFilter"); // Not recommended, under review. Already applied in 2016v2
     metfilters_selection->add<TriggerSelection>("BadPFMuonFilter", "Flag_BadPFMuonFilter");
     metfilters_selection->add<TriggerSelection>("goodVertices", "Flag_goodVertices");
     metfilters_selection->add<TriggerSelection>("ecalBadCalibFilter", "Flag_ecalBadCalibFilter"); // for 2017 and 2018 is always 1. need a EcalBadCalibSelection for the recalculated value.

--- a/common/src/JetCorrections.cxx
+++ b/common/src/JetCorrections.cxx
@@ -741,7 +741,18 @@ const JERSmearing::SFtype1 JERSmearing::SF_13TeV_Autumn18_RunD_V1 = {
 ////
 
 JetResolutionSmearer::JetResolutionSmearer(uhh2::Context & ctx, const JERSmearing::SFtype1& JER_sf){
-  m_gjrs = new GenericJetResolutionSmearer(ctx, "jets", "genjets", JER_sf);
+  const Year & year = extract_year(ctx);
+  std::string resFilename = "";
+  if (year == Year::is2016v2 || year == Year::is2016v3) {
+    resFilename = "2016/Summer16_25nsV1_MC_PtResolution_AK4PFchs.txt";
+  } else if (year == Year::is2017v1 || year == Year::is2017v2) {
+    resFilename = "2017/Fall17_V3_MC_PtResolution_AK4PFchs.txt";
+  } else if (year == Year::is2018) {
+    resFilename = "2018/Autumn18_V1_MC_PtResolution_AK4PFchs.txt";
+  } else {
+    throw runtime_error("Cannot find suitable jet resolution file for this year");
+  }
+  m_gjrs = new GenericJetResolutionSmearer(ctx, "jets", "genjets", JER_sf, resFilename);
 }
 
 bool JetResolutionSmearer::process(uhh2::Event & event) {

--- a/common/src/JetCorrections.cxx
+++ b/common/src/JetCorrections.cxx
@@ -780,6 +780,9 @@ GenericJetResolutionSmearer::GenericJetResolutionSmearer(uhh2::Context& ctx, con
   filename += "/src/UHH2/common/data/";
   filename += ResolutionFileName;
   m_resfile.open(filename);
+  if (!m_resfile) {
+    throw runtime_error("Resolution file " + filename + " does not exist");
+  }
 
   //get the formula from the header
   TString dummy;

--- a/common/src/Utils.cxx
+++ b/common/src/Utils.cxx
@@ -19,7 +19,7 @@ bool file_exists(const std::string & path){
         return S_ISREG(s.st_mode);
     }
 }
-    
+
 }
 
 const Jet * nextJet(const Particle  & p, const std::vector<Jet> & jets){
@@ -85,4 +85,19 @@ std::string locate_file(const std::string & fname){
         }
     }
     throw runtime_error("Could not locate file '" + fname + "' in $CMSSW_BASE/src/{UHH2,} or $SFRAME_DIR/{UHH2,}.");
+}
+
+
+Year extract_year(const uhh2::Context & ctx) {
+    const std::string datasetVer = ctx.get("dataset_version");
+    for (auto const & [year, str] : year_str_map) {
+        if (datasetVer.find(str) != std::string::npos) {
+            return year;
+        }
+    }
+    std::string yearStr = "";
+    for (auto const & iter : year_str_map) {
+        yearStr += iter.second + ",";
+    }
+    throw std::runtime_error("Cannot figure out year from dataset_version. Should include one of: " + yearStr);
 }


### PR DESCRIPTION
MET filters now year-dependent, since some are run during the ntupleisation. To aid this (plus later things) have added in a `Year` enum class with helper function `extract_year(uhh2::Context)`. 

(I left in the commented-out filters so it's obvious that they've been considered but turned off for now, rather than forgotten about)

Also fix for `JetResolutionSmearer` since it was using a non-existent default file. It now checks first if file exists. It also now chooses a default file based on the Year. (NB the JER SF are still not auto year-chosen, but the user can also specify them in the constructor, so not quite sure how to handle this right now.)

[only compile]