### PR TITLE
[102X] Fix combined run periods in new JEC functions

### DIFF
--- a/common/include/JetCorrectionSets.h
+++ b/common/include/JetCorrectionSets.h
@@ -2,6 +2,7 @@
 
 #include <vector>
 #include <string>
+#include <map>
 
 /* namespace to define useful filename constants & functions to be used for jet energy corrections */
 
@@ -25,9 +26,14 @@ namespace JERFiles{
                                     const std::string & jetCollection,
                                     const std::string & correction);
 
+  extern const std::map<std::string, std::map<std::string, std::string> > jecRunMap;
+
+
   const std::string JECPathStringDATA(const std::string & tag,
                                       const std::string & ver,
                                       const std::string & jetCollection,
+                                      // runName can accept individual run (B) or combined (BCD)
+                                      // - it will auto handle combined run periods
                                       const std::string & runName,
                                       const std::string & correction);
 

--- a/common/src/CommonModules.cxx
+++ b/common/src/CommonModules.cxx
@@ -52,8 +52,8 @@ void CommonModules::init(Context & ctx, const std::string & SysType_PU){
     if(jec){
       jet_corrector_B.reset(new JetCorrector(ctx, JERFiles::JECFilesDATA(jec_tag, jec_ver, jec_jet_coll, "B")));
       jet_corrector_C.reset(new JetCorrector(ctx, JERFiles::JECFilesDATA(jec_tag, jec_ver, jec_jet_coll, "C")));
-      jet_corrector_D.reset(new JetCorrector(ctx, JERFiles::JECFilesDATA(jec_tag, jec_ver, jec_jet_coll, "DE")));
-      jet_corrector_E.reset(new JetCorrector(ctx, JERFiles::JECFilesDATA(jec_tag, jec_ver, jec_jet_coll, "DE")));
+      jet_corrector_D.reset(new JetCorrector(ctx, JERFiles::JECFilesDATA(jec_tag, jec_ver, jec_jet_coll, "D")));
+      jet_corrector_E.reset(new JetCorrector(ctx, JERFiles::JECFilesDATA(jec_tag, jec_ver, jec_jet_coll, "E")));
       jet_corrector_F.reset(new JetCorrector(ctx, JERFiles::JECFilesDATA(jec_tag, jec_ver, jec_jet_coll, "F")));
     }
   }

--- a/common/src/JetCorrectionSets.cxx
+++ b/common/src/JetCorrectionSets.cxx
@@ -25,8 +25,10 @@ const std::string JERFiles::JECPathStringMC(const std::string & tag,
   return result;
 }
 
+// translate individual runs into the merged ones
+// e.g. B -> BCD for Summer16
 const std::map<std::string, std::map<std::string, std::string> > JERFiles::jecRunMap = {
-  {"2016", {
+  {"Summer16", {
     {"B", "BCD"},
     {"C", "BCD"},
     {"D", "BCD"},
@@ -38,7 +40,7 @@ const std::map<std::string, std::map<std::string, std::string> > JERFiles::jecRu
     {"H", "GH"},
     {"GH", "GH"}
   }},
-  {"2017", {
+  {"Fall17", {
     {"B", "B"},
     {"C", "C"},
     {"D", "DE"},
@@ -46,7 +48,7 @@ const std::map<std::string, std::map<std::string, std::string> > JERFiles::jecRu
     {"DE", "DE"},
     {"F", "F"}
   }},
-  {"2018", {
+  {"Autumn18", {
     {"A", "A"},
     {"B", "B"},
     {"C", "C"},
@@ -62,18 +64,8 @@ const std::string JERFiles::JECPathStringDATA(const std::string & tag,
   std::string newVer = (tag.find("Summer16_23Sep2016") != std::string::npos) ? "V" : "_V"; // because someone decided to remove the underscore in Summer16_23Sep2016
   newVer += ver;
 
-  std::string year = "";
-  if (tag.find("Summer16") != std::string::npos) {
-    year = "2016";
-  } else if (tag.find("Fall17") != std::string::npos) {
-    year = "2017";
-  } else if (tag.find("Autumn18") != std::string::npos) {
-    year = "2018";
-  } else {
-    throw std::runtime_error("Cannot determine year from tag");
-  }
-
-  std::string newRunName = JERFiles::jecRunMap.at(year).at(runName);
+  std::string campaign = tag.substr(0, tag.find("_"));
+  std::string newRunName = JERFiles::jecRunMap.at(campaign).at(runName);
   // in 2018 they use "_RunA" instead of just "A"
   if (tag.find("18") != std::string::npos) {
     newRunName = "_Run" + runName;

--- a/common/src/JetCorrectionSets.cxx
+++ b/common/src/JetCorrectionSets.cxx
@@ -25,6 +25,35 @@ const std::string JERFiles::JECPathStringMC(const std::string & tag,
   return result;
 }
 
+const std::map<std::string, std::map<std::string, std::string> > JERFiles::jecRunMap = {
+  {"2016", {
+    {"B", "BCD"},
+    {"C", "BCD"},
+    {"D", "BCD"},
+    {"BCD", "BCD"}, // include the combined version as well incase
+    {"E", "EF"},
+    {"F", "EF"},
+    {"EF", "EF"},
+    {"G", "GH"},
+    {"H", "GH"},
+    {"GH", "GH"}
+  }},
+  {"2017", {
+    {"B", "B"},
+    {"C", "C"},
+    {"D", "DE"},
+    {"E", "DE"},
+    {"DE", "DE"},
+    {"F", "F"}
+  }},
+  {"2018", {
+    {"A", "A"},
+    {"B", "B"},
+    {"C", "C"},
+    {"D", "D"}
+  }}
+};
+
 const std::string JERFiles::JECPathStringDATA(const std::string & tag,
                                               const std::string & ver,
                                               const std::string & jetCollection,
@@ -33,7 +62,18 @@ const std::string JERFiles::JECPathStringDATA(const std::string & tag,
   std::string newVer = (tag.find("Summer16_23Sep2016") != std::string::npos) ? "V" : "_V"; // because someone decided to remove the underscore in Summer16_23Sep2016
   newVer += ver;
 
-  std::string newRunName = runName;
+  std::string year = "";
+  if (tag.find("Summer16") != std::string::npos) {
+    year = "2016";
+  } else if (tag.find("Fall17") != std::string::npos) {
+    year = "2017";
+  } else if (tag.find("Autumn18") != std::string::npos) {
+    year = "2018";
+  } else {
+    throw std::runtime_error("Cannot determine year from tag");
+  }
+
+  std::string newRunName = JERFiles::jecRunMap.at(year).at(runName);
   // in 2018 they use "_RunA" instead of just "A"
   if (tag.find("18") != std::string::npos) {
     newRunName = "_Run" + runName;


### PR DESCRIPTION
[only compile]

The JEC string functions from #1271 didn't handle cases where run periods were combined, e.g. BCD in 2016. Now there is an internal translation map, so that the user can specify either "BCD" or "B", "C", or "D", and still get the correct BCD file. This improves the interface for users.