### PR TITLE
[102X] Better CRAB request names

### DIFF
--- a/scripts/crab/crab_template.py
+++ b/scripts/crab/crab_template.py
@@ -50,9 +50,9 @@ def get_request_name(dataset_name):
     elif 'ext' in dataset_name:
         modified_name += '_ext'
 
-    if "v1" in dataset_name:
+    if "-v1" in dataset_name:
         modified_name += "_v1"
-    elif "v2" in dataset_name:
+    elif "-v2" in dataset_name:
         modified_name += "_v2"
 
     modified_name += "_" + strftime('%H%M_%d_%b_%y')

--- a/scripts/crab/crab_template.py
+++ b/scripts/crab/crab_template.py
@@ -1,13 +1,13 @@
 # This is a small example how the crab api can easily be used to create something like multi crab.
-# It has some additional features like also creating the xml files for you. 
-# For it to work you need inputDatasets & requestNames apart from the classical part 
+# It has some additional features like also creating the xml files for you.
+# For it to work you need inputDatasets & requestNames apart from the classical part
 #
 # Make sure to have a unique directory where your joboutput is saved, otherwise the script gets confused and you too!!
 #
 # Usage ./CrabConfig ConfigFile [options]
 #
 # Take care here to make the request names *nice*
-# 
+#
 # autocomplete_Datasets(ListOfDatasets) works also for several entries with *
 
 
@@ -50,6 +50,12 @@ def get_request_name(dataset_name):
     elif 'ext' in dataset_name:
         modified_name += '_ext'
 
+    # For e.g. Run2016B which is split into 2
+    if "ver1" in dataset_name:
+        modified_name += "_ver1"
+    elif "ver2" in dataset_name:
+        modified_name += "_ver2"
+
     if "-v1" in dataset_name:
         modified_name += "_v1"
     elif "-v2" in dataset_name:
@@ -77,12 +83,12 @@ config = config()
 config.General.workArea = 'crab_Test'
 config.General.transferOutputs = True
 config.General.transferLogs = True
-        
+
 config.JobType.pluginName = 'Analysis'
 config.JobType.psetName = os.path.join(os.environ['CMSSW_BASE'], 'src/UHH2/core/python/ntuplewriter_mc_2018.py')
 config.JobType.outputFiles = ["Ntuple.root"]
 config.JobType.maxMemoryMB = 2500
-        
+
 config.Data.inputDBS = 'global'
 config.Data.splitting = 'EventAwareLumiBased'
 config.Data.unitsPerJob = 24000
@@ -100,7 +106,7 @@ except ProxyException as e:
     print "Not setting config.Data.outLFNDirBase, will use default"
 
 config.Data.publication = False
-config.JobType.sendExternalFolder = True 
+config.JobType.sendExternalFolder = True
 #config.Data.allowNonValidInputDataset = True
 #config.Data.publishDataName = 'CRAB3_tutorial_May2015_MC_analysis'
 

--- a/scripts/crab/crab_template.py
+++ b/scripts/crab/crab_template.py
@@ -30,21 +30,21 @@ def get_request_name(dataset_name):
         modified_name = modified_name[:max_len]
 
     # Add run year+period for data
-    year_match = re.search(r'201[678][A-Z]', x)
+    year_match = re.search(r'201[678][A-Z]', dataset_name)
     if year_match:
         modified_name += '_'
         modified_name += year_match.group(0)
 
-    if 'ext1' in x:
+    if 'ext1' in dataset_name:
         modified_name += '_ext1'
-    elif 'ext2' in x:
+    elif 'ext2' in dataset_name:
         modified_name += '_ext2'
-    elif 'ext' in x:
+    elif 'ext' in dataset_name:
         modified_name += '_ext'
 
-    if "v1" in x:
+    if "v1" in dataset_name:
         modified_name += "_v1"
-    elif "v2" in x:
+    elif "v2" in dataset_name:
         modified_name += "_v2"
 
     modified_name += "_" + strftime('%H%M_%d_%b_%y')

--- a/scripts/crab/crab_template.py
+++ b/scripts/crab/crab_template.py
@@ -24,8 +24,8 @@ def get_request_name(dataset_name):
     modified_name = modified_name.replace('_TuneCUETP8M1_13TeV_pythia8', '_P8M1')
 
     # request name can only be 100 characters maximum
-    # at this point we need to chop it down to allow for ext2, v2, time, date
-    max_len = 100-25
+    # at this point we need to chop it down, to allow for campaign, time, date, ext2, v2
+    max_len = 100-34
     if len(modified_name) > max_len:
         modified_name = modified_name[:max_len]
 
@@ -34,6 +34,14 @@ def get_request_name(dataset_name):
     if year_match:
         modified_name += '_'
         modified_name += year_match.group(0)
+
+    # Add MC campaign
+    if "Summer16" in dataset_name:
+        modified_name += "_Summer16"
+    elif "Fall17" in dataset_name:
+        modified_name += "_Fall17"
+    elif "Autumn18" in dataset_name:
+        modified_name += "_Autumn18"
 
     if 'ext1' in dataset_name:
         modified_name += '_ext1'

--- a/scripts/crab/crab_template.py
+++ b/scripts/crab/crab_template.py
@@ -9,23 +9,51 @@
 # Take care here to make the request names *nice*
 # 
 # autocomplete_Datasets(ListOfDatasets) works also for several entries with *
