### PR TITLE
[102X] year & run auto-switchers for analysis modules

### DIFF
--- a/common/include/Utils.h
+++ b/common/include/Utils.h
@@ -119,6 +119,15 @@ Year extract_year(const uhh2::Context & ctx);
 
 
 /**
+ * Run period names for each year
+ */
+const std::vector<std::string> runPeriods2016 = {"B", "C", "D", "E", "F", "G", "H"};
+
+const std::vector<std::string> runPeriods2017 = {"B", "C", "D", "E", "F"};
+
+const std::vector<std::string> runPeriods2018 = {"A", "B", "C", "D"};
+
+/**
  * Map run periods to run numbers for each year
  *
  * All pairs for a run period are inclusive of both lower & upper numbers

--- a/common/include/Utils.h
+++ b/common/include/Utils.h
@@ -121,9 +121,9 @@ Year extract_year(const uhh2::Context & ctx);
 /**
  * Map run periods to run numbers for each year
  *
- * All pairs for a run period are up to and including the last number
+ * All pairs for a run period are inclusive of both lower & upper numbers
  */
-const std::unordered_map<std::string, std::unordered_map<std::string, std::pair<int, int>>>
+const std::unordered_map<std::string, std::map<std::string, std::pair<int, int>>>
   run_number_map = {
     // taken from https://twiki.cern.ch/twiki/bin/view/CMS/PdmV2016Analysis
     { "2016", {

--- a/common/include/Utils.h
+++ b/common/include/Utils.h
@@ -116,3 +116,46 @@ const std::map<Year, std::string> year_str_map = {
 
 /* Get Year enum from dataset_version in XML config */
 Year extract_year(const uhh2::Context & ctx);
+
+
+/**
+ * Map run periods to run numbers for each year
+ *
+ * All pairs for a run period are up to and including the last number
+ */
+const std::unordered_map<std::string, std::unordered_map<std::string, std::pair<int, int>>>
+  run_number_map = {
+    // taken from https://twiki.cern.ch/twiki/bin/view/CMS/PdmV2016Analysis
+    { "2016", {
+        { "A", std::pair(-1, -1) }, // dummy ones for consistency
+        { "B", std::pair(272007, 275376) },
+        { "C", std::pair(275657, 276283) },
+        { "D", std::pair(276315, 276811) },
+        { "E", std::pair(276831, 277420) },
+        { "F", std::pair(277772, 278808) },
+        { "G", std::pair(278820, 280385) },
+        { "H", std::pair(280919, 284044) },
+    }},
+    // taken from https://twiki.cern.ch/twiki/bin/view/CMS/PdmV2017Analysis
+    { "2017", {
+        { "A", std::pair(-1, -1) },
+        { "B", std::pair(297020, 299329) },
+        { "C", std::pair(299337, 302029) },
+        { "D", std::pair(302030, 303434) },
+        { "E", std::pair(303435, 304826) },
+        { "F", std::pair(304911, 306462) },
+        { "G", std::pair(-1, -1) },
+        { "H", std::pair(-1, -1) },
+    }},
+    // taken from https://twiki.cern.ch/twiki/bin/view/CMS/PdmV2018Analysis
+    { "2018", {
+        { "A", std::pair(315252, 316995) },
+        { "B", std::pair(316998, 319312) },
+        { "C", std::pair(319313, 320393) },
+        { "D", std::pair(320394, 325273) },
+        { "E", std::pair(-1, -1) },
+        { "F", std::pair(-1, -1) },
+        { "G", std::pair(-1, -1) },
+        { "H", std::pair(-1, -1) },
+    }},
+};

--- a/common/include/YearRunSwitchers.h
+++ b/common/include/YearRunSwitchers.h
@@ -2,6 +2,7 @@
 #include "UHH2/core/include/AnalysisModule.h"
 #include "UHH2/core/include/Event.h"
 #include "UHH2/core/include/Utils.h"
+#include "UHH2/common/include/Utils.h"
 
 #include <map>
 
@@ -16,9 +17,10 @@
 
 class YearSwitcher: public uhh2::AnalysisModule {
 public:
-  // FIXME: Would it be faster though to ask context for the year i.e. get it from the dataset Version?
-  // Doesn't make use of event.year, so avoids slow string matching potentially
-  YearSwitcher();
+  YearSwitcher(uhh2::Context & ctx);
+
+  // Automatically run the appropriate module.
+  // If there isn't a matching one, just return true
   virtual bool process(uhh2::Event & event) override;
 
   // Methods to assign module for each year
@@ -35,17 +37,19 @@ public:
   void setup2018(uhh2::AnalysisModule * module);
 
 private:
-  // check if event.year matches year string
-  bool isYear(const uhh2::Event & event, const std::string & year);
+  Year year_;
+  bool doneInit_;
 
-  // have modules for each year, plus the specific versions of each year
+  // have modules for each year, plus for the specific versions of each year
   // shared_ptr, because the user might already own it, and we want to ensure
   // it is kept alive, or deleted as necessary if this is the only owner
 
-  // FIXME: broken as this will create a new copy, not extend lifetime of original
+  // FIXME: broken as this will create a new copy, not extend lifetime of original?!
   std::shared_ptr<uhh2::AnalysisModule> module2016_, module2016v2_, module2016v3_;
   std::shared_ptr<uhh2::AnalysisModule> module2017_, module2017v1_, module2017v2_;
   std::shared_ptr<uhh2::AnalysisModule> module2018_;
+  std::shared_ptr<uhh2::AnalysisModule> theModule_;
+
 };
 
 
@@ -60,6 +64,9 @@ private:
 class RunSwitcher: public uhh2::AnalysisModule {
 public:
   RunSwitcher(const std::string & year);
+
+  // Run the module corresponding to this year in the relevant run period
+  // If none found, return true
   virtual bool process(uhh2::Event & event) override;
 
   // Method to assign a module to a particular run period

--- a/common/include/YearRunSwitchers.h
+++ b/common/include/YearRunSwitchers.h
@@ -1,0 +1,50 @@
+#pragma once
+#include "UHH2/core/include/AnalysisModule.h"
+#include "UHH2/core/include/Event.h"
+#include "UHH2/core/include/Utils.h"
+
+#include <map>
+
+
+/**
+ * Classes to aid automatically running modules for different years and run periods.
+ *
+ * Thee encapsulate the logic of switching years/runs away, so the user does
+ * not need to implement it themselves.
+ */
+
+
+class YearSwitcher: public uhh2::AnalysisModule {
+public:
+  // FIXME: Would it be faster though to ask context for the year i.e. get it from the dataset Version?
+  // Doesn't make use of event.year, so avoids slow string matching potentially
+  YearSwitcher();
+  virtual bool process(uhh2::Event & event) override;
+
+  // Methods to assign module for each year
+  // Note that the setup<year>v* are more specific, and if set, 
+  // will take preference over the module passed to setup<year>
+  void setup2016(uhh2::AnalysisModule * module);
+  void setup2016v2(uhh2::AnalysisModule * module);
+  void setup2016v3(uhh2::AnalysisModule * module);
+  
+  void setup2017(uhh2::AnalysisModule * module);
+  void setup2017v1(uhh2::AnalysisModule * module);
+  void setup2017v2(uhh2::AnalysisModule * module);
+  
+  void setup2018(uhh2::AnalysisModule * module);
+
+private:
+  // check if event.year matches year string
+  bool isYear(const uhh2::Event & event, const std::string & year);
+
+  // have modules for each year, plus the specific versions of each year
+  // shared_ptr, because the user might already own it, and we want to ensure
+  // it is kept alive, or deleted as necessary if this is the only owner
+  
+  // FIXME: broken as this will create a new copy, not extend lifetime of original
+  std::shared_ptr<uhh2::AnalysisModule> module2016_, module2016v2_, module2016v3_;
+  std::shared_ptr<uhh2::AnalysisModule> module2017_, module2017v1_, module2017v2_;
+  std::shared_ptr<uhh2::AnalysisModule> module2018_;
+};
+

--- a/common/include/YearRunSwitchers.h
+++ b/common/include/YearRunSwitchers.h
@@ -32,8 +32,7 @@ public:
 
   // Get the relevant module, incase you need to access its other methods
   // You will need to cast it to the specific derived type,
-  // e.g. RunSwitcher * rs = dynamic_cast<RunSwitcher*>(myYearSwitcher->module());
-  // Returns raw pointer as RunSwitcher has shared_ptr to it already
+  // e.g. std::shared_ptr<RunSwitcher> rs = std::dynamic_pointer_cast<RunSwitcher>(myYearSwitcher->module());
   std::shared_ptr<uhh2::AnalysisModule> module();
 
   // Methods to assign module for each year
@@ -83,7 +82,7 @@ public:
 
   // Get the relevant module, incase you need to access its other methods
   // You will need to cast it to the specific derived type,
-  // e.g. std::shared_ptr<JetCorrector> jc = std::dynamic_pointer_cast<JetCorrector*>(myYearSwitcher->module());
+  // e.g. std::shared_ptr<JetCorrector> jc = std::dynamic_pointer_cast<JetCorrector>(myRunSwitcher->module());
   std::shared_ptr<uhh2::AnalysisModule> module(const uhh2::Event & event);
 
   // Method to assign a module to a particular run period

--- a/common/include/YearRunSwitchers.h
+++ b/common/include/YearRunSwitchers.h
@@ -56,8 +56,9 @@ private:
 /**
  * Class to handle different AnalysisModules for different run periods in data
  *
- * User should setup a module for each run period (e.g. "A") with the `setupRun()`
- * method.
+ * One instance of this class is designed to handle a specific year's data.
+ * User should then setup a module for each run period (e.g. "A")
+ * with the `setupRun()` method.
  * Calling `process()` will then automatically figure out which one to use based
  * on the event run number.
  */
@@ -75,5 +76,6 @@ public:
 private:
   std::string year_;
   std::map<std::string, std::pair<int, int>> runNumberMap_;
+  //shared_ptr usage: see comments in YearSwitcher
   std::map<std::string, std::shared_ptr<uhh2::AnalysisModule>> runModuleMap_;
 };

--- a/common/include/YearRunSwitchers.h
+++ b/common/include/YearRunSwitchers.h
@@ -75,7 +75,7 @@ private:
  */
 class RunSwitcher: public uhh2::AnalysisModule {
 public:
-  RunSwitcher(const std::string & year);
+  RunSwitcher(const uhh2::Context & ctx, const std::string & year);
 
   // Run the module corresponding to this year in the relevant run period
   // If none found, return true
@@ -94,6 +94,7 @@ private:
   std::string shortYear(const std::string & year);
 
   std::string year_;
+  bool skip_;
   std::map<std::string, std::pair<int, int>> runNumberMap_;
   //shared_ptr usage: see comments in YearSwitcher
   std::map<std::string, std::shared_ptr<uhh2::AnalysisModule>> runModuleMap_;

--- a/common/include/YearRunSwitchers.h
+++ b/common/include/YearRunSwitchers.h
@@ -22,16 +22,16 @@ public:
   virtual bool process(uhh2::Event & event) override;
 
   // Methods to assign module for each year
-  // Note that the setup<year>v* are more specific, and if set, 
+  // Note that the setup<year>v* are more specific, and if set,
   // will take preference over the module passed to setup<year>
   void setup2016(uhh2::AnalysisModule * module);
   void setup2016v2(uhh2::AnalysisModule * module);
   void setup2016v3(uhh2::AnalysisModule * module);
-  
+
   void setup2017(uhh2::AnalysisModule * module);
   void setup2017v1(uhh2::AnalysisModule * module);
   void setup2017v2(uhh2::AnalysisModule * module);
-  
+
   void setup2018(uhh2::AnalysisModule * module);
 
 private:
@@ -41,10 +41,22 @@ private:
   // have modules for each year, plus the specific versions of each year
   // shared_ptr, because the user might already own it, and we want to ensure
   // it is kept alive, or deleted as necessary if this is the only owner
-  
+
   // FIXME: broken as this will create a new copy, not extend lifetime of original
   std::shared_ptr<uhh2::AnalysisModule> module2016_, module2016v2_, module2016v3_;
   std::shared_ptr<uhh2::AnalysisModule> module2017_, module2017v1_, module2017v2_;
   std::shared_ptr<uhh2::AnalysisModule> module2018_;
 };
 
+
+class RunSwitcher: public uhh2::AnalysisModule {
+public:
+  RunSwitcher(const std::string & year);
+  virtual bool process(uhh2::Event & event) override;
+  void setupRun(const std::string & runPeriod, uhh2::AnalysisModule * module);
+
+private:
+  std::string year_;
+  std::map<std::string, std::pair<int, int>> runNumberMap_;
+  std::map<std::string, std::shared_ptr<uhh2::AnalysisModule>> runModuleMap_;
+};

--- a/common/include/YearRunSwitchers.h
+++ b/common/include/YearRunSwitchers.h
@@ -15,9 +15,16 @@
  */
 
 
+/**
+ * Class to handle different AnalysisModules for different years
+ *
+ * The user can setup a module for each year using the `setup*()` methods,
+ * and it will automatically run the correct one for a given dataset
+ * when `process()` is called.
+ */
 class YearSwitcher: public uhh2::AnalysisModule {
 public:
-  YearSwitcher(uhh2::Context & ctx);
+  YearSwitcher(const uhh2::Context & ctx);
 
   // Automatically run the appropriate module.
   // If there isn't a matching one, just return true
@@ -27,20 +34,20 @@ public:
   // You will need to cast it to the specific derived type,
   // e.g. RunSwitcher * rs = dynamic_cast<RunSwitcher*>(myYearSwitcher->module());
   // Returns raw pointer as RunSwitcher has shared_ptr to it already
-  uhh2::AnalysisModule * module();
+  std::shared_ptr<uhh2::AnalysisModule> module();
 
   // Methods to assign module for each year
   // Note that the setup<year>v* are more specific, and if set,
   // will take preference over the module passed to setup<year>
-  void setup2016(uhh2::AnalysisModule * module);
-  void setup2016v2(uhh2::AnalysisModule * module);
-  void setup2016v3(uhh2::AnalysisModule * module);
+  void setup2016(std::shared_ptr<uhh2::AnalysisModule> module);
+  void setup2016v2(std::shared_ptr<uhh2::AnalysisModule> module);
+  void setup2016v3(std::shared_ptr<uhh2::AnalysisModule> module);
 
-  void setup2017(uhh2::AnalysisModule * module);
-  void setup2017v1(uhh2::AnalysisModule * module);
-  void setup2017v2(uhh2::AnalysisModule * module);
+  void setup2017(std::shared_ptr<uhh2::AnalysisModule> module);
+  void setup2017v1(std::shared_ptr<uhh2::AnalysisModule> module);
+  void setup2017v2(std::shared_ptr<uhh2::AnalysisModule> module);
 
-  void setup2018(uhh2::AnalysisModule * module);
+  void setup2018(std::shared_ptr<uhh2::AnalysisModule> module);
 
 private:
   Year year_;
@@ -49,8 +56,6 @@ private:
   // have modules for each year, plus for the specific versions of each year
   // shared_ptr, because the user might already own it, and we want to ensure
   // it is kept alive, or deleted as necessary if this is the only owner
-
-  // FIXME: broken as this will create a new copy, not extend lifetime of original?!
   std::shared_ptr<uhh2::AnalysisModule> module2016_, module2016v2_, module2016v3_;
   std::shared_ptr<uhh2::AnalysisModule> module2017_, module2017v1_, module2017v2_;
   std::shared_ptr<uhh2::AnalysisModule> module2018_;
@@ -78,14 +83,16 @@ public:
 
   // Get the relevant module, incase you need to access its other methods
   // You will need to cast it to the specific derived type,
-  // e.g. JetCorrector * jc = dynamic_cast<JetCorrector*>(myYearSwitcher->module());
-  // Returns raw pointer as RunSwitcher has shared_ptr to it already
-  uhh2::AnalysisModule * module(const uhh2::Event & event);
+  // e.g. std::shared_ptr<JetCorrector> jc = std::dynamic_pointer_cast<JetCorrector*>(myYearSwitcher->module());
+  std::shared_ptr<uhh2::AnalysisModule> module(const uhh2::Event & event);
 
   // Method to assign a module to a particular run period
-  void setupRun(const std::string & runPeriod, uhh2::AnalysisModule * module);
+  void setupRun(const std::string & runPeriod, std::shared_ptr<uhh2::AnalysisModule> module);
 
 private:
+  // convert e.g. 2016v2 -> 2016
+  std::string shortYear(const std::string & year);
+
   std::string year_;
   std::map<std::string, std::pair<int, int>> runNumberMap_;
   //shared_ptr usage: see comments in YearSwitcher

--- a/common/include/YearRunSwitchers.h
+++ b/common/include/YearRunSwitchers.h
@@ -23,6 +23,12 @@ public:
   // If there isn't a matching one, just return true
   virtual bool process(uhh2::Event & event) override;
 
+  // Get the relevant module, incase you need to access its other methods
+  // You will need to cast it to the specific derived type,
+  // e.g. RunSwitcher * rs = dynamic_cast<RunSwitcher*>(myYearSwitcher->module());
+  // Returns raw pointer as RunSwitcher has shared_ptr to it already
+  uhh2::AnalysisModule * module();
+
   // Methods to assign module for each year
   // Note that the setup<year>v* are more specific, and if set,
   // will take preference over the module passed to setup<year>
@@ -69,6 +75,12 @@ public:
   // Run the module corresponding to this year in the relevant run period
   // If none found, return true
   virtual bool process(uhh2::Event & event) override;
+
+  // Get the relevant module, incase you need to access its other methods
+  // You will need to cast it to the specific derived type,
+  // e.g. JetCorrector * jc = dynamic_cast<JetCorrector*>(myYearSwitcher->module());
+  // Returns raw pointer as RunSwitcher has shared_ptr to it already
+  uhh2::AnalysisModule * module(const uhh2::Event & event);
 
   // Method to assign a module to a particular run period
   void setupRun(const std::string & runPeriod, uhh2::AnalysisModule * module);

--- a/common/include/YearRunSwitchers.h
+++ b/common/include/YearRunSwitchers.h
@@ -49,6 +49,14 @@ private:
 };
 
 
+/**
+ * Class to handle different AnalysisModules for different run periods in data
+ *
+ * User should setup a module for each run period (e.g. "A") with the `setupRun()`
+ * method.
+ * Calling `process()` will then automatically figure out which one to use based
+ * on the event run number.
+ */
 class RunSwitcher: public uhh2::AnalysisModule {
 public:
   RunSwitcher(const std::string & year);

--- a/common/include/YearRunSwitchers.h
+++ b/common/include/YearRunSwitchers.h
@@ -53,6 +53,8 @@ class RunSwitcher: public uhh2::AnalysisModule {
 public:
   RunSwitcher(const std::string & year);
   virtual bool process(uhh2::Event & event) override;
+
+  // Method to assign a module to a particular run period
   void setupRun(const std::string & runPeriod, uhh2::AnalysisModule * module);
 
 private:

--- a/common/src/YearRunSwitchers.cxx
+++ b/common/src/YearRunSwitchers.cxx
@@ -1,0 +1,79 @@
+#include "UHH2/common/include/YearRunSwitchers.h"
+#include "UHH2/common/include/Utils.h"
+
+
+YearSwitcher::YearSwitcher():
+  module2016_(nullptr),
+  module2016v2_(nullptr),
+  module2016v3_(nullptr),
+  module2017_(nullptr),
+  module2017v1_(nullptr),
+  module2017v2_(nullptr),
+  module2018_(nullptr)
+{}
+
+bool YearSwitcher::process(uhh2::Event & event) {
+  if (isYear(event, "2016v2") && module2016v2_) {
+    return module2016v2_->process(event);
+  }
+  else if (isYear(event, "2016v3") && module2016v3_) {
+    return module2016v3_->process(event);
+  }
+  else if (isYear(event, "2016") && module2016_) {
+    return module2016_->process(event);
+  }
+
+  else if (isYear(event, "2017v1") && module2017v1_) {
+    return module2017v1_->process(event);
+  } 
+  else if (isYear(event, "2017v2") && module2017v2_) {
+    return module2017v2_->process(event);
+  }
+  else if (isYear(event, "2017") && module2017_) {
+    return module2017_->process(event);
+  }
+  
+  else if (isYear(event, "2018") && module2018_) {
+    return module2018_->process(event);
+  }
+  
+  else {
+    throw std::runtime_error("YearSwitcher cannot handle event.year = " + event.year 
+                             + ", you must use the relevant setup*() method");
+  }
+}
+
+// have to accept pointer as AnalysisModule is an abstract base class
+void YearSwitcher::setup2016(uhh2::AnalysisModule * module) {
+  module2016_.reset(module);
+}
+
+void YearSwitcher::setup2016v2(uhh2::AnalysisModule * module) {
+  module2016v2_.reset(module);
+}
+
+void YearSwitcher::setup2016v3(uhh2::AnalysisModule * module) {
+  module2016v3_.reset(module);
+}
+
+void YearSwitcher::setup2017(uhh2::AnalysisModule * module) {
+  module2017_.reset(module);
+}
+
+void YearSwitcher::setup2017v1(uhh2::AnalysisModule * module) {
+  module2017v1_.reset(module);
+}
+
+void YearSwitcher::setup2017v2(uhh2::AnalysisModule * module) {
+  module2017v2_.reset(module);
+}
+
+void YearSwitcher::setup2018(uhh2::AnalysisModule * module) {
+  module2018_.reset(module);
+}
+
+
+bool YearSwitcher::isYear(const uhh2::Event & event, const std::string & year) {
+  return event.year.find(year) != std::string::npos;
+}
+

--- a/common/src/YearRunSwitchers.cxx
+++ b/common/src/YearRunSwitchers.cxx
@@ -96,6 +96,8 @@ RunSwitcher::RunSwitcher(const std::string & year)
 }
 
 bool RunSwitcher::process(uhh2::Event & event) {
+  if (!event.isRealData) return true; // this class only makes sense for data
+
   // find which run period we are in using event.run
   // then use that to call the relevant module
   for (const auto & [key, val] : runNumberMap_) {

--- a/common/src/YearRunSwitchers.cxx
+++ b/common/src/YearRunSwitchers.cxx
@@ -108,7 +108,7 @@ bool RunSwitcher::process(uhh2::Event & event) {
       }
     }
   }
-  return false;
+  return true;
 }
 
 void RunSwitcher::setupRun(const std::string & runPeriod, uhh2::AnalysisModule * module) {

--- a/examples/config/ExampleYearRunSwitch.xml
+++ b/examples/config/ExampleYearRunSwitch.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE JobConfiguration PUBLIC "" "JobConfig.dtd">
+
+<!-- OutputLevel controls which messages are printed; set to VERBOSE or DEBUG for more verbosity, to WARNING or ERROR for less -->
+<JobConfiguration JobName="ExampleCycleJob" OutputLevel="INFO">
+    <Library Name="libSUHH2examples"/>
+    <Package Name="SUHH2examples.par" />
+
+   <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="./" PostFix="" TargetLumi="1" >
+
+        <InputData Lumi="1" NEventsMax="5" Type="DATA" Version="Data_2018" Cacheable="False">
+            <In FileName="data2018.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="5" Type="DATA" Version="Data_2016v3" Cacheable="False">
+            <In FileName="data2016v3.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="5" Type="DATA" Version="Data_2017v2" Cacheable="False">
+            <In FileName="data2017v2.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+        </InputData>
+
+        <UserConfig>
+            <!-- define which collections to read from the input. Only specify what you need to save I/O time -->
+            <Item Name="JetCollection" Value="jetsAk4CHS" />
+            <Item Name="GenJetCollection" Value="slimmedGenJets" />
+            <Item Name="METName" Value="slimmedMETs" />
+
+            <Item Name="AnalysisModule" Value="ExampleModuleYearRunSwitch" />
+
+            <!-- tell AnalysisModuleRunner NOT to use the MC event weight from SFrame; rather let
+                 MCLumiWeight (called via CommonModules) calculate the MC event weight. The MC
+                 event weight assigned by MCLumiWeight is InputData.Lumi / Cycle.TargetLumi. -->
+            <Item Name="use_sframe_weight" Value="false" />
+
+        </UserConfig>
+    </Cycle>
+</JobConfiguration>

--- a/examples/src/ExampleModuleYearRunSwitch.cxx
+++ b/examples/src/ExampleModuleYearRunSwitch.cxx
@@ -25,7 +25,7 @@ public:
     explicit DummyModule(const std::string & note):
     note_(note)
     {}
-    
+
     virtual bool process(Event & event){
         cout << note_ << endl;
         return true;
@@ -36,55 +36,101 @@ private:
 
 
 /** \brief Example of how to handle setting up modules for different years, run periods
- * 
+ *
  */
 class ExampleModuleYearRunSwitch: public AnalysisModule {
 public:
-    
+
     explicit ExampleModuleYearRunSwitch(Context & ctx);
     virtual bool process(Event & event) override;
 
 private:
-    
-    std::unique_ptr<YearSwitcher> dummyTextAll, jetCleanerAll;
+
+    std::unique_ptr<YearSwitcher> dummyTextYearSwitcher, jetCleanerYearSwitcher, megaYearSwitcher;
+    std::unique_ptr<RunSwitcher> dummyTextRun18, dummyTextRun17;
+
+    // Note that these are raw pointers
+    // FIXME: surely there must be a better way? Do these leak?
+    RunSwitcher *megaRunSwitcher16, *megaRunSwitcher17, *megaRunSwitcher18;
 
 };
 
 
 ExampleModuleYearRunSwitch::ExampleModuleYearRunSwitch(Context & ctx){
     cout << "Hello World from ExampleModuleYearRunSwitch!" << endl;
-    
+
     // Setup and instance of DummyModule module to be run for each year
     // Note that e.g. the 2016 one will be run for both 2016v2 & 2016v3 ntuples
-    dummyTextAll.reset(new YearSwitcher()); 
-    dummyTextAll->setup2016(new DummyModule("I am 2016"));
-    dummyTextAll->setup2017(new DummyModule("I am 2017"));
-    dummyTextAll->setup2018(new DummyModule("I am 2018"));
-    
+    dummyTextYearSwitcher.reset(new YearSwitcher());
+    dummyTextYearSwitcher->setup2016(new DummyModule("I am 2016"));
+    dummyTextYearSwitcher->setup2017(new DummyModule("I am 2017"));
+    dummyTextYearSwitcher->setup2018(new DummyModule("I am 2018"));
+
     // Here we specify a particular module for 2017v2 ntuples. This will be run
     // instead of the one created in setup2017() above.
     // 2017v1 ntuples will still use that one though.
-    dummyTextAll->setup2017v2(new DummyModule("I am 2017v2"));
+    dummyTextYearSwitcher->setup2017v2(new DummyModule("I am 2017v2"));
 
-    
-    // Here is a more realistic example - only for 2017, 
-    // we decide to exclude HF jets and raise the pT cut as well
-    jetCleanerAll.reset(new YearSwitcher()); 
-    jetCleanerAll->setup2016(new JetCleaner(ctx, 30.0, 5.));
-    jetCleanerAll->setup2017(new JetCleaner(ctx, 50.0, 3));
-    jetCleanerAll->setup2018(new JetCleaner(ctx, 30.0, 5));
-    
+    // Here is a more realistic example - we apply some jet cuts,
+    // but only for 2017 we decide to exclude HF jets and raise the pT cut as well
+    jetCleanerYearSwitcher.reset(new YearSwitcher());
+    jetCleanerYearSwitcher->setup2016(new JetCleaner(ctx, 30.0, 5.));
+    jetCleanerYearSwitcher->setup2017(new JetCleaner(ctx, 50.0, 3));
+    jetCleanerYearSwitcher->setup2018(new JetCleaner(ctx, 30.0, 5));
+
+
+    // Here we setup modules for specific run periods in a given year
+    dummyTextRun18.reset(new RunSwitcher("2018"));
+    dummyTextRun18->setupRun("A", new DummyModule("2018 Run A"));
+    dummyTextRun18->setupRun("B", new DummyModule("2018 Run B"));
+    dummyTextRun18->setupRun("C", new DummyModule("2018 Run C"));
+    dummyTextRun18->setupRun("D", new DummyModule("2018 Run D"));
+
+    // much easier way to iterate over all Run periods:
+    dummyTextRun17.reset(new RunSwitcher("2017"));
+    for (const auto & itr : {"B", "C", "D", "E", "F"}) {
+        dummyTextRun17->setupRun(itr, new DummyModule("2017 Run " + std::string(itr)));
+    }
+
+    // Finally, we can also combine these both
+    // Good for e.g. JECs
+    megaRunSwitcher16 = new RunSwitcher("2016");
+    for (const auto & runItr : runPeriods2016) { // runPeriods defined in common/include/Utils.h
+        megaRunSwitcher16->setupRun(runItr, new DummyModule("Super! 2016 + Run " + runItr));
+    }
+
+    megaRunSwitcher17 = new RunSwitcher("2017");
+    for (const auto & runItr : runPeriods2017) {
+        megaRunSwitcher17->setupRun(runItr, new DummyModule("Mega! 2017 + Run " + runItr));
+    }
+
+    megaRunSwitcher18 = new RunSwitcher("2018");
+    for (const auto & runItr : runPeriods2018) {
+        megaRunSwitcher18->setupRun(runItr, new DummyModule("Ausgezeichnet! 2018 + Run " + runItr));
+    }
+
+    megaYearSwitcher.reset(new YearSwitcher());
+    megaYearSwitcher->setup2016(megaRunSwitcher16);
+    megaYearSwitcher->setup2017(megaRunSwitcher17);
+    megaYearSwitcher->setup2018(megaRunSwitcher18);
+
 }
 
 
 bool ExampleModuleYearRunSwitch::process(Event & event) {
-    
+
     cout << "ExampleModuleYearRunSwitch: Starting to process event (runid, eventid) = (" << event.run << ", " << event.event << "); weight = " << event.weight << endl;
-    
-    // the YearSwitcher uses the event.year stored in the ntuple, 
+
+    // the YearSwitcher uses the event.year stored in the ntuple,
     // ignoring whatver is specified in the dataset Version
-    dummyTextAll->process(event);
-    jetCleanerAll->process(event);
+    dummyTextYearSwitcher->process(event);
+    jetCleanerYearSwitcher->process(event);
+
+    // note that for 2016, these are just ignored and all events return true
+    dummyTextRun17->process(event);
+    dummyTextRun18->process(event);
+
+    megaYearSwitcher->process(event);
 
     return true;
 }

--- a/examples/src/ExampleModuleYearRunSwitch.cxx
+++ b/examples/src/ExampleModuleYearRunSwitch.cxx
@@ -79,7 +79,7 @@ ExampleModuleYearRunSwitch::ExampleModuleYearRunSwitch(Context & ctx){
     jetCleanerYearSwitcher->setup2018(std::make_shared<JetCleaner>(ctx, 30.0, 5));
 
 
-    // // Here we setup modules for specific run periods in a given year
+    // Here we setup modules for specific run periods in a given year
     dummyTextRun18.reset(new RunSwitcher(ctx, "2018"));
     dummyTextRun18->setupRun("A", std::make_shared<DummyModule>("2018 Run A"));
     dummyTextRun18->setupRun("B", std::make_shared<DummyModule>("2018 Run B"));
@@ -121,8 +121,6 @@ bool ExampleModuleYearRunSwitch::process(Event & event) {
 
     cout << "ExampleModuleYearRunSwitch: Starting to process event (runid, eventid) = (" << event.run << ", " << event.event << "); weight = " << event.weight << endl;
 
-    // the YearSwitcher uses the event.year stored in the ntuple,
-    // ignoring whatver is specified in the dataset Version
     dummyTextYearSwitcher->process(event);
     jetCleanerYearSwitcher->process(event);
 

--- a/examples/src/ExampleModuleYearRunSwitch.cxx
+++ b/examples/src/ExampleModuleYearRunSwitch.cxx
@@ -49,9 +49,9 @@ private:
     std::unique_ptr<YearSwitcher> dummyTextYearSwitcher, jetCleanerYearSwitcher, megaYearSwitcher;
     std::unique_ptr<RunSwitcher> dummyTextRun18, dummyTextRun17;
 
-    // Note that these are raw pointers
-    // FIXME: surely there must be a better way? Do these leak?
-    RunSwitcher *megaRunSwitcher16, *megaRunSwitcher17, *megaRunSwitcher18;
+    // Note that these must be shared pointers,
+    // since we store them in a YearSwitcher
+    std::shared_ptr<RunSwitcher> megaRunSwitcher16, megaRunSwitcher17, megaRunSwitcher18;
 
 };
 
@@ -62,51 +62,51 @@ ExampleModuleYearRunSwitch::ExampleModuleYearRunSwitch(Context & ctx){
     // Setup and instance of DummyModule module to be run for each year
     // Note that e.g. the 2016 one will be run for both 2016v2 & 2016v3 ntuples
     dummyTextYearSwitcher.reset(new YearSwitcher(ctx));
-    dummyTextYearSwitcher->setup2016(new DummyModule("I am 2016"));
-    dummyTextYearSwitcher->setup2017(new DummyModule("I am 2017"));
-    dummyTextYearSwitcher->setup2018(new DummyModule("I am 2018"));
+    dummyTextYearSwitcher->setup2016(std::make_shared<DummyModule>("I am 2016"));
+    dummyTextYearSwitcher->setup2017(std::make_shared<DummyModule>("I am 2017"));
+    dummyTextYearSwitcher->setup2018(std::make_shared<DummyModule>("I am 2018"));
 
     // Here we specify a particular module for 2017v2 ntuples. This will be run
     // instead of the one created in setup2017() above.
     // 2017v1 ntuples will still use that one though.
-    dummyTextYearSwitcher->setup2017v2(new DummyModule("I am 2017v2"));
+    dummyTextYearSwitcher->setup2017v2(std::make_shared<DummyModule>("I am 2017v2"));
 
     // Here is a more realistic example - we apply some jet cuts,
     // but only for 2017 we decide to exclude HF jets and raise the pT cut as well
     jetCleanerYearSwitcher.reset(new YearSwitcher(ctx));
-    jetCleanerYearSwitcher->setup2016(new JetCleaner(ctx, 30.0, 5.));
-    jetCleanerYearSwitcher->setup2017(new JetCleaner(ctx, 50.0, 3));
-    jetCleanerYearSwitcher->setup2018(new JetCleaner(ctx, 30.0, 5));
+    jetCleanerYearSwitcher->setup2016(std::make_shared<JetCleaner>(ctx, 30.0, 5.));
+    jetCleanerYearSwitcher->setup2017(std::make_shared<JetCleaner>(ctx, 50.0, 3));
+    jetCleanerYearSwitcher->setup2018(std::make_shared<JetCleaner>(ctx, 30.0, 5));
 
 
-    // Here we setup modules for specific run periods in a given year
-    dummyTextRun18.reset(new RunSwitcher("2018"));
-    dummyTextRun18->setupRun("A", new DummyModule("2018 Run A"));
-    dummyTextRun18->setupRun("B", new DummyModule("2018 Run B"));
-    dummyTextRun18->setupRun("C", new DummyModule("2018 Run C"));
-    dummyTextRun18->setupRun("D", new DummyModule("2018 Run D"));
+    // // Here we setup modules for specific run periods in a given year
+    dummyTextRun18.reset(new RunSwitcher(ctx, "2018"));
+    dummyTextRun18->setupRun("A", std::make_shared<DummyModule>("2018 Run A"));
+    dummyTextRun18->setupRun("B", std::make_shared<DummyModule>("2018 Run B"));
+    dummyTextRun18->setupRun("C", std::make_shared<DummyModule>("2018 Run C"));
+    dummyTextRun18->setupRun("D", std::make_shared<DummyModule>("2018 Run D"));
 
-    // much easier way to iterate over all Run periods:
-    dummyTextRun17.reset(new RunSwitcher("2017"));
+    // // much easier way to iterate over all Run periods:
+    dummyTextRun17.reset(new RunSwitcher(ctx, "2017"));
     for (const auto & itr : {"B", "C", "D", "E", "F"}) {
-        dummyTextRun17->setupRun(itr, new DummyModule("2017 Run " + std::string(itr)));
+        dummyTextRun17->setupRun(itr, std::make_shared<DummyModule>("2017 Run " + std::string(itr)));
     }
 
     // Finally, we can also combine these both
     // Good for e.g. JECs
-    megaRunSwitcher16 = new RunSwitcher("2016");
+    megaRunSwitcher16.reset(new RunSwitcher(ctx, "2016"));
     for (const auto & runItr : runPeriods2016) { // runPeriods defined in common/include/Utils.h
-        megaRunSwitcher16->setupRun(runItr, new DummyModule("Super! 2016 + Run " + runItr));
+        megaRunSwitcher16->setupRun(runItr, std::make_shared<DummyModule>("Super! 2016 + Run " + runItr));
     }
 
-    megaRunSwitcher17 = new RunSwitcher("2017");
+    megaRunSwitcher17.reset(new RunSwitcher(ctx, "2017"));
     for (const auto & runItr : runPeriods2017) {
-        megaRunSwitcher17->setupRun(runItr, new DummyModule("Mega! 2017 + Run " + runItr));
+        megaRunSwitcher17->setupRun(runItr, std::make_shared<DummyModule>("Mega! 2017 + Run " + runItr));
     }
 
-    megaRunSwitcher18 = new RunSwitcher("2018");
+    megaRunSwitcher18.reset(new RunSwitcher(ctx, "2018"));
     for (const auto & runItr : runPeriods2018) {
-        megaRunSwitcher18->setupRun(runItr, new DummyModule("Ausgezeichnet! 2018 + Run " + runItr));
+        megaRunSwitcher18->setupRun(runItr, std::make_shared<DummyModule>("Ausgezeichnet! 2018 + Run " + runItr));
     }
 
     megaYearSwitcher.reset(new YearSwitcher(ctx));

--- a/examples/src/ExampleModuleYearRunSwitch.cxx
+++ b/examples/src/ExampleModuleYearRunSwitch.cxx
@@ -1,0 +1,96 @@
+#include <iostream>
+#include <memory>
+
+#include "UHH2/core/include/AnalysisModule.h"
+#include "UHH2/core/include/Event.h"
+#include "UHH2/common/include/CommonModules.h"
+#include "UHH2/common/include/CleaningModules.h"
+#include "UHH2/common/include/ElectronHists.h"
+#include "UHH2/common/include/NSelections.h"
+#include "UHH2/common/include/YearRunSwitchers.h"
+#include "UHH2/examples/include/ExampleSelections.h"
+#include "UHH2/examples/include/ExampleHists.h"
+
+using namespace std;
+using namespace uhh2;
+
+namespace uhh2examples {
+
+
+/**
+ * Dummy module just to print some text
+ */
+class DummyModule: public AnalysisModule {
+public:
+    explicit DummyModule(const std::string & note):
+    note_(note)
+    {}
+    
+    virtual bool process(Event & event){
+        cout << note_ << endl;
+        return true;
+    }
+private:
+    std::string note_;
+};
+
+
+/** \brief Example of how to handle setting up modules for different years, run periods
+ * 
+ */
+class ExampleModuleYearRunSwitch: public AnalysisModule {
+public:
+    
+    explicit ExampleModuleYearRunSwitch(Context & ctx);
+    virtual bool process(Event & event) override;
+
+private:
+    
+    std::unique_ptr<YearSwitcher> dummyTextAll, jetCleanerAll;
+
+};
+
+
+ExampleModuleYearRunSwitch::ExampleModuleYearRunSwitch(Context & ctx){
+    cout << "Hello World from ExampleModuleYearRunSwitch!" << endl;
+    
+    // Setup and instance of DummyModule module to be run for each year
+    // Note that e.g. the 2016 one will be run for both 2016v2 & 2016v3 ntuples
+    dummyTextAll.reset(new YearSwitcher()); 
+    dummyTextAll->setup2016(new DummyModule("I am 2016"));
+    dummyTextAll->setup2017(new DummyModule("I am 2017"));
+    dummyTextAll->setup2018(new DummyModule("I am 2018"));
+    
+    // Here we specify a particular module for 2017v2 ntuples. This will be run
+    // instead of the one created in setup2017() above.
+    // 2017v1 ntuples will still use that one though.
+    dummyTextAll->setup2017v2(new DummyModule("I am 2017v2"));
+
+    
+    // Here is a more realistic example - only for 2017, 
+    // we decide to exclude HF jets and raise the pT cut as well
+    jetCleanerAll.reset(new YearSwitcher()); 
+    jetCleanerAll->setup2016(new JetCleaner(ctx, 30.0, 5.));
+    jetCleanerAll->setup2017(new JetCleaner(ctx, 50.0, 3));
+    jetCleanerAll->setup2018(new JetCleaner(ctx, 30.0, 5));
+    
+}
+
+
+bool ExampleModuleYearRunSwitch::process(Event & event) {
+    
+    cout << "ExampleModuleYearRunSwitch: Starting to process event (runid, eventid) = (" << event.run << ", " << event.event << "); weight = " << event.weight << endl;
+    
+    // the YearSwitcher uses the event.year stored in the ntuple, 
+    // ignoring whatver is specified in the dataset Version
+    dummyTextAll->process(event);
+    jetCleanerAll->process(event);
+
+    return true;
+}
+
+// as we want to run the ExampleCycleNew directly with AnalysisModuleRunner,
+// make sure the ExampleModuleYearRunSwitch is found by class name. This is ensured by this macro:
+UHH2_REGISTER_ANALYSIS_MODULE(ExampleModuleYearRunSwitch)
+
+}

--- a/examples/src/ExampleModuleYearRunSwitch.cxx
+++ b/examples/src/ExampleModuleYearRunSwitch.cxx
@@ -61,7 +61,7 @@ ExampleModuleYearRunSwitch::ExampleModuleYearRunSwitch(Context & ctx){
 
     // Setup and instance of DummyModule module to be run for each year
     // Note that e.g. the 2016 one will be run for both 2016v2 & 2016v3 ntuples
-    dummyTextYearSwitcher.reset(new YearSwitcher());
+    dummyTextYearSwitcher.reset(new YearSwitcher(ctx));
     dummyTextYearSwitcher->setup2016(new DummyModule("I am 2016"));
     dummyTextYearSwitcher->setup2017(new DummyModule("I am 2017"));
     dummyTextYearSwitcher->setup2018(new DummyModule("I am 2018"));
@@ -73,7 +73,7 @@ ExampleModuleYearRunSwitch::ExampleModuleYearRunSwitch(Context & ctx){
 
     // Here is a more realistic example - we apply some jet cuts,
     // but only for 2017 we decide to exclude HF jets and raise the pT cut as well
-    jetCleanerYearSwitcher.reset(new YearSwitcher());
+    jetCleanerYearSwitcher.reset(new YearSwitcher(ctx));
     jetCleanerYearSwitcher->setup2016(new JetCleaner(ctx, 30.0, 5.));
     jetCleanerYearSwitcher->setup2017(new JetCleaner(ctx, 50.0, 3));
     jetCleanerYearSwitcher->setup2018(new JetCleaner(ctx, 30.0, 5));
@@ -109,7 +109,7 @@ ExampleModuleYearRunSwitch::ExampleModuleYearRunSwitch(Context & ctx){
         megaRunSwitcher18->setupRun(runItr, new DummyModule("Ausgezeichnet! 2018 + Run " + runItr));
     }
 
-    megaYearSwitcher.reset(new YearSwitcher());
+    megaYearSwitcher.reset(new YearSwitcher(ctx));
     megaYearSwitcher->setup2016(megaRunSwitcher16);
     megaYearSwitcher->setup2017(megaRunSwitcher17);
     megaYearSwitcher->setup2018(megaRunSwitcher18);


### PR DESCRIPTION
[only compile]

Add 2 new general classes: `YearSwitcher` and `RunSwitcher`. Each is designed to encapsulate away the logic of switching modules based on year and run #. The idea is the user sets up all the relevant modules at the start in their analysis constructor, then in their analysis `process()` they just call the `process()` method of these classes and don't have to worry any more. An example of usage of each of these, and using them in combination, is included in `ExampleModuleYearRunSwitcher`.

This way the same analysis can be used for different years, and the modules can easily be set up - each accepts anything inheriting from `uhh2::AnalysisModule`.

`YearSwitcher` can be setup for any 2016 dataset, or specialise for 2016v2, v3 separately. If the user does `setup2016()` then `setup2016v3()`, then a 2016v3 dataset will use the latter, whilst a 2016v2 dataset will use the former. Similarly for 2017, v1 & v2.

A `RunSwitcher` instance can be setup for a given year. Here it will ignore `v*`, so e.g. treats `2016v3` as `2016`. Then the user can add modules for given run periods, specifying the run period with a string to allow for looping (see example module L99, 104, 109)

C++ technicality: I'm not entirely sure using a `shared_ptr` is the correct way to aggregate here - I am trying to cover the scenario when the user creates the object in the `setup*` method calls, but also when they have already created the object, and this class needs it to stay alive.

Feedback on the design is welcome!

A target for these classes is the JECs...