### PR TITLE
[102X] Create JEC sets with functions instead of preprocessor macros

### DIFF
--- a/common/include/CommonModules.h
+++ b/common/include/CommonModules.h
@@ -124,6 +124,9 @@ private:
 
     Year year;
 
+    // Parameters for JEC & JLC sets
+    std::string jec_tag, jec_ver, jec_jet_coll;
+
     std::unique_ptr<Selection> lumi_selection;
     std::unique_ptr<AndSelection> metfilters_selection;
 

--- a/common/include/JetCorrectionSets.h
+++ b/common/include/JetCorrectionSets.h
@@ -20,17 +20,33 @@ namespace JERFiles{
    */
 
   // JECPathString returns a single JEC filepath for given tag, ver, etc
-  const std::string JECPathStringMC(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & correction);
-  const std::string JECPathStringDATA(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & runName, const std::string & correction);
+  const std::string JECPathStringMC(const std::string & tag,
+                                    const std::string & ver,
+                                    const std::string & jetCollection,
+                                    const std::string & correction);
+
+  const std::string JECPathStringDATA(const std::string & tag,
+                                      const std::string & ver,
+                                      const std::string & jetCollection,
+                                      const std::string & runName,
+                                      const std::string & correction);
 
   // Some common variable to replace long vector strings
   extern const std::vector<std::string> L1L2L3;
   extern const std::vector<std::string> L1L2L3Residual;
 
   // These are the methods returning the total list of JEC files for a set of levels
-  // Version with runName is for data
-  const std::vector<std::string> JECFilesMC(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::vector<std::string> levels=JERFiles::L1L2L3);
-  const std::vector<std::string> JECFilesDATA(const std::string & tag, const std::string & ver, const std::string & runName, const std::string & jetCollection, const std::vector<std::string> levels=JERFiles::L1L2L3Residual);
+  // This can be passed to e.g. `JetCorrector` class
+  const std::vector<std::string> JECFilesMC(const std::string & tag,
+                                            const std::string & ver,
+                                            const std::string & jetCollection,
+                                            const std::vector<std::string> levels=JERFiles::L1L2L3);
+
+  const std::vector<std::string> JECFilesDATA(const std::string & tag,
+                                              const std::string & ver,
+                                              const std::string & jetCollection,
+                                              const std::string & runName,
+                                              const std::vector<std::string> levels=JERFiles::L1L2L3Residual);
 
   #define DEFINE_CORRECTION_MC(tag,ver,jetCollection,Correction)                            \
   extern const std::vector<std::string> tag##_V##ver##_##Correction##_##jetCollection##_MC; \

--- a/common/include/JetCorrectionSets.h
+++ b/common/include/JetCorrectionSets.h
@@ -13,6 +13,12 @@ namespace JERFiles{
   Files for Data are created for each run separately.
   */
 
+  const std::string JECPathStringMC(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & Correction);
+  const std::vector<std::string> JECFiles_MC(const std::string & tag, const std::string & ver, const std::string & jetCollection);
+
+  const std::string JECPathStringMC2016(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & Correction);
+  const std::vector<std::string> JECFiles_MC2016(const std::string & tag, const std::string & ver, const std::string & jetCollection);
+
   #define DEFINE_CORRECTION_MC(tag,ver,jetCollection,Correction)                            \
   extern const std::vector<std::string> tag##_V##ver##_##Correction##_##jetCollection##_MC; \
 
@@ -67,17 +73,17 @@ namespace JERFiles{
   */
 
   //2016, official Moriond19
-  DEFINE_JECFILES_MC(Summer16_07Aug2017,11,AK4PFchs) 
-  DEFINE_JECFILES_MC(Summer16_07Aug2017,11,AK4PFPuppi) 
-  DEFINE_JECFILES_MC(Summer16_07Aug2017,11,AK8PFchs) 
-  DEFINE_JECFILES_MC(Summer16_07Aug2017,11,AK8PFPuppi) 
-  DEFINE_JECFILES_DATA2016(Summer16_07Aug2017,11,AK4PFchs) 
-  DEFINE_JECFILES_DATA2016(Summer16_07Aug2017,11,AK4PFPuppi) 
-  DEFINE_JECFILES_DATA2016(Summer16_07Aug2017,11,AK8PFchs) 
-  DEFINE_JECFILES_DATA2016(Summer16_07Aug2017,11,AK8PFPuppi) 
+  DEFINE_JECFILES_MC(Summer16_07Aug2017,11,AK4PFchs)
+  DEFINE_JECFILES_MC(Summer16_07Aug2017,11,AK4PFPuppi)
+  DEFINE_JECFILES_MC(Summer16_07Aug2017,11,AK8PFchs)
+  DEFINE_JECFILES_MC(Summer16_07Aug2017,11,AK8PFPuppi)
+  DEFINE_JECFILES_DATA2016(Summer16_07Aug2017,11,AK4PFchs)
+  DEFINE_JECFILES_DATA2016(Summer16_07Aug2017,11,AK4PFPuppi)
+  DEFINE_JECFILES_DATA2016(Summer16_07Aug2017,11,AK8PFchs)
+  DEFINE_JECFILES_DATA2016(Summer16_07Aug2017,11,AK8PFPuppi)
   //2016, JERC legacy studies
-  DEFINE_JECFILES_MC(Summer16_07Aug2017,20,AK4PFchs) 
-  DEFINE_JECFILES_DATA2016(Summer16_07Aug2017,20,AK4PFchs) 
+  DEFINE_JECFILES_MC(Summer16_07Aug2017,20,AK4PFchs)
+  DEFINE_JECFILES_DATA2016(Summer16_07Aug2017,20,AK4PFchs)
 
   //2017, official Moriond19
   DEFINE_JECFILES_MC(Fall17_17Nov2017,32,AK4PFchs)

--- a/common/include/JetCorrectionSets.h
+++ b/common/include/JetCorrectionSets.h
@@ -9,7 +9,7 @@ namespace JERFiles{
 
   /**
    * There are 2 ways to get access to JEC sets, needed for *JetEnergyCorrector class:
-   * - use the JECFiles_[DATA|MC]() functions
+   * - use the JECFiles[DATA|MC]() functions
    * - a C++ variable, defined below with the DEFINE_* macros,
    *   and created in the cxx file with the SET_* macros
    * The 1st option is preferred in user analysis code, as it is more flexible
@@ -18,11 +18,15 @@ namespace JERFiles{
    * The 2nd option just uses the output of the 1st option, and is the reason for
    * all the preprocessor commands. These are kept only for backwards-compatibility.
    */
-  const std::string JECPathStringData(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & runName, const std::string & Correction);
-  const std::vector<std::string> JECFiles_DATA(const std::string & tag, const std::string & ver, const std::string & runName, const std::string & jetCollection, const std::vector<std::string> levels);
 
-  const std::string JECPathStringMC(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & Correction);
-  const std::vector<std::string> JECFiles_MC(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::vector<std::string> levels);
+  // JECPathString returns a single JEC filepath for given tag, ver, etc
+  const std::string JECPathStringMC(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & correction);
+  const std::string JECPathStringDATA(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & runName, const std::string & correction);
+
+  // These are the methods returning the total list of JEC files for a set of levels
+  // Version with runName is for data
+  const std::vector<std::string> JECFilesMC(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::vector<std::string> levels);
+  const std::vector<std::string> JECFilesDATA(const std::string & tag, const std::string & ver, const std::string & runName, const std::string & jetCollection, const std::vector<std::string> levels);
 
   // Some common variable to replace long vector strings
   extern const std::vector<std::string> L1L2L3;

--- a/common/include/JetCorrectionSets.h
+++ b/common/include/JetCorrectionSets.h
@@ -13,6 +13,12 @@ namespace JERFiles{
   Files for Data are created for each run separately.
   */
 
+  const std::string JECPathStringData(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & runName, const std::string & Correction);
+  const std::vector<std::string> JECFiles_DATA(const std::string & tag, const std::string & ver, const std::string & runName, const std::string & jetCollection);
+
+  const std::string JECPathStringData2018(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & runName, const std::string & Correction);
+  const std::vector<std::string> JECFiles_DATA2018(const std::string & tag, const std::string & ver, const std::string & runName, const std::string & jetCollection);
+
   const std::string JECPathStringMC(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & Correction);
   const std::vector<std::string> JECFiles_MC(const std::string & tag, const std::string & ver, const std::string & jetCollection);
 

--- a/common/include/JetCorrectionSets.h
+++ b/common/include/JetCorrectionSets.h
@@ -13,42 +13,36 @@ namespace JERFiles{
   Files for Data are created for each run separately.
   */
 
-  const std::string JECPathStringData(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & runName, const std::string & Correction);
-  const std::vector<std::string> JECFiles_DATA(const std::string & tag, const std::string & ver, const std::string & runName, const std::string & jetCollection);
+  static std::string JECPathStringData(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & runName, const std::string & Correction);
+  static std::vector<std::string> JECFiles_DATA(const std::string & tag, const std::string & ver, const std::string & runName, const std::string & jetCollection);
 
-  const std::string JECPathStringData2018(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & runName, const std::string & Correction);
-  const std::vector<std::string> JECFiles_DATA2018(const std::string & tag, const std::string & ver, const std::string & runName, const std::string & jetCollection);
-
-  const std::string JECPathStringMC(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & Correction);
-  const std::vector<std::string> JECFiles_MC(const std::string & tag, const std::string & ver, const std::string & jetCollection);
-
-  const std::string JECPathStringMC2016(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & Correction);
-  const std::vector<std::string> JECFiles_MC2016(const std::string & tag, const std::string & ver, const std::string & jetCollection);
+  static std::string JECPathStringMC(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & Correction);
+  static std::vector<std::string> JECFiles_MC(const std::string & tag, const std::string & ver, const std::string & jetCollection);
 
   #define DEFINE_CORRECTION_MC(tag,ver,jetCollection,Correction)                            \
-  extern const std::vector<std::string> tag##_V##ver##_##Correction##_##jetCollection##_MC; \
+  extern const static std::vector<std::string> tag##_V##ver##_##Correction##_##jetCollection##_MC; \
 
-#define DEFINE_CORRECTION_DATA2016(tag,ver,jetCollection,Correction)	\
-  extern const std::vector<std::string> tag##_V##ver##_B_##Correction##_##jetCollection##_DATA;   \
-  extern const std::vector<std::string> tag##_V##ver##_C_##Correction##_##jetCollection##_DATA;   \
-  extern const std::vector<std::string> tag##_V##ver##_D_##Correction##_##jetCollection##_DATA;   \
-  extern const std::vector<std::string> tag##_V##ver##_E_##Correction##_##jetCollection##_DATA;   \
-  extern const std::vector<std::string> tag##_V##ver##_F_##Correction##_##jetCollection##_DATA;   \
-  extern const std::vector<std::string> tag##_V##ver##_G_##Correction##_##jetCollection##_DATA;   \
-  extern const std::vector<std::string> tag##_V##ver##_H_##Correction##_##jetCollection##_DATA;   \
+  #define DEFINE_CORRECTION_DATA2016(tag,ver,jetCollection,Correction)	\
+  extern const static std::vector<std::string> tag##_V##ver##_B_##Correction##_##jetCollection##_DATA;   \
+  extern const static std::vector<std::string> tag##_V##ver##_C_##Correction##_##jetCollection##_DATA;   \
+  extern const static std::vector<std::string> tag##_V##ver##_D_##Correction##_##jetCollection##_DATA;   \
+  extern const static std::vector<std::string> tag##_V##ver##_E_##Correction##_##jetCollection##_DATA;   \
+  extern const static std::vector<std::string> tag##_V##ver##_F_##Correction##_##jetCollection##_DATA;   \
+  extern const static std::vector<std::string> tag##_V##ver##_G_##Correction##_##jetCollection##_DATA;   \
+  extern const static std::vector<std::string> tag##_V##ver##_H_##Correction##_##jetCollection##_DATA;   \
 
-#define DEFINE_CORRECTION_DATA2017(tag,ver,jetCollection,Correction)	\
-  extern const std::vector<std::string> tag##_V##ver##_B_##Correction##_##jetCollection##_DATA;   \
-  extern const std::vector<std::string> tag##_V##ver##_C_##Correction##_##jetCollection##_DATA;   \
-  extern const std::vector<std::string> tag##_V##ver##_D_##Correction##_##jetCollection##_DATA;   \
-  extern const std::vector<std::string> tag##_V##ver##_E_##Correction##_##jetCollection##_DATA;   \
-  extern const std::vector<std::string> tag##_V##ver##_F_##Correction##_##jetCollection##_DATA;   \
+  #define DEFINE_CORRECTION_DATA2017(tag,ver,jetCollection,Correction)	\
+  extern const static std::vector<std::string> tag##_V##ver##_B_##Correction##_##jetCollection##_DATA;   \
+  extern const static std::vector<std::string> tag##_V##ver##_C_##Correction##_##jetCollection##_DATA;   \
+  extern const static std::vector<std::string> tag##_V##ver##_D_##Correction##_##jetCollection##_DATA;   \
+  extern const static std::vector<std::string> tag##_V##ver##_E_##Correction##_##jetCollection##_DATA;   \
+  extern const static std::vector<std::string> tag##_V##ver##_F_##Correction##_##jetCollection##_DATA;   \
 
-#define DEFINE_CORRECTION_DATA2018(tag,ver,jetCollection,Correction)	\
-  extern const std::vector<std::string> tag##_V##ver##_A_##Correction##_##jetCollection##_DATA;   \
-  extern const std::vector<std::string> tag##_V##ver##_B_##Correction##_##jetCollection##_DATA;   \
-  extern const std::vector<std::string> tag##_V##ver##_C_##Correction##_##jetCollection##_DATA;   \
-  extern const std::vector<std::string> tag##_V##ver##_D_##Correction##_##jetCollection##_DATA;   \
+  #define DEFINE_CORRECTION_DATA2018(tag,ver,jetCollection,Correction)	\
+  extern const static std::vector<std::string> tag##_V##ver##_A_##Correction##_##jetCollection##_DATA;   \
+  extern const static std::vector<std::string> tag##_V##ver##_B_##Correction##_##jetCollection##_DATA;   \
+  extern const static std::vector<std::string> tag##_V##ver##_C_##Correction##_##jetCollection##_DATA;   \
+  extern const static std::vector<std::string> tag##_V##ver##_D_##Correction##_##jetCollection##_DATA;   \
 
 
   #define DEFINE_JECFILES_MC(tag,ver,jetCollection)     \

--- a/common/include/JetCorrectionSets.h
+++ b/common/include/JetCorrectionSets.h
@@ -24,6 +24,10 @@ namespace JERFiles{
   const std::string JECPathStringMC(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & Correction);
   const std::vector<std::string> JECFiles_MC(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::vector<std::string> levels);
 
+  // Some common variable to replace long vector strings
+  extern const std::vector<std::string> L1L2L3;
+  extern const std::vector<std::string> L1L2L3Residual;
+
   #define DEFINE_CORRECTION_MC(tag,ver,jetCollection,Correction)                            \
   extern const std::vector<std::string> tag##_V##ver##_##Correction##_##jetCollection##_MC; \
 

--- a/common/include/JetCorrectionSets.h
+++ b/common/include/JetCorrectionSets.h
@@ -23,14 +23,14 @@ namespace JERFiles{
   const std::string JECPathStringMC(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & correction);
   const std::string JECPathStringDATA(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & runName, const std::string & correction);
 
-  // These are the methods returning the total list of JEC files for a set of levels
-  // Version with runName is for data
-  const std::vector<std::string> JECFilesMC(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::vector<std::string> levels);
-  const std::vector<std::string> JECFilesDATA(const std::string & tag, const std::string & ver, const std::string & runName, const std::string & jetCollection, const std::vector<std::string> levels);
-
   // Some common variable to replace long vector strings
   extern const std::vector<std::string> L1L2L3;
   extern const std::vector<std::string> L1L2L3Residual;
+
+  // These are the methods returning the total list of JEC files for a set of levels
+  // Version with runName is for data
+  const std::vector<std::string> JECFilesMC(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::vector<std::string> levels=JERFiles::L1L2L3);
+  const std::vector<std::string> JECFilesDATA(const std::string & tag, const std::string & ver, const std::string & runName, const std::string & jetCollection, const std::vector<std::string> levels=JERFiles::L1L2L3Residual);
 
   #define DEFINE_CORRECTION_MC(tag,ver,jetCollection,Correction)                            \
   extern const std::vector<std::string> tag##_V##ver##_##Correction##_##jetCollection##_MC; \

--- a/common/include/JetCorrectionSets.h
+++ b/common/include/JetCorrectionSets.h
@@ -3,46 +3,51 @@
 #include <vector>
 #include <string>
 
-/* namespace to define some useful filename constants to be used for jet energy corrections */
+/* namespace to define useful filename constants & functions to be used for jet energy corrections */
 
 namespace JERFiles{
 
-  /* The idea of the following preprocessor directives is to simplify the creation of new JEC input files.
-  MC and DATA are treated separately by choice: this is mainly becuase of how JEC are developed.
-  Different corrections are applied for MC and Data. Those should stay fixed or follow JME reccomendations.
-  Files for Data are created for each run separately.
-  */
+  /**
+   * There are 2 ways to get access to JEC sets, needed for *JetEnergyCorrector class:
+   * - use the JECFiles_[DATA|MC]() functions
+   * - a C++ variable, defined below with the DEFINE_* macros,
+   *   and created in the cxx file with the SET_* macros
+   * The 1st option is preferred in user analysis code, as it is more flexible
+   * (e.g. one can use variables to change all JEC versions
+   *  for different jet collections simultaneously)
+   * The 2nd option just uses the output of the 1st option, and is the reason for
+   * all the preprocessor commands. These are kept only for backwards-compatibility.
+   */
+  const std::string JECPathStringData(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & runName, const std::string & Correction);
+  const std::vector<std::string> JECFiles_DATA(const std::string & tag, const std::string & ver, const std::string & runName, const std::string & jetCollection, const std::vector<std::string> levels);
 
-  static std::string JECPathStringData(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & runName, const std::string & Correction);
-  static std::vector<std::string> JECFiles_DATA(const std::string & tag, const std::string & ver, const std::string & runName, const std::string & jetCollection);
-
-  static std::string JECPathStringMC(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & Correction);
-  static std::vector<std::string> JECFiles_MC(const std::string & tag, const std::string & ver, const std::string & jetCollection);
+  const std::string JECPathStringMC(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & Correction);
+  const std::vector<std::string> JECFiles_MC(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::vector<std::string> levels);
 
   #define DEFINE_CORRECTION_MC(tag,ver,jetCollection,Correction)                            \
-  extern const static std::vector<std::string> tag##_V##ver##_##Correction##_##jetCollection##_MC; \
+  extern const std::vector<std::string> tag##_V##ver##_##Correction##_##jetCollection##_MC; \
 
   #define DEFINE_CORRECTION_DATA2016(tag,ver,jetCollection,Correction)	\
-  extern const static std::vector<std::string> tag##_V##ver##_B_##Correction##_##jetCollection##_DATA;   \
-  extern const static std::vector<std::string> tag##_V##ver##_C_##Correction##_##jetCollection##_DATA;   \
-  extern const static std::vector<std::string> tag##_V##ver##_D_##Correction##_##jetCollection##_DATA;   \
-  extern const static std::vector<std::string> tag##_V##ver##_E_##Correction##_##jetCollection##_DATA;   \
-  extern const static std::vector<std::string> tag##_V##ver##_F_##Correction##_##jetCollection##_DATA;   \
-  extern const static std::vector<std::string> tag##_V##ver##_G_##Correction##_##jetCollection##_DATA;   \
-  extern const static std::vector<std::string> tag##_V##ver##_H_##Correction##_##jetCollection##_DATA;   \
+  extern const std::vector<std::string> tag##_V##ver##_B_##Correction##_##jetCollection##_DATA;   \
+  extern const std::vector<std::string> tag##_V##ver##_C_##Correction##_##jetCollection##_DATA;   \
+  extern const std::vector<std::string> tag##_V##ver##_D_##Correction##_##jetCollection##_DATA;   \
+  extern const std::vector<std::string> tag##_V##ver##_E_##Correction##_##jetCollection##_DATA;   \
+  extern const std::vector<std::string> tag##_V##ver##_F_##Correction##_##jetCollection##_DATA;   \
+  extern const std::vector<std::string> tag##_V##ver##_G_##Correction##_##jetCollection##_DATA;   \
+  extern const std::vector<std::string> tag##_V##ver##_H_##Correction##_##jetCollection##_DATA;   \
 
   #define DEFINE_CORRECTION_DATA2017(tag,ver,jetCollection,Correction)	\
-  extern const static std::vector<std::string> tag##_V##ver##_B_##Correction##_##jetCollection##_DATA;   \
-  extern const static std::vector<std::string> tag##_V##ver##_C_##Correction##_##jetCollection##_DATA;   \
-  extern const static std::vector<std::string> tag##_V##ver##_D_##Correction##_##jetCollection##_DATA;   \
-  extern const static std::vector<std::string> tag##_V##ver##_E_##Correction##_##jetCollection##_DATA;   \
-  extern const static std::vector<std::string> tag##_V##ver##_F_##Correction##_##jetCollection##_DATA;   \
+  extern const std::vector<std::string> tag##_V##ver##_B_##Correction##_##jetCollection##_DATA;   \
+  extern const std::vector<std::string> tag##_V##ver##_C_##Correction##_##jetCollection##_DATA;   \
+  extern const std::vector<std::string> tag##_V##ver##_D_##Correction##_##jetCollection##_DATA;   \
+  extern const std::vector<std::string> tag##_V##ver##_E_##Correction##_##jetCollection##_DATA;   \
+  extern const std::vector<std::string> tag##_V##ver##_F_##Correction##_##jetCollection##_DATA;   \
 
   #define DEFINE_CORRECTION_DATA2018(tag,ver,jetCollection,Correction)	\
-  extern const static std::vector<std::string> tag##_V##ver##_A_##Correction##_##jetCollection##_DATA;   \
-  extern const static std::vector<std::string> tag##_V##ver##_B_##Correction##_##jetCollection##_DATA;   \
-  extern const static std::vector<std::string> tag##_V##ver##_C_##Correction##_##jetCollection##_DATA;   \
-  extern const static std::vector<std::string> tag##_V##ver##_D_##Correction##_##jetCollection##_DATA;   \
+  extern const std::vector<std::string> tag##_V##ver##_A_##Correction##_##jetCollection##_DATA;   \
+  extern const std::vector<std::string> tag##_V##ver##_B_##Correction##_##jetCollection##_DATA;   \
+  extern const std::vector<std::string> tag##_V##ver##_C_##Correction##_##jetCollection##_DATA;   \
+  extern const std::vector<std::string> tag##_V##ver##_D_##Correction##_##jetCollection##_DATA;   \
 
 
   #define DEFINE_JECFILES_MC(tag,ver,jetCollection)     \

--- a/common/src/CommonModules.cxx
+++ b/common/src/CommonModules.cxx
@@ -49,8 +49,8 @@ void CommonModules::init(Context & ctx, const std::string & SysType_PU){
     if(jec){
       jet_corrector_B.reset(new JetCorrector(ctx, JERFiles::JECFilesDATA("Fall17_17Nov2017", "32", "AK4PFchs", "B")));
       jet_corrector_C.reset(new JetCorrector(ctx, JERFiles::JECFilesDATA("Fall17_17Nov2017", "32", "AK4PFchs", "C")));
-      jet_corrector_D.reset(new JetCorrector(ctx, JERFiles::JECFilesDATA("Fall17_17Nov2017", "32", "AK4PFchs", "D")));
-      jet_corrector_E.reset(new JetCorrector(ctx, JERFiles::JECFilesDATA("Fall17_17Nov2017", "32", "AK4PFchs", "E")));
+      jet_corrector_D.reset(new JetCorrector(ctx, JERFiles::JECFilesDATA("Fall17_17Nov2017", "32", "AK4PFchs", "DE")));
+      jet_corrector_E.reset(new JetCorrector(ctx, JERFiles::JECFilesDATA("Fall17_17Nov2017", "32", "AK4PFchs", "DE")));
       jet_corrector_F.reset(new JetCorrector(ctx, JERFiles::JECFilesDATA("Fall17_17Nov2017", "32", "AK4PFchs", "F")));
     }
   }
@@ -83,8 +83,8 @@ void CommonModules::init(Context & ctx, const std::string & SysType_PU){
     else{
       JLC_B.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::JECFilesDATA("Fall17_17Nov2017", "32", "AK4PFchs", "B")));
       JLC_C.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::JECFilesDATA("Fall17_17Nov2017", "32", "AK4PFchs", "C")));
-      JLC_D.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::JECFilesDATA("Fall17_17Nov2017", "32", "AK4PFchs", "D")));
-      JLC_E.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::JECFilesDATA("Fall17_17Nov2017", "32", "AK4PFchs", "E")));
+      JLC_D.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::JECFilesDATA("Fall17_17Nov2017", "32", "AK4PFchs", "DE")));
+      JLC_E.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::JECFilesDATA("Fall17_17Nov2017", "32", "AK4PFchs", "DE")));
       JLC_F.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::JECFilesDATA("Fall17_17Nov2017", "32", "AK4PFchs", "F")));
     }
   }

