### PR TITLE
[102X] Add ability to store extra trigger bits; use for BadPFMuonFilter instead of in veto mode

### DIFF
--- a/common/src/CommonModules.cxx
+++ b/common/src/CommonModules.cxx
@@ -63,7 +63,11 @@ void CommonModules::init(Context & ctx, const std::string & SysType_PU){
     metfilters_selection->add<TriggerSelection>("EcalDeadCellTriggerPrimitiveFilter", "Flag_EcalDeadCellTriggerPrimitiveFilter");
     if (!is_mc) metfilters_selection->add<TriggerSelection>("eeBadScFilter", "Flag_eeBadScFilter");
     // metfilters_selection->add<TriggerSelection>("BadChargedCandidateFilter", "Flag_BadChargedCandidateFilter"); // Not recommended, under review. Separate module in ntuple_generator for 2016v2
-    if (year != Year::is2016v2) metfilters_selection->add<TriggerSelection>("BadPFMuonFilter", "Flag_BadPFMuonFilter"); // Already filter BadPFMuon events in ntuple production
+    if (year != Year::is2016v2) {
+      metfilters_selection->add<TriggerSelection>("BadPFMuonFilter", "Flag_BadPFMuonFilter");
+    } else {
+      metfilters_selection->add<TriggerSelection>("BadPFMuonFilter", "Extra_BadPFMuonFilter");
+    }
     metfilters_selection->add<TriggerSelection>("goodVertices", "Flag_goodVertices");
     metfilters_selection->add<EcalBadCalibSelection>("EcalBadCalibSelection"); // Use this instead of Flag_ecalBadCalibFilter, uses ecalBadCalibReducedMINIAODFilter in ntuple_generator
     if(pvfilter) metfilters_selection->add<NPVSelection>("1 good PV",1,-1,pvid);

--- a/core/plugins/NtupleWriter.h
+++ b/core/plugins/NtupleWriter.h
@@ -171,6 +171,8 @@ class NtupleWriter : public edm::EDFilter {
 
       std::vector<std::vector<FlavorParticle> > triggerObjects_out;
       std::vector<std::string> triggerObjects_sources;
+      std::vector<edm::EDGetTokenT<bool>> extraTriggers_tokens;
+      std::vector<std::string> extraTriggers_names;
 
       std::vector<bool> skipMETUncertainties;
 

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -2023,20 +2023,23 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
     # only introduced after samples were produced.
     # Newer samples will already have these.
     do_bad_muon_charged_filters = (year == "2016v2")
+    extra_trigger_bits = cms.VInputTag()
     if do_bad_muon_charged_filters:
         process.load('RecoMET.METFilters.BadPFMuonFilter_cfi')
         process.BadPFMuonFilter.muons = cms.InputTag("slimmedMuons")
         process.BadPFMuonFilter.PFCandidates = cms.InputTag("packedPFCandidates")
-        process.BadPFMuonFilter.taggingMode = False  # Run in filter mode to reject events, not store them
+        process.BadPFMuonFilter.taggingMode = True  # Don't veto, store bit in ntuple
         task.add(process.BadPFMuonFilter)
+        extra_trigger_bits.append(process.BadPFMuonFilter.label())
 
         # DISABLE Bad Charged Hadron Filter for now as some inefficiency for TeV jets
         # Under review, update when necessary
         # process.load('RecoMET.METFilters.BadChargedCandidateFilter_cfi')
         # process.BadChargedCandidateFilter.muons = cms.InputTag("slimmedMuons")
         # process.BadChargedCandidateFilter.PFCandidates = cms.InputTag("packedPFCandidates")
-        # process.BadChargedCandidateFilter.taggingMode = False
+        # process.BadChargedCandidateFilter.taggingMode = True
         # task.add(process.BadChargedCandidateFilter)
+        # extra_trigger_bits.append(process.BadChargedCandidateFilter.label())
 
     # NtupleWriter
     #
@@ -2404,6 +2407,13 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                     #  'hltEle27WPLooseGsfTrackIsoFilter',                      # HLT_Ele27_eta2p1_WPLoose_Gsf_v*
                                     #),
                                     trigger_objects=cms.InputTag("selectedPatTrigger" if year == "2016v2" else "slimmedPatTrigger"),
+
+                                    # Extra trigger bits to store
+                                    # Each gets stored as "Extra_<name>"
+                                    # In theory one could also store the EcalBadCalib bit here as well,
+                                    # but that might screw up existing workflows,
+                                    # and removing the branch might screw up existing trees
+                                    extra_trigger_bits=extra_trigger_bits,
 
                                     #For 2017 data with prefiring issue it might be usefull to store L1 seeds
                                     doL1seed=cms.bool(True),


### PR DESCRIPTION
- Adds `extra_trigger_bits` argument to NtupleWriter to allow storing of arbitrary bits (any module that produces a `bool`). These get stored like other trigger bits, but as `Extra_*` to avoid clashing with existing trigger names
- Use this to store BadPFMuonFilter now, which is now run as a tagger instead of filtering events
- Update `CommonModules` to use this new flag for 2016v2 samples