### PR TITLE
Add Github PR template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,10 @@
+This Pull Request will start automatic compilation, then making + testing of ntuples:
+
+- Don't want to run any of this? (e.g. only XML files) Remove the @: [ci @ skip]
+
+- Only want to compile, but don't make + test ntuples? (e.g. change `CommonModules.cxx`) Remove the @: [only @ compile]
+
+Please include destination branch in title, e.g. `[102X]`, + short meaningful title
+
+Please include an explanation message if it's something more complex than just XML dataset files:
+


### PR DESCRIPTION
To remind people of CI options, plus better title + message. This will be the standard template whenever someone opens a PR.