--- a/common/src/CommonModules.cxx
+++ b/common/src/CommonModules.cxx
@@ -40,18 +40,18 @@ void CommonModules::init(Context & ctx, const std::string & SysType_PU){
     if(mclumiweight)  modules.emplace_back(new MCLumiWeight(ctx));
     if(mcpileupreweight) modules.emplace_back(new MCPileupReweight(ctx,SysType_PU));
     if(jec){
-      jet_corrector_MC.reset(new JetCorrector(ctx, JERFiles::Fall17_17Nov2017_V32_L123_AK4PFchs_MC));
+      jet_corrector_MC.reset(new JetCorrector(ctx, JERFiles::JECFilesMC("Fall17_17Nov2017", "32", "AK4PFchs")));
     }
     if(jersmear) jet_resolution_smearer.reset(new JetResolutionSmearer(ctx));
   }
   else{
     if(lumisel) lumi_selection.reset(new LumiSelection(ctx));
     if(jec){
-      jet_corrector_B.reset(new JetCorrector(ctx, JERFiles::Fall17_17Nov2017_V32_B_L123_AK4PFchs_DATA));
-      jet_corrector_C.reset(new JetCorrector(ctx, JERFiles::Fall17_17Nov2017_V32_C_L123_AK4PFchs_DATA));
-      jet_corrector_D.reset(new JetCorrector(ctx, JERFiles::Fall17_17Nov2017_V32_D_L123_AK4PFchs_DATA));
-      jet_corrector_E.reset(new JetCorrector(ctx, JERFiles::Fall17_17Nov2017_V32_E_L123_AK4PFchs_DATA));
-      jet_corrector_F.reset(new JetCorrector(ctx, JERFiles::Fall17_17Nov2017_V32_F_L123_AK4PFchs_DATA));
+      jet_corrector_B.reset(new JetCorrector(ctx, JERFiles::JECFilesDATA("Fall17_17Nov2017", "32", "AK4PFchs", "B")));
+      jet_corrector_C.reset(new JetCorrector(ctx, JERFiles::JECFilesDATA("Fall17_17Nov2017", "32", "AK4PFchs", "C")));
+      jet_corrector_D.reset(new JetCorrector(ctx, JERFiles::JECFilesDATA("Fall17_17Nov2017", "32", "AK4PFchs", "D")));
+      jet_corrector_E.reset(new JetCorrector(ctx, JERFiles::JECFilesDATA("Fall17_17Nov2017", "32", "AK4PFchs", "E")));
+      jet_corrector_F.reset(new JetCorrector(ctx, JERFiles::JECFilesDATA("Fall17_17Nov2017", "32", "AK4PFchs", "F")));
     }
   }
   if(metfilters){
@@ -79,13 +79,13 @@ void CommonModules::init(Context & ctx, const std::string & SysType_PU){
     modules.emplace_back(new JetCleaner(ctx, JetPFID(working_point)));
   }
   if(jetlepcleaner) {
-    if(is_mc) JLC_MC.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::Fall17_17Nov2017_V32_L123_AK4PFchs_MC));
+    if(is_mc) JLC_MC.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::JECFilesMC("Fall17_17Nov2017", "32", "AK4PFchs")));
     else{
-      JLC_B.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::Fall17_17Nov2017_V32_B_L123_AK4PFchs_DATA));
-      JLC_C.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::Fall17_17Nov2017_V32_C_L123_AK4PFchs_DATA));
-      JLC_D.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::Fall17_17Nov2017_V32_D_L123_AK4PFchs_DATA));
-      JLC_E.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::Fall17_17Nov2017_V32_E_L123_AK4PFchs_DATA));
-      JLC_F.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::Fall17_17Nov2017_V32_F_L123_AK4PFchs_DATA));
+      JLC_B.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::JECFilesDATA("Fall17_17Nov2017", "32", "AK4PFchs", "B")));
+      JLC_C.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::JECFilesDATA("Fall17_17Nov2017", "32", "AK4PFchs", "C")));
+      JLC_D.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::JECFilesDATA("Fall17_17Nov2017", "32", "AK4PFchs", "D")));
+      JLC_E.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::JECFilesDATA("Fall17_17Nov2017", "32", "AK4PFchs", "E")));
+      JLC_F.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::JECFilesDATA("Fall17_17Nov2017", "32", "AK4PFchs", "F")));
     }
   }
   modules.emplace_back(new HTCalculator(ctx,HT_jetid));

