### PR TITLE
[102X] Update DeepBoosted Wcq getter name as typo

### DIFF
--- a/core/include/TopJet.h
+++ b/core/include/TopJet.h
@@ -226,7 +226,7 @@ public:
   float btag_DeepBoosted_probTbc() const{return m_btag_DeepBoosted_probTbc;}
 
   float btag_DeepBoosted_probWqq() const{return m_btag_DeepBoosted_probWqq;}
-  float btag_DeepBoosted_proWcq() const{return m_btag_DeepBoosted_probWcq;}
+  float btag_DeepBoosted_probWcq() const{return m_btag_DeepBoosted_probWcq;}
 
   float btag_DeepBoosted_probZcc() const{return m_btag_DeepBoosted_probZcc;}
   float btag_DeepBoosted_probZqq() const{return m_btag_DeepBoosted_probZqq;}


### PR DESCRIPTION
Does not affect already produced samples as member variable not changed.