### PR TITLE
[102X] Add printout of CommonModules setup after init

### DIFF
--- a/common/include/CommonModules.h
+++ b/common/include/CommonModules.h
@@ -96,6 +96,8 @@ public:
     virtual bool process(uhh2::Event & event) override;
     void init(uhh2::Context & ctx, const std::string & SysType_PU = "central");
 
+    void print_setup() const;
+
 private:
     void fail_if_init() const;
 

--- a/common/src/CommonModules.cxx
+++ b/common/src/CommonModules.cxx
@@ -86,6 +86,7 @@ void CommonModules::init(Context & ctx, const std::string & SysType_PU){
   }
   modules.emplace_back(new HTCalculator(ctx,HT_jetid));
   if(jetid) jet_cleaner.reset(new JetCleaner(ctx, jetid));
+  print_setup();
 }
 
 bool CommonModules::process(uhh2::Event & event){
@@ -140,7 +141,7 @@ bool CommonModules::process(uhh2::Event & event){
       else throw runtime_error("CommonModules.cxx: run number not covered by if-statements in process-routine.");
     }
   }
-  else if(jec || jetlepcleaner) cout <<"WARNING: You used CommonModules for either JEC or jet-lepton-cleaning but MET is not corrected. Please be aware of this." << endl;
+  // else if(jec || jetlepcleaner) cout <<"WARNING: You used CommonModules for either JEC or jet-lepton-cleaning but MET is not corrected. Please be aware of this." << endl;
 
   if(jetid) jet_cleaner->process(event);
 
@@ -184,6 +185,44 @@ void CommonModules::disable_metfilters(){
 void CommonModules::disable_pvfilter(){
   fail_if_init();
   pvfilter = false;
+}
+
+void CommonModules::print_setup() const {
+  std::map<std::string, bool> settings_map = {
+    {"MC luminosity reweighting", mclumiweight},
+    {"MC pileup reweighting", mcpileupreweight},
+    {"Golden Lumi", lumisel},
+    {"JECs", jec},
+    {"JER smearing", jersmear},
+    {"Jet-Lepton cleaning", jetlepcleaner},
+    {"MET Type-1 corrections", do_metcorrection},
+    {"MET filters", metfilters},
+    {"PV filter", pvfilter},
+    {"Jet pT sorting", jetptsort},
+    {"Jet PF ID cleaner", jetpfidcleaner},
+    {"Jet ID", (bool) jetid},
+    {"Electron ID", (bool) eleid},
+    {"Muon ID", (bool) muid},
+    {"Tau ID", (bool) tauid},
+  };
+
+  cout << "----------------------------------------------------------------------------------------------------" << endl;
+  cout << "CommonModules setup:" << endl;
+  cout << "----------------------------------------------------------------------------------------------------" << endl;
+  cout << "is MC? = " << (is_mc ? "TRUE" : "FALSE") << endl;
+  cout << "Year = " << year_str_map.at(year) << endl; // can't use [] accessor as not const
+  cout << endl;
+  for (auto const & [name, flag] : settings_map) {
+    cout << name << " = " << (flag ? "ON" : "OFF") << endl;
+  }
+  cout << endl;
+
+  // Now some special messages
+  // coopy logic from process()
+  if (!((jetlepcleaner && jec) || (do_metcorrection && jec)) && (jec || jetlepcleaner)) {
+    cout << "WARNING: You used CommonModules for either JEC or jet-lepton-cleaning but MET is not corrected." << endl;
+  }
+  cout << "----------------------------------------------------------------------------------------------------" << endl;
 }
 
 class TestCommonModules: public AnalysisModule {


### PR DESCRIPTION
Now one sees something like:

```
----------------------------------------------------------------------------------------------------
CommonModules setup:
----------------------------------------------------------------------------------------------------
is MC? = TRUE
Year = 2018

Electron ID = OFF
Golden Lumi = ON
JECs = ON
JER smearing = ON
Jet ID = OFF
Jet PF ID cleaner = ON
Jet pT sorting = OFF
Jet-Lepton cleaning = OFF
MC luminosity reweighting = ON
MC pileup reweighting = ON
MET Type-1 corrections = OFF
MET filters = ON
Muon ID = OFF
PV filter = ON
Tau ID = OFF

WARNING: You used CommonModules for either JEC or jet-lepton-cleaning but MET is not corrected.
----------------------------------------------------------------------------------------------------
```

at the start of running analysis. Hopefully this should make the setup clearer to analyzer.

Also removes the MET correction warning that gets printed out every event.

[only compile]