--- a/common/src/CommonModules.cxx
+++ b/common/src/CommonModules.cxx
@@ -21,6 +21,9 @@ void CommonModules::fail_if_init() const{
 
 CommonModules::CommonModules(){
   working_point = JetPFID::WP_TIGHT_CHS;
+  jec_tag = "Fall17_17Nov2017";
+  jec_ver = "32";
+  jec_jet_coll = "AK4PFchs";
 }
 
 
@@ -40,18 +43,18 @@ void CommonModules::init(Context & ctx, const std::string & SysType_PU){
     if(mclumiweight)  modules.emplace_back(new MCLumiWeight(ctx));
     if(mcpileupreweight) modules.emplace_back(new MCPileupReweight(ctx,SysType_PU));
     if(jec){
-      jet_corrector_MC.reset(new JetCorrector(ctx, JERFiles::JECFilesMC("Fall17_17Nov2017", "32", "AK4PFchs")));
+      jet_corrector_MC.reset(new JetCorrector(ctx, JERFiles::JECFilesMC(jec_tag, jec_ver, jec_jet_coll)));
     }
     if(jersmear) jet_resolution_smearer.reset(new JetResolutionSmearer(ctx));
   }
   else{
     if(lumisel) lumi_selection.reset(new LumiSelection(ctx));
     if(jec){
-      jet_corrector_B.reset(new JetCorrector(ctx, JERFiles::JECFilesDATA("Fall17_17Nov2017", "32", "AK4PFchs", "B")));
-      jet_corrector_C.reset(new JetCorrector(ctx, JERFiles::JECFilesDATA("Fall17_17Nov2017", "32", "AK4PFchs", "C")));
-      jet_corrector_D.reset(new JetCorrector(ctx, JERFiles::JECFilesDATA("Fall17_17Nov2017", "32", "AK4PFchs", "DE")));
-      jet_corrector_E.reset(new JetCorrector(ctx, JERFiles::JECFilesDATA("Fall17_17Nov2017", "32", "AK4PFchs", "DE")));
-      jet_corrector_F.reset(new JetCorrector(ctx, JERFiles::JECFilesDATA("Fall17_17Nov2017", "32", "AK4PFchs", "F")));
+      jet_corrector_B.reset(new JetCorrector(ctx, JERFiles::JECFilesDATA(jec_tag, jec_ver, jec_jet_coll, "B")));
+      jet_corrector_C.reset(new JetCorrector(ctx, JERFiles::JECFilesDATA(jec_tag, jec_ver, jec_jet_coll, "C")));
+      jet_corrector_D.reset(new JetCorrector(ctx, JERFiles::JECFilesDATA(jec_tag, jec_ver, jec_jet_coll, "DE")));
+      jet_corrector_E.reset(new JetCorrector(ctx, JERFiles::JECFilesDATA(jec_tag, jec_ver, jec_jet_coll, "DE")));
+      jet_corrector_F.reset(new JetCorrector(ctx, JERFiles::JECFilesDATA(jec_tag, jec_ver, jec_jet_coll, "F")));
     }
   }
   if(metfilters){
@@ -79,13 +82,13 @@ void CommonModules::init(Context & ctx, const std::string & SysType_PU){
     modules.emplace_back(new JetCleaner(ctx, JetPFID(working_point)));
   }
   if(jetlepcleaner) {
-    if(is_mc) JLC_MC.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::JECFilesMC("Fall17_17Nov2017", "32", "AK4PFchs")));
+    if(is_mc) JLC_MC.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::JECFilesMC(jec_tag, jec_ver, jec_jet_coll)));
     else{
-      JLC_B.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::JECFilesDATA("Fall17_17Nov2017", "32", "AK4PFchs", "B")));
-      JLC_C.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::JECFilesDATA("Fall17_17Nov2017", "32", "AK4PFchs", "C")));
-      JLC_D.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::JECFilesDATA("Fall17_17Nov2017", "32", "AK4PFchs", "DE")));
-      JLC_E.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::JECFilesDATA("Fall17_17Nov2017", "32", "AK4PFchs", "DE")));
-      JLC_F.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::JECFilesDATA("Fall17_17Nov2017", "32", "AK4PFchs", "F")));
+      JLC_B.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::JECFilesDATA(jec_tag, jec_ver, jec_jet_coll, "B")));
+      JLC_C.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::JECFilesDATA(jec_tag, jec_ver, jec_jet_coll, "C")));
+      JLC_D.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::JECFilesDATA(jec_tag, jec_ver, jec_jet_coll, "DE")));
+      JLC_E.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::JECFilesDATA(jec_tag, jec_ver, jec_jet_coll, "DE")));
+      JLC_F.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::JECFilesDATA(jec_tag, jec_ver, jec_jet_coll, "F")));
     }
   }
   modules.emplace_back(new HTCalculator(ctx,HT_jetid));
