### PR TITLE
[102X] Remove datetime from requestname as breaks multicrab

### DIFF
--- a/scripts/crab/crab_template.py
+++ b/scripts/crab/crab_template.py
@@ -12,7 +12,6 @@
 
 
 import re
-from time import strftime
 from DasQuery import autocomplete_Datasets
 
 
@@ -61,7 +60,6 @@ def get_request_name(dataset_name):
     elif "-v2" in dataset_name:
         modified_name += "_v2"
 
-    modified_name += "_" + strftime('%H%M_%d_%b_%y')
     return modified_name
 
 


### PR DESCRIPTION
[ci skip]

Revert change to add datetime stamp to crab requestname, since it screws up using the multicrab script to make XML files (since it uses the requestnames from the crab template file).