-#
+
+
+import re
+from time import strftime
 from DasQuery import autocomplete_Datasets
 
-inputDatasets = ['/DYJetsToLL_M-50_HT-*to*_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_*/MINIAODSIM']
-inputDatasets = autocomplete_Datasets(inputDatasets)
-requestNames = []
-for x in inputDatasets:
-    name = x.split('/')[1]
-    modified_name =name.replace('_TuneCUETP8M1_13TeV-madgraphMLM-pythia8','')
+
+def get_request_name(dataset_name):
+    """Generate short string to use for request name from full dataset name"""
+    modified_name = dataset_name.split('/')[1]
+    modified_name = modified_name.replace('_TuneCUETP8M1_13TeV-madgraphMLM-pythia8', '_P8M1')
+    modified_name = modified_name.replace('_TuneCP5_13TeV-madgraphMLM-pythia8', '_CP5')
+    modified_name = modified_name.replace('_TuneCUETP8M1_13TeV_pythia8', '_P8M1')
+
+    # request name can only be 100 characters maximum
+    # at this point we need to chop it down to allow for ext2, v2, time, date
+    max_len = 100-25
+    if len(modified_name) > max_len:
+        modified_name = modified_name[:max_len]
+
+    # Add run year+period for data
+    year_match = re.search(r'201[678][A-Z]', x)
+    if year_match:
+        modified_name += '_'
+        modified_name += year_match.group(0)
+
     if 'ext1' in x:
         modified_name += '_ext1'
     elif 'ext2' in x:
         modified_name += '_ext2'
     elif 'ext' in x:
         modified_name += '_ext'
-    requestNames.append(modified_name)
 
+    if "v1" in x:
+        modified_name += "_v1"
+    elif "v2" in x:
+        modified_name += "_v2"
+
+    modified_name += "_" + strftime('%H%M_%d_%b_%y')
+    return modified_name
+
+
+inputDatasets = ['/DYJetsToLL_M-50_HT-*to*_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_*/MINIAODSIM']
+inputDatasets = autocomplete_Datasets(inputDatasets)
+requestNames = [get_request_name(x) for x in inputDatasets]
 
 # ===============================================================================
 # Classical part of crab, after resolving the * it uses in the example below just the first entry


### PR DESCRIPTION
Request name in `crab_template.py` now improved: can handle data run periods (previously would only return e.g. 'JetHT' for all run years & periods), long names (CRAB has maximum of 100 char), different versions, shorten a few more common generator strings, add MC campaign name. Also adds in time + date to aid with submissions over different days.

examples:

| Dataset | Request name |
| ---------- | ---------- |
| /JetHT/Run2018A-17Sep2018-v1/MINIAOD | JetHT_2018A_v1_1106_29_Apr_19 |
| /SingleElectron/Run2017B-31Mar2018-v1/MINIAOD | SingleElectron_2017B_v1_1106_29_Apr_19 |
| /JetHT/Run2016B-17Jul2018_ver1-v1/MINIAOD | JetHT_2016B_ver1_v1_1106_29_Apr_19 |
| /JetHT/Run2016B-17Jul2018_ver2-v1/MINIAOD | JetHT_2016B_ver2_v1_1106_29_Apr_19 |
| /JetHT/Run2016B-17Jul2018_ver2-v2/MINIAOD | JetHT_2016B_ver2_v2_1106_29_Apr_19 |
| /QCD_HT100to200_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM | QCD_HT100to200_CP5_Autumn18_v1_1106_29_Apr_19 |
| /ST_tW_top_5f_DS_NoFullyHadronicDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM | ST_tW_top_5f_DS_NoFullyHadronicDecays_13TeV-powheg-pythia8_TuneCUE_Summer16_v2_1106_29_Apr_19 |
| /QCD_HT700to1000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM | QCD_HT700to1000_P8M1_Summer16_v2_1106_29_Apr_19 |
| /QCD_Pt_170to300_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM | QCD_Pt_170to300_P8M1_Summer16_v2_1106_29_Apr_19 |
| /DYJetsToLL_M-50_HT-800to1200_TuneCP5_PSweights_13TeV-madgraphMLM-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM | DYJetsToLL_M-50_HT-800to1200_TuneCP5_PSweights_13TeV-madgraphMLM-p_Autumn18_v2_1106_29_Apr_19 |
| /WJetsToLNu_BGenFilter_Wpt-100to200_TuneCP5_13TeV-madgraphMLM-pythia8_newgridpack/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM | WJetsToLNu_BGenFilter_Wpt-100to200_CP5_newgridpack_Fall17_v1_1106_29_Apr_19 |
| /DYJetsToTauTau_ForcedMuEleDecay_M-50_TuneCP5_PSweights_13TeV-amcatnloFXFX-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14_ext1-v1/MINIAODSIM | DYJetsToTauTau_ForcedMuEleDecay_M-50_TuneCP5_PSweights_13TeV-amcat_Fall17_ext1_v1_1106_29_Apr_19 |
| /DYJetsToLL_M-105To160_VBFFilter_TuneCP5_PSweights_13TeV-amcatnloFXFX-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_VBFPostMGFilter_94X_mc2017_realistic_v14_ext1-v1/MINIAODSIM | DYJetsToLL_M-105To160_VBFFilter_TuneCP5_PSweights_13TeV-amcatnloFX_Fall17_ext1_v1_1106_29_Apr_19 |


[ci skip]