@@ -218,6 +221,10 @@ void CommonModules::print_setup() const {
   cout << endl;
   for (auto const & [name, flag] : settings_map) {
     cout << name << " = " << (flag ? "ON" : "OFF") << endl;
+  }
+  cout << endl;
+  if (jec || jetlepcleaner || do_metcorrection) {
+    cout << "JECs: " << jec_tag << " V" << jec_ver << " for " << jec_jet_coll << endl;
   }
   cout << endl;
 

--- a/common/src/JetCorrectionSets.cxx
+++ b/common/src/JetCorrectionSets.cxx
@@ -55,7 +55,6 @@ const std::string JERFiles::JECPathStringData(const std::string & tag, const std
   return result;
 }
 
-
 const std::vector<std::string> JERFiles::JECFiles_DATA(const std::string & tag, const std::string & ver, const std::string & runName, const std::string & jetCollection, const std::vector<std::string> levels) {
   std::vector<std::string> result;
   for (const auto & level : levels){
@@ -64,13 +63,17 @@ const std::vector<std::string> JERFiles::JECFiles_DATA(const std::string & tag, 
   return result;
 }
 
+const std::vector<std::string> JERFiles::L1L2L3 = {"L1FastJet", "L2Relative", "L3Absolute"};
+const std::vector<std::string> JERFiles::L1L2L3Residual = {"L1FastJet", "L2Relative", "L3Absolute", "L2L3Residual"};
+
+
 // have to use these, cannot use #tag, etc as it is inside another directive and will fail to compile
 #define STRINGIFY(x) #x
 #define TOSTRING(x) STRINGIFY(x)
 
 #define SET_JECFILES_MC(tag,ver,jetCollection)					                                          \
 const std::vector<std::string> JERFiles::tag##_V##ver##_L123_##jetCollection##_MC =               \
-  JERFiles::JECFiles_MC(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), {"L1FastJet", "L2Relative", "L3Absolute"});                   \
+  JERFiles::JECFiles_MC(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), JERFiles::L1L2L3);                   \
 const std::vector<std::string> JERFiles::tag##_V##ver##_L1RC_##jetCollection##_MC =               \
   JERFiles::JECFiles_MC(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), {"L1RC"});                   \
 const std::vector<std::string> JERFiles::tag##_V##ver##_L1FastJet_##jetCollection##_MC =          \
@@ -78,9 +81,9 @@ const std::vector<std::string> JERFiles::tag##_V##ver##_L1FastJet_##jetCollectio
 
 #define SET_CORRECTION_DATA(tag,ver,jetCollection,runName,runCorrection)                                  \
 const std::vector<std::string> JERFiles::tag##_V##ver##_##runName##_L123_##jetCollection##_DATA =         \
-  JERFiles::JECFiles_DATA(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), TOSTRING(runCorrection), {"L1FastJet", "L2Relative", "L3Absolute", "L2L3Residual"}); \
+  JERFiles::JECFiles_DATA(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), TOSTRING(runCorrection), JERFiles::L1L2L3Residual); \
 const std::vector<std::string> JERFiles::tag##_V##ver##_##runName##_L123_noRes_##jetCollection##_DATA =   \
-  JERFiles::JECFiles_DATA(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), TOSTRING(runCorrection), {"L1FastJet", "L2Relative", "L3Absolute"}); \
+  JERFiles::JECFiles_DATA(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), TOSTRING(runCorrection), JERFiles::L1L2L3); \
 const std::vector<std::string> JERFiles::tag##_V##ver##_##runName##_L1RC_##jetCollection##_DATA =         \
   JERFiles::JECFiles_DATA(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), TOSTRING(runCorrection), {"L1RC"}); \
 const std::vector<std::string> JERFiles::tag##_V##ver##_##runName##_L1FastJet_##jetCollection##_DATA =    \

--- a/common/src/JetCorrectionSets.cxx
+++ b/common/src/JetCorrectionSets.cxx
@@ -3,21 +3,7 @@
 
 //see https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookJetEnergyCorrections#GetTxtFiles how to get the txt files with jet energy corrections from the database
 
-/* The idea of the following preprocessor directives is to simplify the creation of new JEC input files.
-More details in UHH2/common/include/JetCorrectionsSets.h
-*/
-
-#define SET_NEWSTRING_DATA(tag,ver,jetCollection,sample,runName,Correction)                                                                                   \
-"JECDatabase/textFiles/" #tag #runName "_V" #ver "_" #sample "/" #tag #runName "_V" #ver "_" #sample "_" #Correction "_" #jetCollection ".txt",  \
-
-#define SET_NEWSTRING_DATA_2018(tag,ver,jetCollection,sample,runName,Correction)                                                                                            \
-"JECDatabase/textFiles/" #tag "_Run" #runName "_V" #ver "_" #sample "/" #tag "_Run" #runName "_V" #ver "_" #sample "_" #Correction "_" #jetCollection ".txt",  \
-
-// have to use these, cannot use #tag, etc as it is inside another directive and will fail to compile
-#define STRINGIFY(x) #x
-#define TOSTRING(x) STRINGIFY(x)
-
-
+// The idea of the following methods is to simplify the creation of new JEC input files.
 const std::string JERFiles::JECPathStringMC(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & Correction) {
   return "JECDatabase/textFiles/"+tag+"_V"+ver+"_MC/"+tag+"_V"+ver+"_MC_"+Correction+"_"+jetCollection+".txt";
 }
@@ -30,6 +16,37 @@ const std::vector<std::string> JERFiles::JECFiles_MC(const std::string & tag, co
   };
 }
 
+const std::string JERFiles::JECPathStringData(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & runName, const std::string & Correction) {
+  return "JECDatabase/textFiles/"+tag+runName+"_V"+ver+"_"+"DATA/"+tag+runName+"_V"+ver+"_DATA_"+Correction+"_"+jetCollection+".txt";
+}
+
+const std::string JERFiles::JECPathStringData2018(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & runName, const std::string & Correction) {
+  return "JECDatabase/textFiles/"+tag+"_Run"+runName+"_V"+ver+"_"+"DATA/"+tag+"_Run"+runName+"_V"+ver+"_DATA_"+Correction+"_"+jetCollection+".txt";
+}
+
+const std::vector<std::string> JERFiles::JECFiles_DATA(const std::string & tag, const std::string & ver, const std::string & runName, const std::string & jetCollection) {
+  return {
+    JERFiles::JECPathStringData(tag, ver, jetCollection, runName, "L1FastJet"),
+    JERFiles::JECPathStringData(tag, ver, jetCollection, runName, "L2Relative"),
+    JERFiles::JECPathStringData(tag, ver, jetCollection, runName, "L3Absolute"),
+    JERFiles::JECPathStringData(tag, ver, jetCollection, runName, "L2L3Residual")
+  };
+}
+
+const std::vector<std::string> JERFiles::JECFiles_DATA2018(const std::string & tag, const std::string & ver, const std::string & runName, const std::string & jetCollection) {
+  return {
+    JERFiles::JECPathStringData2018(tag, ver, jetCollection, runName, "L1FastJet"),
+    JERFiles::JECPathStringData2018(tag, ver, jetCollection, runName, "L2Relative"),
+    JERFiles::JECPathStringData2018(tag, ver, jetCollection, runName, "L3Absolute"),
+    JERFiles::JECPathStringData2018(tag, ver, jetCollection, runName, "L2L3Residual")
+  };
+}
+
+
+// have to use these, cannot use #tag, etc as it is inside another directive and will fail to compile
+#define STRINGIFY(x) #x
+#define TOSTRING(x) STRINGIFY(x)
+
 #define SET_JECFILES_MC(tag,ver,jetCollection)					                                          \
 const std::vector<std::string> JERFiles::tag##_V##ver##_L123_##jetCollection##_MC =               \
   JERFiles::JECFiles_MC(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection));                   \
@@ -40,43 +57,35 @@ const std::vector<std::string> JERFiles::tag##_V##ver##_L1FastJet_##jetCollectio
   JERFiles::JECPathStringMC(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), "L1FastJet")   \
 };                                                                                                \
 
-#define SET_CORRECTION_DATA(tag,ver,jetCollection,runName,runCorrection)                                  \
-const std::vector<std::string> JERFiles::tag##_V##ver##_##runName##_L123_##jetCollection##_DATA = {       \
-  SET_NEWSTRING_DATA(tag,ver,jetCollection,DATA,runCorrection,L1FastJet)                                  \
-  SET_NEWSTRING_DATA(tag,ver,jetCollection,DATA,runCorrection,L2Relative)                                 \
-  SET_NEWSTRING_DATA(tag,ver,jetCollection,DATA,runCorrection,L3Absolute)                                 \
-  SET_NEWSTRING_DATA(tag,ver,jetCollection,DATA,runCorrection,L2L3Residual)                               \
-};                                                                                                        \
+#define SET_CORRECTION_DATA(tag,ver,jetCollection,runName,runCorrection)                                   \
+const std::vector<std::string> JERFiles::tag##_V##ver##_##runName##_L123_##jetCollection##_DATA =          \
+  JERFiles::JECFiles_DATA(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), TOSTRING(runCorrection)); \
 const std::vector<std::string> JERFiles::tag##_V##ver##_##runName##_L123_noRes_##jetCollection##_DATA = { \
