### PR TITLE
[102X] Improve JetResolutionSmearer

### DIFF
--- a/common/include/JetCorrections.h
+++ b/common/include/JetCorrections.h
@@ -276,27 +276,32 @@ class GenericJetResolutionSmearer : public uhh2::AnalysisModule {
 
 
 
-/** \brief Smear the jet four-momenta in MC to match the resolution in data
+/** \brief Smear the Jets' (specified in event.jets / JetCollection) four-momenta in MC to match the resolution in data.
+ * It will have no effect on data events.
  *
- * The corrections applied correspond to the values listed here:
- * https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetResolution
- * for 8TeV data (r36 from 2014-08-28) using the method to scale
- * the genjet pt - reco pt difference.
+ * There are 2 constructors to either automatically choose resolution txt file
+ * & scale factors based on year & jet algorithm,
+ * or allow the user to specify them exactly.
+ *
+ * See https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetResolution for details
+ * We use the hybrid method, depending on if a matching genjet was found.
  *
  * Run this *after* the jet energy corrections.
  *
  * IMPORTANT: do NOT run the module twice, as then, the jets will be smeared twice, which
  * is too much.
  *
- * Options parsed from the given Context:
- *  - "jersmear_direction": either "nominal", "up", or "down" to apply nominal, +1sigma, -1sigma smearing resp.
+ * Options parsed from the given Context in the XML file:
+ *  - "jersmear_direction": either "nominal", "up", or "down" to apply
+ *    nominal, +1sigma, -1sigma smearing respectively
  *
  * Please note that the JetResolutionSmearer does not sort the (re-)corrected jets by pt;
  * you might want to do that before running algorithms / plotting which assume that.
  */
 class JetResolutionSmearer: public uhh2::AnalysisModule{
 public:
-    explicit JetResolutionSmearer(uhh2::Context & ctx, const JERSmearing::SFtype1& JER_sf=JERSmearing::SF_13TeV_Fall17_V3);
+    explicit JetResolutionSmearer(uhh2::Context & ctx);
+    explicit JetResolutionSmearer(uhh2::Context & ctx, const JERSmearing::SFtype1& JER_sf, const std::string& resFilename);
 
     virtual bool process(uhh2::Event & event) override;
 

--- a/common/src/JetCorrections.cxx
+++ b/common/src/JetCorrections.cxx
@@ -741,16 +741,37 @@ const JERSmearing::SFtype1 JERSmearing::SF_13TeV_Autumn18_RunD_V1 = {
 ////
 
 JetResolutionSmearer::JetResolutionSmearer(uhh2::Context & ctx, const JERSmearing::SFtype1& JER_sf){
+  // Auto-determine correct resolution txt file from year + jet & PU algorithms
+  std::string jetstr = uhh2::string2lowercase(ctx.get("JetCollection"));
+
+  std::string jetAlgoRadius;
+  if (jetstr.find("ak4") != std::string::npos) {
+    jetAlgoRadius = "AK4";
+  } else if (jetstr.find("ak8") != std::string::npos) {
+    jetAlgoRadius = "AK8";
+  } else {
+    throw runtime_error("JetCollection does not contain AK4 or AK8 - cannot determine filename for JetResolutionSmearer");
+  }
+
+  std::string puName;
+  if (jetstr.find("chs") != std::string::npos) {
+    puName = "chs";
+  } else if (jetstr.find("puppi") != std::string::npos) {
+    puName = "Puppi";
+  } else {
+    throw runtime_error("JetCollection not CHS or Puppi - cannot determine filename for JetResolutionSmearer");
+  }
+
   const Year & year = extract_year(ctx);
   std::string resFilename = "";
   if (year == Year::is2016v2 || year == Year::is2016v3) {
-    resFilename = "2016/Summer16_25nsV1_MC_PtResolution_AK4PFchs.txt";
+    resFilename = "2016/Summer16_25nsV1_MC_PtResolution_"+jetAlgoRadius+"PF"+puName+".txt";
   } else if (year == Year::is2017v1 || year == Year::is2017v2) {
-    resFilename = "2017/Fall17_V3_MC_PtResolution_AK4PFchs.txt";
+    resFilename = "2017/Fall17_V3_MC_PtResolution_"+jetAlgoRadius+"PF"+puName+".txt";
   } else if (year == Year::is2018) {
-    resFilename = "2018/Autumn18_V1_MC_PtResolution_AK4PFchs.txt";
+    resFilename = "2018/Autumn18_V1_MC_PtResolution_"+jetAlgoRadius+"PF"+puName+".txt";
   } else {
-    throw runtime_error("Cannot find suitable jet resolution file for this year");
+    throw runtime_error("Cannot find suitable jet resolution file for this year for JetResolutionSmearer");
   }
   m_gjrs = new GenericJetResolutionSmearer(ctx, "jets", "genjets", JER_sf, resFilename);
 }

--- a/common/src/JetCorrections.cxx
+++ b/common/src/JetCorrections.cxx
@@ -698,7 +698,7 @@ const JERSmearing::SFtype1 JERSmearing::SF_13TeV_Autumn18_RunABC_V1 = {
   // 1 = JER SF
   // 2 = JER SF + 1sigma
   // 3 = JER SF - 1sigma
-  
+
   {{0.522, 1.1609, 1.2161, 1.1057}},
   {{0.783, 1.1309, 1.1919, 1.0699}},
   {{1.131, 1.0918, 1.127, 1.0566}},
@@ -740,8 +740,8 @@ const JERSmearing::SFtype1 JERSmearing::SF_13TeV_Autumn18_RunD_V1 = {
 
 ////
 
-JetResolutionSmearer::JetResolutionSmearer(uhh2::Context & ctx, const JERSmearing::SFtype1& JER_sf){
-  // Auto-determine correct resolution txt file from year + jet & PU algorithms
+JetResolutionSmearer::JetResolutionSmearer(uhh2::Context & ctx){
+  // Auto-determine correct resolution txt file & SFs from year + jet & PU algorithms
   std::string jetstr = uhh2::string2lowercase(ctx.get("JetCollection"));
 
   std::string jetAlgoRadius;
@@ -763,16 +763,26 @@ JetResolutionSmearer::JetResolutionSmearer(uhh2::Context & ctx, const JERSmearin
   }
 
   const Year & year = extract_year(ctx);
+  JERSmearing::SFtype1 JER_sf;
   std::string resFilename = "";
   if (year == Year::is2016v2 || year == Year::is2016v3) {
+    JER_sf = JERSmearing::SF_13TeV_Summer16_25nsV1;
     resFilename = "2016/Summer16_25nsV1_MC_PtResolution_"+jetAlgoRadius+"PF"+puName+".txt";
   } else if (year == Year::is2017v1 || year == Year::is2017v2) {
+    JER_sf = JERSmearing::SF_13TeV_Fall17_V3;
     resFilename = "2017/Fall17_V3_MC_PtResolution_"+jetAlgoRadius+"PF"+puName+".txt";
   } else if (year == Year::is2018) {
+    JER_sf = JERSmearing::SF_13TeV_Autumn18_V1;
     resFilename = "2018/Autumn18_V1_MC_PtResolution_"+jetAlgoRadius+"PF"+puName+".txt";
   } else {
-    throw runtime_error("Cannot find suitable jet resolution file for this year for JetResolutionSmearer");
+    throw runtime_error("Cannot find suitable jet resolution file & scale factors for this year for JetResolutionSmearer");
   }
+
+  m_gjrs = new GenericJetResolutionSmearer(ctx, "jets", "genjets", JER_sf, resFilename);
+}
+
+
+JetResolutionSmearer::JetResolutionSmearer(uhh2::Context & ctx, const JERSmearing::SFtype1& JER_sf, const std::string& resFilename){
   m_gjrs = new GenericJetResolutionSmearer(ctx, "jets", "genjets", JER_sf, resFilename);
 }
 

--- a/common/src/JetCorrections.cxx
+++ b/common/src/JetCorrections.cxx
@@ -777,7 +777,7 @@ JetResolutionSmearer::JetResolutionSmearer(uhh2::Context & ctx, const JERSmearin
 }
 
 bool JetResolutionSmearer::process(uhh2::Event & event) {
-
+  if(event.isRealData) return true;
   m_gjrs->process(event);
   return true;
 }

--- a/core/include/Utils.h
+++ b/core/include/Utils.h
@@ -40,6 +40,10 @@ std::string int2string(int i) DEPRECATED("use std::to_string instead");
 /// Convert a string to a double
 double string2double(const std::string & s);
 
+/// Convert a string to all lowercase (better for substring matching)
+/// NB Not good with non-ASCII letters e.g. ß !
+std::string string2lowercase(const std::string & s);
+
 /// Make a C++-mangled typename human-readable
 std::string demangle(const std::string & mangled_typename);
 

--- a/core/src/Utils.cxx
+++ b/core/src/Utils.cxx
@@ -4,6 +4,7 @@
 #include <stdexcept>
 #include <cassert>
 #include <limits>
+#include <algorithm>
 #include <strings.h>
 
 #include <boost/lexical_cast.hpp>
@@ -56,6 +57,12 @@ std::string uhh2::int2string(int i){
 
 double uhh2::string2double(const std::string & s){
     return boost::lexical_cast<double>(s);
+}
+
+std::string uhh2::string2lowercase(const std::string & s){
+    std::string outS(s);
+    std::transform(outS.begin(), outS.end(), outS.begin(), ::tolower);
+    return outS;
 }
 
 std::string uhh2::demangle(const std::string & mangled_typename){


### PR DESCRIPTION
Following on from #1218, this changes `JetResolutionSmearer` so that it now has 2 constructors to handle all the year-dependence:

- one takes no arguments apart from usual `uhh2::Context`, and tries to automatically figure out the correct resolution txt file and SFs for the given year & JetCollection name (AK4 vs 8, CHS vs PUPPI)
- one requires arguments to specify both the resolution txt file and the SFs (since both are year-dependent)

Note that this does break existing uses of the constructor that specified only the SFs; however they would actually be incorrect anyway (since potentially using wrong resolution txt file), so it's good that analysis code is aware of this change.

This means that the `JetResolutionSmearer` object in `CommonModules` is now fully-automated (as per the 1st constructor) so should be correctly smearing `event.jets`

[only compile]