### PR TITLE
Configs for storing jet constituents in 2016, 2017 and 2018

### DIFF
--- a/core/python/ntuplewriter_mc_2016v3_leadingjetConstits.py
+++ b/core/python/ntuplewriter_mc_2016v3_leadingjetConstits.py
@@ -18,26 +18,23 @@ process.source.fileNames = cms.untracked.vstring([
     # '/store/mc/RunIIAutumn18MiniAOD/QCD_Pt-15to7000_TuneCP5_Flat2018_13TeV_pythia8/MINIAODSIM/102X_upgrade2018_realistic_v15_ext1-v1/110000/5A494E5A-1A3B-B947-9F85-AF4588ACBBBA.root'
 ])
 
-# Turn on jet constituent storing for all jet collections in this ntuple
+# Turn on jet constituent storing for leading three AK4 jets
 process.MyNtuple.doPFJetConstituentsNjets=3
-process.MyNtuple.doPFTopJetConstituentsNjets=3
 process.MyNtuple.doGenJetConstituentsNjets=3
-process.MyNtuple.doGenTopJetConstituentsNjets=3
-#process.MyNtuple.doPFhotvrJetConstituentsNjets=3
-#process.MyNtuple.doXCone_dijet=True
-#process.MyNtuple.doPFxconeJetConstituentsNjets=2
-#process.MyNtuple.doGenXCone_dijet=True
-#process.MyNtuple.doGenhotvrJetConstituentsNjets=3
-#process.MyNtuple.doGenxconeJetConstituentsNjets=2
-#process.MyNtuple.doPFxconeDijetJetConstituentsNjets=3
-#process.MyNtuple.doGenxconeDijetJetConstituentsNjets=3
 
+# Turn on jet constituent storing for leading three AK8 jets
+process.MyNtuple.doPFTopJetConstituentsNjets=3
+process.MyNtuple.doGenTopJetConstituentsNjets=3
+
+# Turn on jet constituent storing for all AK8 jets with pT > 300 GeV
 process.MyNtuple.doPFTopJetConstituentsMinJetPt=300
 process.MyNtuple.doGenTopJetConstituentsMinJetPt=300
 
+# Turn on jet constituent storing for the two exclusive XCone jets
 process.MyNtuple.doPFxconeJetConstituentsNjets=2
 process.MyNtuple.doGenxconeJetConstituentsNjets=2
 
+# Store leptons with photons in a small cone around them to add up collinear radiation, only needed for TT (switch off for other samples)
 process.MyNtuple.genjet_sources.extend(["muonGenJets", "electronGenJets"])
 
 # Do this after setting process.source.fileNames, since we want the ability to override it on the commandline

--- a/core/python/ntuplewriter_mc_2017v2_leadingjetConstits.py
+++ b/core/python/ntuplewriter_mc_2017v2_leadingjetConstits.py
@@ -1,0 +1,44 @@
+import FWCore.ParameterSet.Config as cms
+from UHH2.core.ntuple_generator import generate_process  # use CMSSW type path for CRAB
+from UHH2.core.optionsParse import setup_opts, parse_apply_opts
+
+
+"""NTuple config for 2017v2 MC datasets.
+
+You should try and put any centralised changes in generate_process(), not here.
+"""
+
+
+process = generate_process(year="2017v2", useData=False)
+
+# Please do not commit changes to source filenames - used for consistency testing
+process.source.fileNames = cms.untracked.vstring([
+    '/store/mc/RunIIFall17MiniAODv2/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/30000/D221F074-FF58-E811-958D-509A4C78138B.root'
+])
+
+# Turn on jet constituent storing for leading three AK4 jets
+process.MyNtuple.doPFJetConstituentsNjets=3
+process.MyNtuple.doGenJetConstituentsNjets=3
+
+# Turn on jet constituent storing for leading three AK8 jets
+process.MyNtuple.doPFTopJetConstituentsNjets=3
+process.MyNtuple.doGenTopJetConstituentsNjets=3
+
+# Turn on jet constituent storing for all AK8 jets with pT > 300 GeV
+process.MyNtuple.doPFTopJetConstituentsMinJetPt=300
+process.MyNtuple.doGenTopJetConstituentsMinJetPt=300
+
+# Turn on jet constituent storing for the two exclusive XCone jets
+process.MyNtuple.doPFxconeJetConstituentsNjets=2
+process.MyNtuple.doGenxconeJetConstituentsNjets=2
+
+# Store leptons with photons in a small cone around them to add up collinear radiation, only needed for TT (switch off for other samples)
+process.MyNtuple.genjet_sources.extend(["muonGenJets", "electronGenJets"])
+
+
+# Do this after setting process.source.fileNames, since we want the ability to override it on the commandline
+options = setup_opts()
+parse_apply_opts(process, options)
+
+with open('pydump_mc_2017v2.py', 'w') as f:
+    f.write(process.dumpPython())