-  SET_NEWSTRING_DATA(tag,ver,jetCollection,DATA,runCorrection,L1FastJet)                                  \
-  SET_NEWSTRING_DATA(tag,ver,jetCollection,DATA,runCorrection,L2Relative)                                 \
-  SET_NEWSTRING_DATA(tag,ver,jetCollection,DATA,runCorrection,L3Absolute)                                 \
+  JERFiles::JECPathStringData(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), TOSTRING(runCorrection), "L1FastJet"), \
+  JERFiles::JECPathStringData(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), TOSTRING(runCorrection), "L2Relative"), \
+  JERFiles::JECPathStringData(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), TOSTRING(runCorrection), "L3Absolute") \
 };                                                                                                        \
 const std::vector<std::string> JERFiles::tag##_V##ver##_##runName##_L1RC_##jetCollection##_DATA = {       \
-  SET_NEWSTRING_DATA(tag,ver,jetCollection,DATA,runCorrection,L1RC)                                       \
+  JERFiles::JECPathStringData(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), TOSTRING(runCorrection), "L1RC") \
 };                                                                                                        \
 const std::vector<std::string> JERFiles::tag##_V##ver##_##runName##_L1FastJet_##jetCollection##_DATA = {  \
-  SET_NEWSTRING_DATA(tag,ver,jetCollection,DATA,runCorrection,L1FastJet)                                  \
+  JERFiles::JECPathStringData(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), TOSTRING(runCorrection), "L1FastJet") \
 };                                                                                                        \
 
 
 #define SET_CORRECTION_DATA_2018(tag,ver,jetCollection,runName,runCorrection)                             \
-const std::vector<std::string> JERFiles::tag##_V##ver##_##runName##_L123_##jetCollection##_DATA = {       \
-  SET_NEWSTRING_DATA_2018(tag,ver,jetCollection,DATA,runCorrection,L1FastJet)                             \
-  SET_NEWSTRING_DATA_2018(tag,ver,jetCollection,DATA,runCorrection,L2Relative)                            \
-  SET_NEWSTRING_DATA_2018(tag,ver,jetCollection,DATA,runCorrection,L3Absolute)                            \
-  SET_NEWSTRING_DATA_2018(tag,ver,jetCollection,DATA,runCorrection,L2L3Residual)                          \
-};                                                                                                        \
+const std::vector<std::string> JERFiles::tag##_V##ver##_##runName##_L123_##jetCollection##_DATA =       \
+  JERFiles::JECFiles_DATA2018(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), TOSTRING(runCorrection)); \
 const std::vector<std::string> JERFiles::tag##_V##ver##_##runName##_L123_noRes_##jetCollection##_DATA = { \
-  SET_NEWSTRING_DATA_2018(tag,ver,jetCollection,DATA,runCorrection,L1FastJet)                             \
-  SET_NEWSTRING_DATA_2018(tag,ver,jetCollection,DATA,runCorrection,L2Relative)                            \
-  SET_NEWSTRING_DATA_2018(tag,ver,jetCollection,DATA,runCorrection,L3Absolute)                            \
+  JERFiles::JECPathStringData2018(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), TOSTRING(runCorrection), "L1FastJet"), \
+  JERFiles::JECPathStringData2018(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), TOSTRING(runCorrection), "L2Relative"), \
+  JERFiles::JECPathStringData2018(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), TOSTRING(runCorrection), "L3Absolute") \
 };                                                                                                        \
 const std::vector<std::string> JERFiles::tag##_V##ver##_##runName##_L1RC_##jetCollection##_DATA = {       \
-  SET_NEWSTRING_DATA_2018(tag,ver,jetCollection,DATA,runCorrection,L1RC)                                       \
+  JERFiles::JECPathStringData2018(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), TOSTRING(runCorrection), "L1RC") \
 };                                                                                                        \
 const std::vector<std::string> JERFiles::tag##_V##ver##_##runName##_L1FastJet_##jetCollection##_DATA = {  \
-  SET_NEWSTRING_DATA_2018(tag,ver,jetCollection,DATA,runCorrection,L1FastJet)                                  \
+  JERFiles::JECPathStringData(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), TOSTRING(runCorrection), "L1FastJet") \
 };                                                                                                        \
 
 #define SET_JECFILES_DATA_2016(tag,ver,jetCollection) \

--- a/common/src/JetCorrectionSets.cxx
+++ b/common/src/JetCorrectionSets.cxx
@@ -4,7 +4,7 @@
 //see https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookJetEnergyCorrections#GetTxtFiles how to get the txt files with jet energy corrections from the database
 
 // The idea of the following methods is to simplify the creation of new JEC input files.
-const std::string JERFiles::JECPathStringMC(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & Correction) {
+const std::string JERFiles::JECPathStringMC(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & correction) {
   std::string result = "JECDatabase/textFiles/";
   result += tag;
   std::string verPrefix = (tag.find("Summer16_23Sep2016") != std::string::npos) ? "V" : "_V"; // because someone decided to remove the underscore in Summer16_23Sep2016
@@ -15,22 +15,14 @@ const std::string JERFiles::JECPathStringMC(const std::string & tag, const std::
   result += verPrefix;
   result += ver;
   result += "_MC_";
-  result += Correction;
+  result += correction;
   result += "_";
   result += jetCollection;
   result += ".txt";
   return result;
 }
 
-const std::vector<std::string> JERFiles::JECFiles_MC(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::vector<std::string> levels) {
-  std::vector<std::string> result;
-  for (const auto & level : levels){
-    result.push_back(JERFiles::JECPathStringMC(tag, ver, jetCollection, level));
-  }
-  return result;
-}
-
-const std::string JERFiles::JECPathStringData(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & runName, const std::string & Correction) {
+const std::string JERFiles::JECPathStringDATA(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & runName, const std::string & correction) {
   std::string newRunName = runName;
   // in 2018 they use "_RunA" instead of just "A"
   if (tag.find("18") != std::string::npos) {
@@ -47,17 +39,25 @@ const std::string JERFiles::JECPathStringData(const std::string & tag, const std
   result += newRunName;
   result += verPrefix;
   result += "_DATA_";
-  result += Correction;
+  result += correction;
   result += "_";
   result += jetCollection;
   result += ".txt";
   return result;
 }
 
-const std::vector<std::string> JERFiles::JECFiles_DATA(const std::string & tag, const std::string & ver, const std::string & runName, const std::string & jetCollection, const std::vector<std::string> levels) {
+const std::vector<std::string> JERFiles::JECFilesMC(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::vector<std::string> levels) {
   std::vector<std::string> result;
   for (const auto & level : levels){
-    result.push_back(JERFiles::JECPathStringData(tag, ver, jetCollection, runName, level));
+    result.push_back(JERFiles::JECPathStringMC(tag, ver, jetCollection, level));
+  }
+  return result;
+}
+
+const std::vector<std::string> JERFiles::JECFilesDATA(const std::string & tag, const std::string & ver, const std::string & runName, const std::string & jetCollection, const std::vector<std::string> levels) {
+  std::vector<std::string> result;
+  for (const auto & level : levels){
+    result.push_back(JERFiles::JECPathStringDATA(tag, ver, jetCollection, runName, level));
   }
   return result;
 }
@@ -72,21 +72,21 @@ const std::vector<std::string> JERFiles::L1L2L3Residual = {"L1FastJet", "L2Relat
 
 #define SET_JECFILES_MC(tag,ver,jetCollection)					                                          \
 const std::vector<std::string> JERFiles::tag##_V##ver##_L123_##jetCollection##_MC =               \
-  JERFiles::JECFiles_MC(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), JERFiles::L1L2L3);                   \
+  JERFiles::JECFilesMC(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), JERFiles::L1L2L3);                   \
 const std::vector<std::string> JERFiles::tag##_V##ver##_L1RC_##jetCollection##_MC =               \
-  JERFiles::JECFiles_MC(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), {"L1RC"});                   \
+  JERFiles::JECFilesMC(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), {"L1RC"});                   \
 const std::vector<std::string> JERFiles::tag##_V##ver##_L1FastJet_##jetCollection##_MC =          \
-  JERFiles::JECFiles_MC(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), {"L1FastJet"});                   \
+  JERFiles::JECFilesMC(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), {"L1FastJet"});                   \
 
 #define SET_CORRECTION_DATA(tag,ver,jetCollection,runName,runCorrection)                                  \
 const std::vector<std::string> JERFiles::tag##_V##ver##_##runName##_L123_##jetCollection##_DATA =         \
-  JERFiles::JECFiles_DATA(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), TOSTRING(runCorrection), JERFiles::L1L2L3Residual); \
+  JERFiles::JECFilesDATA(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), TOSTRING(runCorrection), JERFiles::L1L2L3Residual); \
 const std::vector<std::string> JERFiles::tag##_V##ver##_##runName##_L123_noRes_##jetCollection##_DATA =   \
-  JERFiles::JECFiles_DATA(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), TOSTRING(runCorrection), JERFiles::L1L2L3); \
+  JERFiles::JECFilesDATA(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), TOSTRING(runCorrection), JERFiles::L1L2L3); \
 const std::vector<std::string> JERFiles::tag##_V##ver##_##runName##_L1RC_##jetCollection##_DATA =         \
-  JERFiles::JECFiles_DATA(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), TOSTRING(runCorrection), {"L1RC"}); \
+  JERFiles::JECFilesDATA(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), TOSTRING(runCorrection), {"L1RC"}); \
 const std::vector<std::string> JERFiles::tag##_V##ver##_##runName##_L1FastJet_##jetCollection##_DATA =    \
-  JERFiles::JECFiles_DATA(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), TOSTRING(runCorrection), {"L1FastJet"}); \
+  JERFiles::JECFilesDATA(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), TOSTRING(runCorrection), {"L1FastJet"}); \
 
 
 #define SET_JECFILES_DATA_2016(tag,ver,jetCollection) \

--- a/common/src/JetCorrectionSets.cxx
+++ b/common/src/JetCorrectionSets.cxx
@@ -89,11 +89,11 @@ const std::vector<std::string> JERFiles::JECFilesDATA(const std::string & tag,
 
 #define SET_JECFILES_MC(tag,ver,jetCollection)					                                          \
 const std::vector<std::string> JERFiles::tag##_V##ver##_L123_##jetCollection##_MC =               \
-  JERFiles::JECFilesMC(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), JERFiles::L1L2L3);                   \
+  JERFiles::JECFilesMC(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), JERFiles::L1L2L3);  \
 const std::vector<std::string> JERFiles::tag##_V##ver##_L1RC_##jetCollection##_MC =               \
