### PR TITLE
[102X] Update locate_file(), use in various modules

### DIFF
--- a/common/include/Utils.h
+++ b/common/include/Utils.h
@@ -50,7 +50,8 @@ std::pair<double, double> drmin_pTrel(const Particle & p, const std::vector<Jet>
  * If fname is an absolute name (=starting with '/'), no file resolution is done, just the check
  * whether the file exists (and exception throwing if not).
  *
- * If fname is a relative path, these directories are tried and the first wins:
+ * If fname is a relative path, it first checks if the relative path exists.
+ * If it doesn't, then these directories are tried and the first wins:
  *  1. $CMSSW_BASE/src/UHH2/
  *  2. $CMSSW_BASE/src/
  *  3. $SFRAME_DIR/UHH2/

--- a/common/src/LumiSelection.cxx
+++ b/common/src/LumiSelection.cxx
@@ -1,4 +1,5 @@
 #include "UHH2/common/include/LumiSelection.h"
+#include "UHH2/common/include/Utils.h"
 
 #include "TFile.h"
 #include "TTree.h"
@@ -9,7 +10,7 @@ using namespace std;
 
 LumiSelection::LumiSelection(uhh2::Context & ctx){
 
-  string lumifile = ctx.get("lumi_file");
+  string lumifile = locate_file(ctx.get("lumi_file"));
   std::unique_ptr<TFile> file(TFile::Open(lumifile.c_str(), "read"));
   TTree * tree = dynamic_cast<TTree*>(file->Get("AnalysisTree"));
   if(!tree){

--- a/common/src/LuminosityHists.cxx
+++ b/common/src/LuminosityHists.cxx
@@ -1,6 +1,7 @@
 #include "UHH2/core/include/Utils.h"
 #include "UHH2/core/include/Event.h"
 #include "UHH2/common/include/LuminosityHists.h"
+#include "UHH2/common/include/Utils.h"
 
 #include "TFile.h"
 #include "TTree.h"
@@ -33,7 +34,7 @@ LuminosityHists::LuminosityHists(uhh2::Context & ctx,
         throw runtime_error("lumihists_lumi_per_bin is <= 0.0; this is not allowed");
     }
     
-    string lumifile = ctx.get("lumi_file");
+    string lumifile = locate_file(ctx.get("lumi_file"));
     std::unique_ptr<TFile> file(TFile::Open(lumifile.c_str(), "read"));
     TTree * tree = dynamic_cast<TTree*>(file->Get("AnalysisTree"));
     if(!tree){

--- a/common/src/Utils.cxx
+++ b/common/src/Utils.cxx
@@ -61,6 +61,10 @@ std::string locate_file(const std::string & fname){
         }
         return fname;
     }
+    // try the current relative string first, e.g. ../x/y.root
+    if (file_exists(fname)) {
+        return fname;
+    }
     // relative: try the various locations ...
     auto cmssw_base = getenv("CMSSW_BASE");
     if(cmssw_base != NULL){


### PR DESCRIPTION
`locate_file()` now also looks for the relative path name without any prepending of `SFRAME_DIR` etc.

Use it in various modules, whenever a `TFile` is opened. Should mean fewer absolute paths in XML configs

[only compile]