--- a/core/python/ntuplewriter_mc_2018_leadingjetConstits.py
+++ b/core/python/ntuplewriter_mc_2018_leadingjetConstits.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+from UHH2.core.ntuple_generator import generate_process  # use CMSSW type path for CRAB
+from UHH2.core.optionsParse import setup_opts, parse_apply_opts
+
+
+"""NTuple config for 2018 MC datasets.
+
+You should try and put any centralised changes in generate_process(), not here.
+"""
+
+
+process = generate_process(year="2018", useData=False)
+
+# Please do not commit changes to source filenames - used for consistency testing
+process.source.fileNames = cms.untracked.vstring([
+    '/store/mc/RunIIAutumn18MiniAOD/TTToHadronic_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/102X_upgrade2018_realistic_v15-v1/100000/2A6B8F74-04C7-1B46-A56E-8C786D0C2E84.root'
+    # '/store/mc/RunIIAutumn18MiniAOD/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/102X_upgrade2018_realistic_v15-v1/110000/D774DA06-04F6-5E45-B02E-70ECD0DD697F.root'
+    # '/store/mc/RunIIAutumn18MiniAOD/QCD_Pt-15to7000_TuneCP5_Flat2018_13TeV_pythia8/MINIAODSIM/102X_upgrade2018_realistic_v15_ext1-v1/110000/5A494E5A-1A3B-B947-9F85-AF4588ACBBBA.root'
+])
+
+# Turn on jet constituent storing for leading three AK4 jets
+process.MyNtuple.doPFJetConstituentsNjets=3
+process.MyNtuple.doGenJetConstituentsNjets=3
+
+# Turn on jet constituent storing for leading three AK8 jets
+process.MyNtuple.doPFTopJetConstituentsNjets=3
+process.MyNtuple.doGenTopJetConstituentsNjets=3
+
+# Turn on jet constituent storing for all AK8 jets with pT > 300 GeV
+process.MyNtuple.doPFTopJetConstituentsMinJetPt=300
+process.MyNtuple.doGenTopJetConstituentsMinJetPt=300
+
+# Turn on jet constituent storing for the two exclusive XCone jets
+process.MyNtuple.doPFxconeJetConstituentsNjets=2
+process.MyNtuple.doGenxconeJetConstituentsNjets=2
+
+# Store leptons with photons in a small cone around them to add up collinear radiation, only needed for TT (switch off for other samples)
+process.MyNtuple.genjet_sources.extend(["muonGenJets", "electronGenJets"])
+
+
+# Do this after setting process.source.fileNames, since we want the ability to override it on the commandline
+options = setup_opts()
+parse_apply_opts(process, options)
+
+with open('pydump_mc_2018.py', 'w') as f:
+    f.write(process.dumpPython())


### PR DESCRIPTION
Should use these configs for all MC samples relevant for q/g and top jet measurements. 