-  JERFiles::JECFilesMC(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), {"L1RC"});                   \
+  JERFiles::JECFilesMC(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), {"L1RC"});          \
 const std::vector<std::string> JERFiles::tag##_V##ver##_L1FastJet_##jetCollection##_MC =          \
-  JERFiles::JECFilesMC(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), {"L1FastJet"});                   \
+  JERFiles::JECFilesMC(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), {"L1FastJet"});     \
 
 #define SET_CORRECTION_DATA(tag,ver,jetCollection,runName,runCorrection)                                  \
 const std::vector<std::string> JERFiles::tag##_V##ver##_##runName##_L123_##jetCollection##_DATA =         \

--- a/common/src/JetCorrectionSets.cxx
+++ b/common/src/JetCorrectionSets.cxx
@@ -4,16 +4,19 @@
 //see https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookJetEnergyCorrections#GetTxtFiles how to get the txt files with jet energy corrections from the database
 
 // The idea of the following methods is to simplify the creation of new JEC input files.
-const std::string JERFiles::JECPathStringMC(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & correction) {
+const std::string JERFiles::JECPathStringMC(const std::string & tag,
+                                            const std::string & ver,
+                                            const std::string & jetCollection,
+                                            const std::string & correction) {
+  std::string newVer = (tag.find("Summer16_23Sep2016") != std::string::npos) ? "V" : "_V"; // because someone decided to remove the underscore in Summer16_23Sep2016
+  newVer += ver;
+
   std::string result = "JECDatabase/textFiles/";
   result += tag;
-  std::string verPrefix = (tag.find("Summer16_23Sep2016") != std::string::npos) ? "V" : "_V"; // because someone decided to remove the underscore in Summer16_23Sep2016
-  result += verPrefix;
-  result += ver;
+  result += newVer;
   result += "_MC/";
   result += tag;
-  result += verPrefix;
-  result += ver;
+  result += newVer;
   result += "_MC_";
   result += correction;
   result += "_";
@@ -22,22 +25,28 @@ const std::string JERFiles::JECPathStringMC(const std::string & tag, const std::
   return result;
 }
 
-const std::string JERFiles::JECPathStringDATA(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & runName, const std::string & correction) {
+const std::string JERFiles::JECPathStringDATA(const std::string & tag,
+                                              const std::string & ver,
+                                              const std::string & jetCollection,
+                                              const std::string & runName,
+                                              const std::string & correction) {
+  std::string newVer = (tag.find("Summer16_23Sep2016") != std::string::npos) ? "V" : "_V"; // because someone decided to remove the underscore in Summer16_23Sep2016
+  newVer += ver;
+
   std::string newRunName = runName;
   // in 2018 they use "_RunA" instead of just "A"
   if (tag.find("18") != std::string::npos) {
     newRunName = "_Run" + runName;
   }
+
   std::string result = "JECDatabase/textFiles/";
   result += tag;
   result += newRunName;
-  std::string verPrefix = (tag.find("Summer16_23Sep2016") != std::string::npos) ? "V" : "_V"; // because someone decided to remove the underscore in Summer16_23Sep2016
-  result += verPrefix;
-  result += ver;
+  result += newVer;
   result += "_DATA/";
   result += tag;
   result += newRunName;
-  result += verPrefix;
+  result += newVer;
   result += "_DATA_";
   result += correction;
   result += "_";
@@ -50,7 +59,10 @@ const std::vector<std::string> JERFiles::L1L2L3 = {"L1FastJet", "L2Relative", "L
 
 const std::vector<std::string> JERFiles::L1L2L3Residual = {"L1FastJet", "L2Relative", "L3Absolute", "L2L3Residual"};
 
-const std::vector<std::string> JERFiles::JECFilesMC(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::vector<std::string> levels) {
+const std::vector<std::string> JERFiles::JECFilesMC(const std::string & tag,
+                                                    const std::string & ver,
+                                                    const std::string & jetCollection,
+                                                    const std::vector<std::string> levels) {
   std::vector<std::string> result;
   for (const auto & level : levels){
     result.push_back(JERFiles::JECPathStringMC(tag, ver, jetCollection, level));
@@ -58,7 +70,11 @@ const std::vector<std::string> JERFiles::JECFilesMC(const std::string & tag, con
   return result;
 }
 
-const std::vector<std::string> JERFiles::JECFilesDATA(const std::string & tag, const std::string & ver, const std::string & runName, const std::string & jetCollection, const std::vector<std::string> levels) {
+const std::vector<std::string> JERFiles::JECFilesDATA(const std::string & tag,
+                                                      const std::string & ver,
+                                                      const std::string & jetCollection,
+                                                      const std::string & runName,
+                                                      const std::vector<std::string> levels) {
   std::vector<std::string> result;
   for (const auto & level : levels){
     result.push_back(JERFiles::JECPathStringDATA(tag, ver, jetCollection, runName, level));

--- a/common/src/JetCorrectionSets.cxx
+++ b/common/src/JetCorrectionSets.cxx
@@ -7,7 +7,7 @@
 const std::string JERFiles::JECPathStringMC(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & Correction) {
   std::string result = "JECDatabase/textFiles/";
   result += tag;
-  std::string verPrefix = (tag.find("Summer16_23Sep2016") != std::string::npos) ? "V" : "_V"; // because someone decided to remove the underscore
+  std::string verPrefix = (tag.find("Summer16_23Sep2016") != std::string::npos) ? "V" : "_V"; // because someone decided to remove the underscore in Summer16_23Sep2016
   result += verPrefix;
   result += ver;
   result += "_MC/";
@@ -39,14 +39,13 @@ const std::string JERFiles::JECPathStringData(const std::string & tag, const std
   std::string result = "JECDatabase/textFiles/";
   result += tag;
   result += newRunName;
-  result += "_V";
+  std::string verPrefix = (tag.find("Summer16_23Sep2016") != std::string::npos) ? "V" : "_V"; // because someone decided to remove the underscore in Summer16_23Sep2016
+  result += verPrefix;
   result += ver;
-  result += "_";
-  result += "DATA/";
+  result += "_DATA/";
   result += tag;
   result += newRunName;
-  result += "_V";
-  result += ver;
+  result += verPrefix;
   result += "_DATA_";
   result += Correction;
   result += "_";

--- a/common/src/JetCorrectionSets.cxx
+++ b/common/src/JetCorrectionSets.cxx
@@ -4,14 +4,15 @@
 //see https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookJetEnergyCorrections#GetTxtFiles how to get the txt files with jet energy corrections from the database
 
 // The idea of the following methods is to simplify the creation of new JEC input files.
-const std::string JERFiles::JECPathStringMC(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & Correction) {
+std::string JERFiles::JECPathStringMC(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & Correction) {
   std::string result="JECDatabase/textFiles/";
   result += tag;
-  result += "_V";
+  std::string verPrefix = (tag.find("Summer16_23Sep2016") != std::string::npos) ? "V" : "_V"; // because someone decided to remove the underscore
+  result += verPrefix;
   result += ver;
   result += "_MC/";
   result += tag;
-  result += "_V";
+  result += verPrefix;
   result += ver;
   result += "_MC_";
   result += Correction;
@@ -21,7 +22,7 @@ const std::string JERFiles::JECPathStringMC(const std::string & tag, const std::
   return result;
 }
 
-const std::vector<std::string> JERFiles::JECFiles_MC(const std::string & tag, const std::string & ver, const std::string & jetCollection) {
+std::vector<std::string> JERFiles::JECFiles_MC(const std::string & tag, const std::string & ver, const std::string & jetCollection) {
   return {
     JERFiles::JECPathStringMC(tag, ver, jetCollection, "L1FastJet"),
     JERFiles::JECPathStringMC(tag, ver, jetCollection, "L2Relative"),
@@ -29,16 +30,21 @@ const std::vector<std::string> JERFiles::JECFiles_MC(const std::string & tag, co
   };
 }
 
-const std::string JERFiles::JECPathStringData(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & runName, const std::string & Correction) {
+std::string JERFiles::JECPathStringData(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & runName, const std::string & Correction) {
+  std::string newRunName = runName;
+  // in 2018 they use "_RunA" instead of just "A"
+  if (tag.find("18") != std::string::npos) {
+    newRunName = "_Run" + runName;
+  }
   std::string result = "JECDatabase/textFiles/";
   result += tag;
-  result += runName;
+  result += newRunName;
   result += "_V";
   result += ver;
   result += "_";
   result += "DATA/";
   result += tag;
-  result += runName;
+  result += newRunName;
   result += "_V";
   result += ver;
   result += "_DATA_";
@@ -49,29 +55,8 @@ const std::string JERFiles::JECPathStringData(const std::string & tag, const std
   return result;
 }
 
-const std::string JERFiles::JECPathStringData2018(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & runName, const std::string & Correction) {
-  std::string result = "JECDatabase/textFiles/";
-  result += tag;
-  result += "_Run";
-  result += runName;
-  result += "_V";
-  result += ver;
-  result += "_";
-  result += "DATA/";
-  result += tag;
-  result += "_Run";
-  result += runName;
-  result += "_V";
-  result += ver;
-  result += "_DATA_";
-  result += Correction;
-  result += "_";
-  result += jetCollection;
-  result += ".txt";
-  return result;
-}
 
-const std::vector<std::string> JERFiles::JECFiles_DATA(const std::string & tag, const std::string & ver, const std::string & runName, const std::string & jetCollection) {
+std::vector<std::string> JERFiles::JECFiles_DATA(const std::string & tag, const std::string & ver, const std::string & runName, const std::string & jetCollection) {
   return {
     JERFiles::JECPathStringData(tag, ver, jetCollection, runName, "L1FastJet"),
     JERFiles::JECPathStringData(tag, ver, jetCollection, runName, "L2Relative"),
@@ -79,16 +64,6 @@ const std::vector<std::string> JERFiles::JECFiles_DATA(const std::string & tag, 
     JERFiles::JECPathStringData(tag, ver, jetCollection, runName, "L2L3Residual")
   };
 }
-
-const std::vector<std::string> JERFiles::JECFiles_DATA2018(const std::string & tag, const std::string & ver, const std::string & runName, const std::string & jetCollection) {
-  return {
-    JERFiles::JECPathStringData2018(tag, ver, jetCollection, runName, "L1FastJet"),
-    JERFiles::JECPathStringData2018(tag, ver, jetCollection, runName, "L2Relative"),
-    JERFiles::JECPathStringData2018(tag, ver, jetCollection, runName, "L3Absolute"),
-    JERFiles::JECPathStringData2018(tag, ver, jetCollection, runName, "L2L3Residual")
-  };
-}
-
 
 // have to use these, cannot use #tag, etc as it is inside another directive and will fail to compile
 #define STRINGIFY(x) #x
@@ -120,21 +95,6 @@ const std::vector<std::string> JERFiles::tag##_V##ver##_##runName##_L1FastJet_##
 };                                                                                                        \
 
 
-#define SET_CORRECTION_DATA_2018(tag,ver,jetCollection,runName,runCorrection)                             \
-const std::vector<std::string> JERFiles::tag##_V##ver##_##runName##_L123_##jetCollection##_DATA =       \
-  JERFiles::JECFiles_DATA2018(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), TOSTRING(runCorrection)); \
-const std::vector<std::string> JERFiles::tag##_V##ver##_##runName##_L123_noRes_##jetCollection##_DATA = { \
-  JERFiles::JECPathStringData2018(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), TOSTRING(runCorrection), "L1FastJet"), \
-  JERFiles::JECPathStringData2018(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), TOSTRING(runCorrection), "L2Relative"), \
-  JERFiles::JECPathStringData2018(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), TOSTRING(runCorrection), "L3Absolute") \
-};                                                                                                        \
-const std::vector<std::string> JERFiles::tag##_V##ver##_##runName##_L1RC_##jetCollection##_DATA = {       \
-  JERFiles::JECPathStringData2018(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), TOSTRING(runCorrection), "L1RC") \
-};                                                                                                        \
-const std::vector<std::string> JERFiles::tag##_V##ver##_##runName##_L1FastJet_##jetCollection##_DATA = {  \
-  JERFiles::JECPathStringData(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), TOSTRING(runCorrection), "L1FastJet") \
-};                                                                                                        \
-
 #define SET_JECFILES_DATA_2016(tag,ver,jetCollection) \
 SET_CORRECTION_DATA(tag,ver,jetCollection,B,BCD)      \
 SET_CORRECTION_DATA(tag,ver,jetCollection,C,BCD)      \
@@ -152,47 +112,13 @@ SET_CORRECTION_DATA(tag,ver,jetCollection,D,DE)       \
 SET_CORRECTION_DATA(tag,ver,jetCollection,E,DE)       \
 SET_CORRECTION_DATA(tag,ver,jetCollection,F,F)        \
 
+
 #define SET_JECFILES_DATA_2018(tag,ver,jetCollection) \
-SET_CORRECTION_DATA_2018(tag,ver,jetCollection,A,A)   \
-SET_CORRECTION_DATA_2018(tag,ver,jetCollection,B,B)   \
-SET_CORRECTION_DATA_2018(tag,ver,jetCollection,C,C)   \
-SET_CORRECTION_DATA_2018(tag,ver,jetCollection,D,D)   \
+SET_CORRECTION_DATA(tag,ver,jetCollection,A,A)   \
+SET_CORRECTION_DATA(tag,ver,jetCollection,B,B)   \
+SET_CORRECTION_DATA(tag,ver,jetCollection,C,C)   \
+SET_CORRECTION_DATA(tag,ver,jetCollection,D,D)   \
 
-
-const std::string JERFiles::JECPathStringMC2016(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & Correction) {
-  std::string result = "JECDatabase/textFiles/";
-  result += tag;
-  result += "V";
-  result += ver;
-  result += "_MC/";
-  result += tag;
-  result += "V";
-  result += ver;
-  result += "_MC_";
-  result += Correction;
-  result += "_";
-  result += jetCollection;
-  result += ".txt";
-  return result;
-}
-
-const std::vector<std::string> JERFiles::JECFiles_MC2016(const std::string & tag, const std::string & ver, const std::string & jetCollection) {
-  return {
-    JERFiles::JECPathStringMC2016(tag, ver, jetCollection, "L1FastJet"),
-    JERFiles::JECPathStringMC2016(tag, ver, jetCollection, "L2Relative"),
-    JERFiles::JECPathStringMC2016(tag, ver, jetCollection, "L3Absolute")
-  };
-}
-
-#define SET_JECFILES_MC2016(tag,ver,jetCollection)					                                        \
-const std::vector<std::string> JERFiles::tag##_V##ver##_L123_##jetCollection##_MC =                 \
-  JERFiles::JECFiles_MC2016(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection));                 \
-const std::vector<std::string> JERFiles::tag##_V##ver##_L1RC_##jetCollection##_MC = {               \
-  JERFiles::JECPathStringMC2016(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), "L1RC")      \
-};                                                                                                  \
-const std::vector<std::string> JERFiles::tag##_V##ver##_L1FastJet_##jetCollection##_MC = {          \
-  JERFiles::JECPathStringMC2016(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), "L1FastJet") \
-};                                                                                                  \
 
 /* Here we create the new vectors. The usage is the following:
 SET_JECFILES_*( a tag to identify which JEC use ,version, jet collection used)

--- a/common/src/JetCorrectionSets.cxx
+++ b/common/src/JetCorrectionSets.cxx
@@ -5,7 +5,20 @@
 
 // The idea of the following methods is to simplify the creation of new JEC input files.
 const std::string JERFiles::JECPathStringMC(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & Correction) {
-  return "JECDatabase/textFiles/"+tag+"_V"+ver+"_MC/"+tag+"_V"+ver+"_MC_"+Correction+"_"+jetCollection+".txt";
+  std::string result="JECDatabase/textFiles/";
+  result += tag;
+  result += "_V";
+  result += ver;
+  result += "_MC/";
+  result += tag;
+  result += "_V";
+  result += ver;
+  result += "_MC_";
+  result += Correction;
+  result += "_";
+  result += jetCollection;
+  result += ".txt";
+  return result;
 }
 
 const std::vector<std::string> JERFiles::JECFiles_MC(const std::string & tag, const std::string & ver, const std::string & jetCollection) {
@@ -17,11 +30,45 @@ const std::vector<std::string> JERFiles::JECFiles_MC(const std::string & tag, co
 }
 
 const std::string JERFiles::JECPathStringData(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & runName, const std::string & Correction) {
-  return "JECDatabase/textFiles/"+tag+runName+"_V"+ver+"_"+"DATA/"+tag+runName+"_V"+ver+"_DATA_"+Correction+"_"+jetCollection+".txt";
+  std::string result = "JECDatabase/textFiles/";
+  result += tag;
+  result += runName;
+  result += "_V";
+  result += ver;
+  result += "_";
+  result += "DATA/";
+  result += tag;
+  result += runName;
+  result += "_V";
+  result += ver;
+  result += "_DATA_";
+  result += Correction;
+  result += "_";
+  result += jetCollection;
+  result += ".txt";
+  return result;
 }
 
 const std::string JERFiles::JECPathStringData2018(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & runName, const std::string & Correction) {
-  return "JECDatabase/textFiles/"+tag+"_Run"+runName+"_V"+ver+"_"+"DATA/"+tag+"_Run"+runName+"_V"+ver+"_DATA_"+Correction+"_"+jetCollection+".txt";
+  std::string result = "JECDatabase/textFiles/";
+  result += tag;
+  result += "_Run";
+  result += runName;
+  result += "_V";
+  result += ver;
+  result += "_";
+  result += "DATA/";
+  result += tag;
+  result += "_Run";
+  result += runName;
+  result += "_V";
+  result += ver;
+  result += "_DATA_";
+  result += Correction;
+  result += "_";
+  result += jetCollection;
+  result += ".txt";
+  return result;
 }
 
 const std::vector<std::string> JERFiles::JECFiles_DATA(const std::string & tag, const std::string & ver, const std::string & runName, const std::string & jetCollection) {
@@ -113,7 +160,20 @@ SET_CORRECTION_DATA_2018(tag,ver,jetCollection,D,D)   \
 
 
 const std::string JERFiles::JECPathStringMC2016(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & Correction) {
-  return "JECDatabase/textFiles/"+tag+"V"+ver+"_MC/"+tag+"V"+ver+"_MC_"+Correction+"_"+jetCollection+".txt";
+  std::string result = "JECDatabase/textFiles/";
+  result += tag;
+  result += "V";
+  result += ver;
+  result += "_MC/";
+  result += tag;
+  result += "V";
+  result += ver;
+  result += "_MC_";
+  result += Correction;
+  result += "_";
+  result += jetCollection;
+  result += ".txt";
+  return result;
 }
 
 const std::vector<std::string> JERFiles::JECFiles_MC2016(const std::string & tag, const std::string & ver, const std::string & jetCollection) {

--- a/common/src/JetCorrectionSets.cxx
+++ b/common/src/JetCorrectionSets.cxx
@@ -13,21 +13,32 @@ More details in UHH2/common/include/JetCorrectionsSets.h
 #define SET_NEWSTRING_DATA_2018(tag,ver,jetCollection,sample,runName,Correction)                                                                                            \
 "JECDatabase/textFiles/" #tag "_Run" #runName "_V" #ver "_" #sample "/" #tag "_Run" #runName "_V" #ver "_" #sample "_" #Correction "_" #jetCollection ".txt",  \
 
-#define SET_NEWSTRING_MC(tag,ver,jetCollection,sample,Correction)                                                                           \
-"JECDatabase/textFiles/" #tag "_V" #ver "_" #sample "/" #tag "_V" #ver "_" #sample "_" #Correction "_" #jetCollection ".txt",  \
+// have to use these, cannot use #tag, etc as it is inside another directive and will fail to compile
+#define STRINGIFY(x) #x
+#define TOSTRING(x) STRINGIFY(x)
 
-#define SET_JECFILES_MC(tag,ver,jetCollection)					                                    \
-const std::vector<std::string> JERFiles::tag##_V##ver##_L123_##jetCollection##_MC = {       \
-  SET_NEWSTRING_MC(tag,ver,jetCollection,MC,L1FastJet)                                      \
-  SET_NEWSTRING_MC(tag,ver,jetCollection,MC,L2Relative)                                     \
-  SET_NEWSTRING_MC(tag,ver,jetCollection,MC,L3Absolute)                                     \
-};                                                                                          \
-const std::vector<std::string> JERFiles::tag##_V##ver##_L1RC_##jetCollection##_MC = {       \
-  SET_NEWSTRING_MC(tag,ver,jetCollection,MC,L1RC)                                           \
-};                                                                                          \
-const std::vector<std::string> JERFiles::tag##_V##ver##_L1FastJet_##jetCollection##_MC = {  \
-  SET_NEWSTRING_MC(tag,ver,jetCollection,MC,L1FastJet)                                      \
-};                                                                                          \
+
+const std::string JERFiles::JECPathStringMC(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & Correction) {
+  return "JECDatabase/textFiles/"+tag+"_V"+ver+"_MC/"+tag+"_V"+ver+"_MC_"+Correction+"_"+jetCollection+".txt";
+}
+
+const std::vector<std::string> JERFiles::JECFiles_MC(const std::string & tag, const std::string & ver, const std::string & jetCollection) {
+  return {
+    JERFiles::JECPathStringMC(tag, ver, jetCollection, "L1FastJet"),
+    JERFiles::JECPathStringMC(tag, ver, jetCollection, "L2Relative"),
+    JERFiles::JECPathStringMC(tag, ver, jetCollection, "L3Absolute")
+  };
+}
+
+#define SET_JECFILES_MC(tag,ver,jetCollection)					                                          \
+const std::vector<std::string> JERFiles::tag##_V##ver##_L123_##jetCollection##_MC =               \
+  JERFiles::JECFiles_MC(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection));                   \
+const std::vector<std::string> JERFiles::tag##_V##ver##_L1RC_##jetCollection##_MC = {             \
+  JERFiles::JECPathStringMC(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), "L1RC")        \
+};                                                                                                \
+const std::vector<std::string> JERFiles::tag##_V##ver##_L1FastJet_##jetCollection##_MC = {        \
+  JERFiles::JECPathStringMC(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), "L1FastJet")   \
+};                                                                                                \
 
 #define SET_CORRECTION_DATA(tag,ver,jetCollection,runName,runCorrection)                                  \
 const std::vector<std::string> JERFiles::tag##_V##ver##_##runName##_L123_##jetCollection##_DATA = {       \
@@ -92,23 +103,27 @@ SET_CORRECTION_DATA_2018(tag,ver,jetCollection,C,C)   \
 SET_CORRECTION_DATA_2018(tag,ver,jetCollection,D,D)   \
 
 
+const std::string JERFiles::JECPathStringMC2016(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::string & Correction) {
+  return "JECDatabase/textFiles/"+tag+"V"+ver+"_MC/"+tag+"V"+ver+"_MC_"+Correction+"_"+jetCollection+".txt";
+}
 
+const std::vector<std::string> JERFiles::JECFiles_MC2016(const std::string & tag, const std::string & ver, const std::string & jetCollection) {
+  return {
+    JERFiles::JECPathStringMC2016(tag, ver, jetCollection, "L1FastJet"),
+    JERFiles::JECPathStringMC2016(tag, ver, jetCollection, "L2Relative"),
+    JERFiles::JECPathStringMC2016(tag, ver, jetCollection, "L3Absolute")
+  };
+}
 
-#define SET_NEWSTRING_MC2016(tag,ver,jetCollection,sample,Correction)                                                                     \
-"JECDatabase/textFiles/" #tag "V" #ver "_" #sample "/" #tag "V" #ver "_" #sample "_" #Correction "_" #jetCollection ".txt",  \
-
-#define SET_JECFILES_MC2016(tag,ver,jetCollection)					                                \
-const std::vector<std::string> JERFiles::tag##_V##ver##_L123_##jetCollection##_MC = {       \
-  SET_NEWSTRING_MC2016(tag,ver,jetCollection,MC,L1FastJet)                                  \
-  SET_NEWSTRING_MC2016(tag,ver,jetCollection,MC,L2Relative)                                 \
-  SET_NEWSTRING_MC2016(tag,ver,jetCollection,MC,L3Absolute)                                 \
-};                                                                                          \
-const std::vector<std::string> JERFiles::tag##_V##ver##_L1RC_##jetCollection##_MC = {       \
-  SET_NEWSTRING_MC2016(tag,ver,jetCollection,MC,L1RC)                                       \
-};                                                                                          \
-const std::vector<std::string> JERFiles::tag##_V##ver##_L1FastJet_##jetCollection##_MC = {  \
-  SET_NEWSTRING_MC2016(tag,ver,jetCollection,MC,L1FastJet)                                  \
-};                                                                                          \
+#define SET_JECFILES_MC2016(tag,ver,jetCollection)					                                        \
+const std::vector<std::string> JERFiles::tag##_V##ver##_L123_##jetCollection##_MC =                 \
+  JERFiles::JECFiles_MC2016(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection));                 \
+const std::vector<std::string> JERFiles::tag##_V##ver##_L1RC_##jetCollection##_MC = {               \
+  JERFiles::JECPathStringMC2016(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), "L1RC")      \
+};                                                                                                  \
+const std::vector<std::string> JERFiles::tag##_V##ver##_L1FastJet_##jetCollection##_MC = {          \
+  JERFiles::JECPathStringMC2016(TOSTRING(tag), TOSTRING(ver), TOSTRING(jetCollection), "L1FastJet") \
+};                                                                                                  \
 
 /* Here we create the new vectors. The usage is the following:
 SET_JECFILES_*( a tag to identify which JEC use ,version, jet collection used)

--- a/common/src/JetCorrectionSets.cxx
+++ b/common/src/JetCorrectionSets.cxx
@@ -46,6 +46,10 @@ const std::string JERFiles::JECPathStringDATA(const std::string & tag, const std
   return result;
 }
 
+const std::vector<std::string> JERFiles::L1L2L3 = {"L1FastJet", "L2Relative", "L3Absolute"};
+
+const std::vector<std::string> JERFiles::L1L2L3Residual = {"L1FastJet", "L2Relative", "L3Absolute", "L2L3Residual"};
+
 const std::vector<std::string> JERFiles::JECFilesMC(const std::string & tag, const std::string & ver, const std::string & jetCollection, const std::vector<std::string> levels) {
   std::vector<std::string> result;
   for (const auto & level : levels){
@@ -61,9 +65,6 @@ const std::vector<std::string> JERFiles::JECFilesDATA(const std::string & tag, c
   }
   return result;
 }
-
-const std::vector<std::string> JERFiles::L1L2L3 = {"L1FastJet", "L2Relative", "L3Absolute"};
-const std::vector<std::string> JERFiles::L1L2L3Residual = {"L1FastJet", "L2Relative", "L3Absolute", "L2L3Residual"};
 
 
 // have to use these, cannot use #tag, etc as it is inside another directive and will fail to compile

--- a/common/test/TestJetCorrections.cpp
+++ b/common/test/TestJetCorrections.cpp
@@ -9,8 +9,8 @@ using namespace std;
 class TestJetCorrections: public uhh2::AnalysisModule {
 public:
     explicit TestJetCorrections(Context &ctx ) {
-        jec_mc.reset(new JetCorrector(ctx, JERFiles::Summer16_07Aug2017_V11_L123_AK4PFchs_MC));
-	jec_data.reset(new JetCorrector(ctx, JERFiles::Summer16_07Aug2017_V11_B_L123_AK4PFchs_DATA));
+        jec_mc.reset(new JetCorrector(ctx, JERFiles::JECFilesMC("Summer16_07Aug2017", "11", "AK4PFchs")));
+        jec_data.reset(new JetCorrector(ctx, JERFiles::JECFilesDATA("Summer16_07Aug2017", "11", "AK4PFchs", "B")));
         printer_before.reset(new JetPrinter("before", 20.0));
         printer_after.reset(new JetPrinter("after", 20.0));
     }

--- a/common/test/test_JER.cpp
+++ b/common/test/test_JER.cpp
@@ -53,13 +53,13 @@ test_JER::test_JER(uhh2::Context& ctx){
   std::vector<std::string> JEC_AK4, JEC_AK8;
   if(isMC){
 
-    JEC_AK4 = JERFiles::Summer16_07Aug2017_V11_L123_AK4PFchs_MC;
-    JEC_AK8 = JERFiles::Summer16_07Aug2017_V11_L123_AK4PFchs_MC;
+    JEC_AK4 = JERFiles::JECFilesMC("Summer16_07Aug2017", "11", "AK4PFchs");
+    JEC_AK8 = JERFiles::JECFilesMC("Summer16_07Aug2017", "11", "AK8PFchs");
   }
   else {
 
-    JEC_AK4 = JERFiles::Summer16_07Aug2017_V11_B_L123_AK4PFchs_DATA;
-    JEC_AK8 = JERFiles::Summer16_07Aug2017_V11_B_L123_AK4PFchs_DATA;
+    JEC_AK4 = JERFiles::JECFilesDATA("Summer16_07Aug2017", "11", "AK4PFchs", "B");
+    JEC_AK8 = JERFiles::JECFilesDATA("Summer16_07Aug2017", "11", "AK8PFchs", "B");
   }
 
   jet_IDcleaner.reset(new JetCleaner(ctx, jetID));

--- a/common/test/test_JLCkey.cpp
+++ b/common/test/test_JLCkey.cpp
@@ -57,13 +57,13 @@ test_JLCkey::test_JLCkey(uhh2::Context& ctx){
   std::vector<std::string> JEC_AK4, JEC_AK8;
   if(isMC){
 
-    JEC_AK4 = JERFiles::Summer16_07Aug2017_V11_L123_AK4PFchs_MC;
-    JEC_AK8 = JERFiles::Summer16_07Aug2017_V11_L123_AK4PFchs_MC;
+    JEC_AK4 = JERFiles::JECFilesMC("Summer16_07Aug2017", "11", "AK4PFchs");
+    JEC_AK8 = JERFiles::JECFilesMC("Summer16_07Aug2017", "11", "AK8PFchs");
   }
   else {
 
-    JEC_AK4 = JERFiles::Summer16_07Aug2017_V11_B_L123_AK4PFchs_DATA;
-    JEC_AK8 = JERFiles::Summer16_07Aug2017_V11_B_L123_AK4PFchs_DATA;
+    JEC_AK4 = JERFiles::JECFilesDATA("Summer16_07Aug2017", "11", "AK4PFchs", "B");
+    JEC_AK8 = JERFiles::JECFilesDATA("Summer16_07Aug2017", "11", "AK8PFchs", "B");
   }
 
   jet_IDcleaner.reset(new JetCleaner(ctx, jetID));


### PR DESCRIPTION
[only compile]

Realised that all the JEC variables can be initialised with functions instead of preprocessor macros. This removes the `SET_NEWSTRING_*`, `SET_CORRECTION_DATA_*` macros in favour of `JECFilesDATA()`, `JECFilesMC()`, and the lower-level `JECStringPathDATA()`, `JECStringPathMC()`. 

The idea being that in the future user move away from pre-defined C++ variables (e.g. `JERFiles:: Fall17_17Nov2017_V32_B_L123_AK4PFchs_DATA`) and instead can use normal strings e.g. `JERFiles::JECFilesDATA("Fall17_17Nov2017", "32", "AK4PFchs", "B"))` (e.g see changes to `CommonModules`).
This way, it's much easier to control JEC version, jet collection, run etc.
Note that these methods have levels of L1L2L3 for MC, and L1L2L3L23Residual for DATA, but this can easily be overriden in the function call by the user.

All the existing C++ variable are still there to not break existing code, although we should encourage users to use the method-based approach instead.

The grander plan is to encapsulate calls to these functions in another class which automatically handles setting up the JEC files depending on the year, and also handles which Run period is needed depending on run number. The idea is to hide away the logic of which run period to use, since it is something common to many analyses, and only exposes e.g. JEC version number.

The user just has to update the version number when they want to update JECs, rather than remembering to change variable names for MC, DATA, across N run periods.

