### PR TITLE
[102X] Use Year & Run switchers in CommonModules - DON'T MERGE

### DIFF
--- a/common/include/CommonModules.h
+++ b/common/include/CommonModules.h
@@ -109,9 +109,9 @@ private:
     TauId tauid;
     JetPFID::wp working_point;
     std::unique_ptr<YearSwitcher> jet_corrector_MC, jet_corrector_data;
-    RunSwitcher *jec_switcher_16, *jec_switcher_17, *jec_switcher_18;
+    std::shared_ptr<RunSwitcher> jec_switcher_16, jec_switcher_17, jec_switcher_18;
     std::unique_ptr<YearSwitcher> JLC_MC, JLC_data;
-    RunSwitcher *JLC_switcher_16, *JLC_switcher_17, *JLC_switcher_18;
+    std::shared_ptr<RunSwitcher> JLC_switcher_16, JLC_switcher_17, JLC_switcher_18;
     std::unique_ptr<JetResolutionSmearer> jet_resolution_smearer;
     std::unique_ptr<JetCleaner> jet_cleaner;
 

--- a/common/include/CommonModules.h
+++ b/common/include/CommonModules.h
@@ -8,6 +8,7 @@
 #include "UHH2/common/include/JetIds.h"
 #include "UHH2/common/include/JetCorrections.h"
 #include "UHH2/common/include/CleaningModules.h"
+#include "UHH2/common/include/YearRunSwitchers.h"
 
 
 /** \brief Run a configurable list commonly used modules
@@ -107,15 +108,12 @@ private:
     MuonId muid;
     TauId tauid;
     JetPFID::wp working_point;
-    std::unique_ptr<JetCorrector> jet_corrector_MC, jet_corrector_B, jet_corrector_C, jet_corrector_D, jet_corrector_E, jet_corrector_F;
-    std::unique_ptr<JetLeptonCleaner_by_KEYmatching> JLC_MC, JLC_B, JLC_C, JLC_D, JLC_E, JLC_F;
+    std::unique_ptr<YearSwitcher> jet_corrector_MC, jet_corrector_data;
+    RunSwitcher *jec_switcher_16, *jec_switcher_17, *jec_switcher_18;
+    std::unique_ptr<YearSwitcher> JLC_MC, JLC_data;
+    RunSwitcher *JLC_switcher_16, *JLC_switcher_17, *JLC_switcher_18;
     std::unique_ptr<JetResolutionSmearer> jet_resolution_smearer;
     std::unique_ptr<JetCleaner> jet_cleaner;
-    const int runnr_B = 299329;
-    const int runnr_C = 302029;
-    const int runnr_D = 303434;
-    const int runnr_E = 304826;
-    const int runnr_F = 306462;
 
     bool mclumiweight = true, mcpileupreweight = true, jersmear = true, jec = true, lumisel=true, jetlepcleaner = false, topjetlepcleaner =false, jetptsort = false, metfilters = true, pvfilter = true, jetpfidcleaner=true, do_metcorrection = false;
     double topjetcleanerDR;
@@ -125,7 +123,10 @@ private:
     Year year;
 
     // Parameters for JEC & JLC sets
-    std::string jec_tag, jec_ver, jec_jet_coll;
+    std::string jec_tag_2016, jec_ver_2016;
+    std::string jec_tag_2017, jec_ver_2017;
+    std::string jec_tag_2018, jec_ver_2018;
+    std::string jec_jet_coll;
 
     std::unique_ptr<Selection> lumi_selection;
     std::unique_ptr<AndSelection> metfilters_selection;

--- a/common/include/Utils.h
+++ b/common/include/Utils.h
@@ -119,6 +119,15 @@ Year extract_year(const uhh2::Context & ctx);
 
 
 /**
+ * Run period names for each year
+ */
+const std::vector<std::string> runPeriods2016 = {"B", "C", "D", "E", "F", "G", "H"};
+
+const std::vector<std::string> runPeriods2017 = {"B", "C", "D", "E", "F"};
+
+const std::vector<std::string> runPeriods2018 = {"A", "B", "C", "D"};
+
+/**
  * Map run periods to run numbers for each year
  *
  * All pairs for a run period are inclusive of both lower & upper numbers

--- a/common/include/Utils.h
+++ b/common/include/Utils.h
@@ -121,9 +121,9 @@ Year extract_year(const uhh2::Context & ctx);
 /**
  * Map run periods to run numbers for each year
  *
- * All pairs for a run period are up to and including the last number
+ * All pairs for a run period are inclusive of both lower & upper numbers
  */
-const std::unordered_map<std::string, std::unordered_map<std::string, std::pair<int, int>>>
+const std::unordered_map<std::string, std::map<std::string, std::pair<int, int>>>
   run_number_map = {
     // taken from https://twiki.cern.ch/twiki/bin/view/CMS/PdmV2016Analysis
     { "2016", {

--- a/common/include/Utils.h
+++ b/common/include/Utils.h
@@ -116,3 +116,46 @@ const std::map<Year, std::string> year_str_map = {
 
 /* Get Year enum from dataset_version in XML config */
 Year extract_year(const uhh2::Context & ctx);
+
+
+/**
+ * Map run periods to run numbers for each year
+ *
+ * All pairs for a run period are up to and including the last number
+ */
+const std::unordered_map<std::string, std::unordered_map<std::string, std::pair<int, int>>>
+  run_number_map = {
+    // taken from https://twiki.cern.ch/twiki/bin/view/CMS/PdmV2016Analysis
+    { "2016", {
+        { "A", std::pair(-1, -1) }, // dummy ones for consistency
+        { "B", std::pair(272007, 275376) },
+        { "C", std::pair(275657, 276283) },
+        { "D", std::pair(276315, 276811) },
+        { "E", std::pair(276831, 277420) },
+        { "F", std::pair(277772, 278808) },
+        { "G", std::pair(278820, 280385) },
+        { "H", std::pair(280919, 284044) },
+    }},
+    // taken from https://twiki.cern.ch/twiki/bin/view/CMS/PdmV2017Analysis
+    { "2017", {
+        { "A", std::pair(-1, -1) },
+        { "B", std::pair(297020, 299329) },
+        { "C", std::pair(299337, 302029) },
+        { "D", std::pair(302030, 303434) },
+        { "E", std::pair(303435, 304826) },
+        { "F", std::pair(304911, 306462) },
+        { "G", std::pair(-1, -1) },
+        { "H", std::pair(-1, -1) },
+    }},
+    // taken from https://twiki.cern.ch/twiki/bin/view/CMS/PdmV2018Analysis
+    { "2018", {
+        { "A", std::pair(315252, 316995) },
+        { "B", std::pair(316998, 319312) },
+        { "C", std::pair(319313, 320393) },
+        { "D", std::pair(320394, 325273) },
+        { "E", std::pair(-1, -1) },
+        { "F", std::pair(-1, -1) },
+        { "G", std::pair(-1, -1) },
+        { "H", std::pair(-1, -1) },
+    }},
+};

--- a/common/include/YearRunSwitchers.h
+++ b/common/include/YearRunSwitchers.h
@@ -2,6 +2,7 @@
 #include "UHH2/core/include/AnalysisModule.h"
 #include "UHH2/core/include/Event.h"
 #include "UHH2/core/include/Utils.h"
+#include "UHH2/common/include/Utils.h"
 
 #include <map>
 
@@ -16,9 +17,10 @@
 
 class YearSwitcher: public uhh2::AnalysisModule {
 public:
-  // FIXME: Would it be faster though to ask context for the year i.e. get it from the dataset Version?
-  // Doesn't make use of event.year, so avoids slow string matching potentially
-  YearSwitcher();
+  YearSwitcher(uhh2::Context & ctx);
+
+  // Automatically run the appropriate module.
+  // If there isn't a matching one, just return true
   virtual bool process(uhh2::Event & event) override;
 
   // Methods to assign module for each year
@@ -35,17 +37,19 @@ public:
   void setup2018(uhh2::AnalysisModule * module);
 
 private:
-  // check if event.year matches year string
-  bool isYear(const uhh2::Event & event, const std::string & year);
+  Year year_;
+  bool doneInit_;
 
-  // have modules for each year, plus the specific versions of each year
+  // have modules for each year, plus for the specific versions of each year
   // shared_ptr, because the user might already own it, and we want to ensure
   // it is kept alive, or deleted as necessary if this is the only owner
 
-  // FIXME: broken as this will create a new copy, not extend lifetime of original
+  // FIXME: broken as this will create a new copy, not extend lifetime of original?!
   std::shared_ptr<uhh2::AnalysisModule> module2016_, module2016v2_, module2016v3_;
   std::shared_ptr<uhh2::AnalysisModule> module2017_, module2017v1_, module2017v2_;
   std::shared_ptr<uhh2::AnalysisModule> module2018_;
+  std::shared_ptr<uhh2::AnalysisModule> theModule_;
+
 };
 
 
@@ -60,6 +64,9 @@ private:
 class RunSwitcher: public uhh2::AnalysisModule {
 public:
   RunSwitcher(const std::string & year);
+
+  // Run the module corresponding to this year in the relevant run period
+  // If none found, return true
   virtual bool process(uhh2::Event & event) override;
 
   // Method to assign a module to a particular run period

--- a/common/include/YearRunSwitchers.h
+++ b/common/include/YearRunSwitchers.h
@@ -1,0 +1,50 @@
+#pragma once
+#include "UHH2/core/include/AnalysisModule.h"
+#include "UHH2/core/include/Event.h"
+#include "UHH2/core/include/Utils.h"
+
+#include <map>
+
+
+/**
+ * Classes to aid automatically running modules for different years and run periods.
+ *
+ * Thee encapsulate the logic of switching years/runs away, so the user does
+ * not need to implement it themselves.
+ */
+
+
+class YearSwitcher: public uhh2::AnalysisModule {
+public:
+  // FIXME: Would it be faster though to ask context for the year i.e. get it from the dataset Version?
+  // Doesn't make use of event.year, so avoids slow string matching potentially
+  YearSwitcher();
+  virtual bool process(uhh2::Event & event) override;
+
+  // Methods to assign module for each year
+  // Note that the setup<year>v* are more specific, and if set, 
+  // will take preference over the module passed to setup<year>
+  void setup2016(uhh2::AnalysisModule * module);
+  void setup2016v2(uhh2::AnalysisModule * module);
+  void setup2016v3(uhh2::AnalysisModule * module);
+  
+  void setup2017(uhh2::AnalysisModule * module);
+  void setup2017v1(uhh2::AnalysisModule * module);
+  void setup2017v2(uhh2::AnalysisModule * module);
+  
+  void setup2018(uhh2::AnalysisModule * module);
+
+private:
+  // check if event.year matches year string
+  bool isYear(const uhh2::Event & event, const std::string & year);
+
+  // have modules for each year, plus the specific versions of each year
+  // shared_ptr, because the user might already own it, and we want to ensure
+  // it is kept alive, or deleted as necessary if this is the only owner
+  
+  // FIXME: broken as this will create a new copy, not extend lifetime of original
+  std::shared_ptr<uhh2::AnalysisModule> module2016_, module2016v2_, module2016v3_;
+  std::shared_ptr<uhh2::AnalysisModule> module2017_, module2017v1_, module2017v2_;
+  std::shared_ptr<uhh2::AnalysisModule> module2018_;
+};
+

--- a/common/include/YearRunSwitchers.h
+++ b/common/include/YearRunSwitchers.h
@@ -56,8 +56,9 @@ private:
 /**
  * Class to handle different AnalysisModules for different run periods in data
  *
- * User should setup a module for each run period (e.g. "A") with the `setupRun()`
- * method.
+ * One instance of this class is designed to handle a specific year's data.
+ * User should then setup a module for each run period (e.g. "A")
+ * with the `setupRun()` method.
  * Calling `process()` will then automatically figure out which one to use based
  * on the event run number.
  */
@@ -75,5 +76,6 @@ public:
 private:
   std::string year_;
   std::map<std::string, std::pair<int, int>> runNumberMap_;
+  //shared_ptr usage: see comments in YearSwitcher
   std::map<std::string, std::shared_ptr<uhh2::AnalysisModule>> runModuleMap_;
 };

--- a/common/include/YearRunSwitchers.h
+++ b/common/include/YearRunSwitchers.h
@@ -22,16 +22,16 @@ public:
   virtual bool process(uhh2::Event & event) override;
 
   // Methods to assign module for each year
-  // Note that the setup<year>v* are more specific, and if set, 
+  // Note that the setup<year>v* are more specific, and if set,
   // will take preference over the module passed to setup<year>
   void setup2016(uhh2::AnalysisModule * module);
   void setup2016v2(uhh2::AnalysisModule * module);
   void setup2016v3(uhh2::AnalysisModule * module);
-  
+
   void setup2017(uhh2::AnalysisModule * module);
   void setup2017v1(uhh2::AnalysisModule * module);
   void setup2017v2(uhh2::AnalysisModule * module);
-  
+
   void setup2018(uhh2::AnalysisModule * module);
 
 private:
@@ -41,10 +41,22 @@ private:
   // have modules for each year, plus the specific versions of each year
   // shared_ptr, because the user might already own it, and we want to ensure
   // it is kept alive, or deleted as necessary if this is the only owner
-  
+
   // FIXME: broken as this will create a new copy, not extend lifetime of original
   std::shared_ptr<uhh2::AnalysisModule> module2016_, module2016v2_, module2016v3_;
   std::shared_ptr<uhh2::AnalysisModule> module2017_, module2017v1_, module2017v2_;
   std::shared_ptr<uhh2::AnalysisModule> module2018_;
 };
 
+
+class RunSwitcher: public uhh2::AnalysisModule {
+public:
+  RunSwitcher(const std::string & year);
+  virtual bool process(uhh2::Event & event) override;
+  void setupRun(const std::string & runPeriod, uhh2::AnalysisModule * module);
+
+private:
+  std::string year_;
+  std::map<std::string, std::pair<int, int>> runNumberMap_;
+  std::map<std::string, std::shared_ptr<uhh2::AnalysisModule>> runModuleMap_;
+};

--- a/common/include/YearRunSwitchers.h
+++ b/common/include/YearRunSwitchers.h
@@ -23,6 +23,12 @@ public:
   // If there isn't a matching one, just return true
   virtual bool process(uhh2::Event & event) override;
 
+  // Get the relevant module, incase you need to access its other methods
+  // You will need to cast it to the specific derived type,
+  // e.g. RunSwitcher * rs = dynamic_cast<RunSwitcher*>(myYearSwitcher->module());
+  // Returns raw pointer as RunSwitcher has shared_ptr to it already
+  uhh2::AnalysisModule * module();
+
   // Methods to assign module for each year
   // Note that the setup<year>v* are more specific, and if set,
   // will take preference over the module passed to setup<year>
@@ -69,6 +75,12 @@ public:
   // Run the module corresponding to this year in the relevant run period
   // If none found, return true
   virtual bool process(uhh2::Event & event) override;
+
+  // Get the relevant module, incase you need to access its other methods
+  // You will need to cast it to the specific derived type,
+  // e.g. JetCorrector * jc = dynamic_cast<JetCorrector*>(myYearSwitcher->module());
+  // Returns raw pointer as RunSwitcher has shared_ptr to it already
+  uhh2::AnalysisModule * module(const uhh2::Event & event);
 
   // Method to assign a module to a particular run period
   void setupRun(const std::string & runPeriod, uhh2::AnalysisModule * module);

--- a/common/include/YearRunSwitchers.h
+++ b/common/include/YearRunSwitchers.h
@@ -49,6 +49,14 @@ private:
 };
 
 
+/**
+ * Class to handle different AnalysisModules for different run periods in data
+ *
+ * User should setup a module for each run period (e.g. "A") with the `setupRun()`
+ * method.
+ * Calling `process()` will then automatically figure out which one to use based
+ * on the event run number.
+ */
 class RunSwitcher: public uhh2::AnalysisModule {
 public:
   RunSwitcher(const std::string & year);

--- a/common/include/YearRunSwitchers.h
+++ b/common/include/YearRunSwitchers.h
@@ -53,6 +53,8 @@ class RunSwitcher: public uhh2::AnalysisModule {
 public:
   RunSwitcher(const std::string & year);
   virtual bool process(uhh2::Event & event) override;
+
+  // Method to assign a module to a particular run period
   void setupRun(const std::string & runPeriod, uhh2::AnalysisModule * module);
 
 private:

--- a/common/src/CommonModules.cxx
+++ b/common/src/CommonModules.cxx
@@ -52,28 +52,28 @@ void CommonModules::init(Context & ctx, const std::string & SysType_PU){
     if(mcpileupreweight) modules.emplace_back(new MCPileupReweight(ctx,SysType_PU));
     if(jec){
       jet_corrector_MC.reset(new YearSwitcher(ctx));
-      jet_corrector_MC->setup2016(new JetCorrector(ctx, JERFiles::JECFilesMC(jec_tag_2016, jec_ver_2016, jec_jet_coll)));
-      jet_corrector_MC->setup2017(new JetCorrector(ctx, JERFiles::JECFilesMC(jec_tag_2017, jec_ver_2017, jec_jet_coll)));
-      jet_corrector_MC->setup2018(new JetCorrector(ctx, JERFiles::JECFilesMC(jec_tag_2018, jec_ver_2018, jec_jet_coll)));
+      jet_corrector_MC->setup2016(std::make_shared<JetCorrector>(ctx, JERFiles::JECFilesMC(jec_tag_2016, jec_ver_2016, jec_jet_coll)));
+      jet_corrector_MC->setup2017(std::make_shared<JetCorrector>(ctx, JERFiles::JECFilesMC(jec_tag_2017, jec_ver_2017, jec_jet_coll)));
+      jet_corrector_MC->setup2018(std::make_shared<JetCorrector>(ctx, JERFiles::JECFilesMC(jec_tag_2018, jec_ver_2018, jec_jet_coll)));
     }
     if(jersmear) jet_resolution_smearer.reset(new JetResolutionSmearer(ctx));
   }
   else{
     if(lumisel) lumi_selection.reset(new LumiSelection(ctx));
     if(jec){
-      jec_switcher_16 = new RunSwitcher("2016");
+      jec_switcher_16.reset(new RunSwitcher(ctx, "2016"));
       for (const auto & runItr : runPeriods2016) { // runPeriods defined in common/include/Utils.h
-        jec_switcher_16->setupRun(runItr, new JetCorrector(ctx, JERFiles::JECFilesDATA(jec_tag_2016, jec_ver_2016, jec_jet_coll, runItr)));
+        jec_switcher_16->setupRun(runItr, std::make_shared<JetCorrector>(ctx, JERFiles::JECFilesDATA(jec_tag_2016, jec_ver_2016, jec_jet_coll, runItr)));
       }
 
-      jec_switcher_17 = new RunSwitcher("2017");
+      jec_switcher_17.reset(new RunSwitcher(ctx, "2017"));
       for (const auto & runItr : runPeriods2017) {
-        jec_switcher_17->setupRun(runItr, new JetCorrector(ctx, JERFiles::JECFilesDATA(jec_tag_2017, jec_ver_2017, jec_jet_coll, runItr)));
+        jec_switcher_17->setupRun(runItr, std::make_shared<JetCorrector>(ctx, JERFiles::JECFilesDATA(jec_tag_2017, jec_ver_2017, jec_jet_coll, runItr)));
       }
 
-      jec_switcher_18 = new RunSwitcher("2018");
+      jec_switcher_18.reset(new RunSwitcher(ctx, "2018"));
       for (const auto & runItr : runPeriods2018) {
-        jec_switcher_18->setupRun(runItr, new JetCorrector(ctx, JERFiles::JECFilesDATA(jec_tag_2018, jec_ver_2018, jec_jet_coll, runItr)));
+        jec_switcher_18->setupRun(runItr, std::make_shared<JetCorrector>(ctx, JERFiles::JECFilesDATA(jec_tag_2018, jec_ver_2018, jec_jet_coll, runItr)));
       }
 
       jet_corrector_data.reset(new YearSwitcher(ctx));
@@ -109,24 +109,24 @@ void CommonModules::init(Context & ctx, const std::string & SysType_PU){
   if(jetlepcleaner) {
     if(is_mc) {
       JLC_MC.reset(new YearSwitcher(ctx));
-      JLC_MC->setup2016(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::JECFilesMC(jec_tag_2016, jec_ver_2016, jec_jet_coll)));
-      JLC_MC->setup2017(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::JECFilesMC(jec_tag_2017, jec_ver_2017, jec_jet_coll)));
-      JLC_MC->setup2018(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::JECFilesMC(jec_tag_2018, jec_ver_2018, jec_jet_coll)));
+      JLC_MC->setup2016(std::make_shared<JetLeptonCleaner_by_KEYmatching>(ctx, JERFiles::JECFilesMC(jec_tag_2016, jec_ver_2016, jec_jet_coll)));
+      JLC_MC->setup2017(std::make_shared<JetLeptonCleaner_by_KEYmatching>(ctx, JERFiles::JECFilesMC(jec_tag_2017, jec_ver_2017, jec_jet_coll)));
+      JLC_MC->setup2018(std::make_shared<JetLeptonCleaner_by_KEYmatching>(ctx, JERFiles::JECFilesMC(jec_tag_2018, jec_ver_2018, jec_jet_coll)));
     }
     else{
-      JLC_switcher_16 = new RunSwitcher("2016");
+      JLC_switcher_16.reset(new RunSwitcher(ctx, "2016"));
       for (const auto & runItr : runPeriods2016) {
-        JLC_switcher_16->setupRun(runItr, new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::JECFilesDATA(jec_tag_2016, jec_ver_2016, jec_jet_coll, runItr)));
+        JLC_switcher_16->setupRun(runItr, std::make_shared<JetLeptonCleaner_by_KEYmatching>(ctx, JERFiles::JECFilesDATA(jec_tag_2016, jec_ver_2016, jec_jet_coll, runItr)));
       }
 
-      JLC_switcher_17 = new RunSwitcher("2017");
+      JLC_switcher_17.reset(new RunSwitcher(ctx, "2017"));
       for (const auto & runItr : runPeriods2017) {
-        JLC_switcher_17->setupRun(runItr, new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::JECFilesDATA(jec_tag_2017, jec_ver_2017, jec_jet_coll, runItr)));
+        JLC_switcher_17->setupRun(runItr, std::make_shared<JetLeptonCleaner_by_KEYmatching>(ctx, JERFiles::JECFilesDATA(jec_tag_2017, jec_ver_2017, jec_jet_coll, runItr)));
       }
 
-      JLC_switcher_18 = new RunSwitcher("2018");
+      JLC_switcher_18.reset(new RunSwitcher(ctx, "2018"));
       for (const auto & runItr : runPeriods2018) {
-        JLC_switcher_18->setupRun(runItr, new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::JECFilesDATA(jec_tag_2018, jec_ver_2018, jec_jet_coll, runItr)));
+        JLC_switcher_18->setupRun(runItr, std::make_shared<JetLeptonCleaner_by_KEYmatching>(ctx, JERFiles::JECFilesDATA(jec_tag_2018, jec_ver_2018, jec_jet_coll, runItr)));
       }
 
       JLC_data.reset(new YearSwitcher(ctx));
@@ -175,13 +175,12 @@ bool CommonModules::process(uhh2::Event & event){
   //set do_metcorrection = true in case you applied jet lepton cleaning by yourself and before calling common modules
   if((jetlepcleaner && jec) || (do_metcorrection && jec)){
     if (is_mc) {
-      // raw pointer OK as the YearSwitcher owns it...
       // some casting needed to get back to derived type
-      JetCorrector * jc = dynamic_cast<JetCorrector*>(jet_corrector_MC->module());
+      std::shared_ptr<JetCorrector> jc = std::dynamic_pointer_cast<JetCorrector>(jet_corrector_MC->module());
       jc->correct_met(event);
     } else {
-      RunSwitcher * rs = dynamic_cast<RunSwitcher*>(jet_corrector_data->module());
-      JetCorrector * jc = dynamic_cast<JetCorrector*>(rs->module(event));
+      std::shared_ptr<RunSwitcher> rs = std::dynamic_pointer_cast<RunSwitcher>(jet_corrector_data->module());
+      std::shared_ptr<JetCorrector> jc = std::dynamic_pointer_cast<JetCorrector>(rs->module(event));
       jc->correct_met(event);
     }
   }

--- a/common/src/CommonModules.cxx
+++ b/common/src/CommonModules.cxx
@@ -21,8 +21,16 @@ void CommonModules::fail_if_init() const{
 
 CommonModules::CommonModules(){
   working_point = JetPFID::WP_TIGHT_CHS;
-  jec_tag = "Fall17_17Nov2017";
-  jec_ver = "32";
+
+  jec_tag_2016 = "Summer16_07Aug2017";
+  jec_ver_2016 = "11";
+
+  jec_tag_2017 = "Fall17_17Nov2017";
+  jec_ver_2017 = "32";
+
+  jec_tag_2018 = "Autumn18";
+  jec_ver_2018 = "8";
+
   jec_jet_coll = "AK4PFchs";
 }
 
@@ -43,18 +51,35 @@ void CommonModules::init(Context & ctx, const std::string & SysType_PU){
     if(mclumiweight)  modules.emplace_back(new MCLumiWeight(ctx));
     if(mcpileupreweight) modules.emplace_back(new MCPileupReweight(ctx,SysType_PU));
     if(jec){
-      jet_corrector_MC.reset(new JetCorrector(ctx, JERFiles::JECFilesMC(jec_tag, jec_ver, jec_jet_coll)));
+      jet_corrector_MC.reset(new YearSwitcher(ctx));
+      jet_corrector_MC->setup2016(new JetCorrector(ctx, JERFiles::JECFilesMC(jec_tag_2016, jec_ver_2016, jec_jet_coll)));
+      jet_corrector_MC->setup2017(new JetCorrector(ctx, JERFiles::JECFilesMC(jec_tag_2017, jec_ver_2017, jec_jet_coll)));
+      jet_corrector_MC->setup2018(new JetCorrector(ctx, JERFiles::JECFilesMC(jec_tag_2018, jec_ver_2018, jec_jet_coll)));
     }
     if(jersmear) jet_resolution_smearer.reset(new JetResolutionSmearer(ctx));
   }
   else{
     if(lumisel) lumi_selection.reset(new LumiSelection(ctx));
     if(jec){
-      jet_corrector_B.reset(new JetCorrector(ctx, JERFiles::JECFilesDATA(jec_tag, jec_ver, jec_jet_coll, "B")));
-      jet_corrector_C.reset(new JetCorrector(ctx, JERFiles::JECFilesDATA(jec_tag, jec_ver, jec_jet_coll, "C")));
-      jet_corrector_D.reset(new JetCorrector(ctx, JERFiles::JECFilesDATA(jec_tag, jec_ver, jec_jet_coll, "D")));
-      jet_corrector_E.reset(new JetCorrector(ctx, JERFiles::JECFilesDATA(jec_tag, jec_ver, jec_jet_coll, "E")));
-      jet_corrector_F.reset(new JetCorrector(ctx, JERFiles::JECFilesDATA(jec_tag, jec_ver, jec_jet_coll, "F")));
+      jec_switcher_16 = new RunSwitcher("2016");
+      for (const auto & runItr : runPeriods2016) { // runPeriods defined in common/include/Utils.h
+        jec_switcher_16->setupRun(runItr, new JetCorrector(ctx, JERFiles::JECFilesDATA(jec_tag_2016, jec_ver_2016, jec_jet_coll, runItr)));
+      }
+
+      jec_switcher_17 = new RunSwitcher("2017");
+      for (const auto & runItr : runPeriods2017) {
+        jec_switcher_17->setupRun(runItr, new JetCorrector(ctx, JERFiles::JECFilesDATA(jec_tag_2017, jec_ver_2017, jec_jet_coll, runItr)));
+      }
+
+      jec_switcher_18 = new RunSwitcher("2018");
+      for (const auto & runItr : runPeriods2018) {
+        jec_switcher_18->setupRun(runItr, new JetCorrector(ctx, JERFiles::JECFilesDATA(jec_tag_2018, jec_ver_2018, jec_jet_coll, runItr)));
+      }
+
+      jet_corrector_data.reset(new YearSwitcher(ctx));
+      jet_corrector_data->setup2016(jec_switcher_16);
+      jet_corrector_data->setup2017(jec_switcher_17);
+      jet_corrector_data->setup2018(jec_switcher_18);
     }
   }
   if(metfilters){
@@ -82,13 +107,32 @@ void CommonModules::init(Context & ctx, const std::string & SysType_PU){
     modules.emplace_back(new JetCleaner(ctx, JetPFID(working_point)));
   }
   if(jetlepcleaner) {
-    if(is_mc) JLC_MC.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::JECFilesMC(jec_tag, jec_ver, jec_jet_coll)));
+    if(is_mc) {
+      JLC_MC.reset(new YearSwitcher(ctx));
+      JLC_MC->setup2016(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::JECFilesMC(jec_tag_2016, jec_ver_2016, jec_jet_coll)));
+      JLC_MC->setup2017(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::JECFilesMC(jec_tag_2017, jec_ver_2017, jec_jet_coll)));
+      JLC_MC->setup2018(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::JECFilesMC(jec_tag_2018, jec_ver_2018, jec_jet_coll)));
+    }
     else{
-      JLC_B.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::JECFilesDATA(jec_tag, jec_ver, jec_jet_coll, "B")));
-      JLC_C.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::JECFilesDATA(jec_tag, jec_ver, jec_jet_coll, "C")));
-      JLC_D.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::JECFilesDATA(jec_tag, jec_ver, jec_jet_coll, "DE")));
-      JLC_E.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::JECFilesDATA(jec_tag, jec_ver, jec_jet_coll, "DE")));
-      JLC_F.reset(new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::JECFilesDATA(jec_tag, jec_ver, jec_jet_coll, "F")));
+      JLC_switcher_16 = new RunSwitcher("2016");
+      for (const auto & runItr : runPeriods2016) {
+        JLC_switcher_16->setupRun(runItr, new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::JECFilesDATA(jec_tag_2016, jec_ver_2016, jec_jet_coll, runItr)));
+      }
+
+      JLC_switcher_17 = new RunSwitcher("2017");
+      for (const auto & runItr : runPeriods2017) {
+        JLC_switcher_17->setupRun(runItr, new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::JECFilesDATA(jec_tag_2017, jec_ver_2017, jec_jet_coll, runItr)));
+      }
+
+      JLC_switcher_18 = new RunSwitcher("2018");
+      for (const auto & runItr : runPeriods2018) {
+        JLC_switcher_18->setupRun(runItr, new JetLeptonCleaner_by_KEYmatching(ctx, JERFiles::JECFilesDATA(jec_tag_2018, jec_ver_2018, jec_jet_coll, runItr)));
+      }
+
+      JLC_data.reset(new YearSwitcher(ctx));
+      JLC_data->setup2016(JLC_switcher_16);
+      JLC_data->setup2017(JLC_switcher_17);
+      JLC_data->setup2018(JLC_switcher_18);
     }
   }
   modules.emplace_back(new HTCalculator(ctx,HT_jetid));
@@ -111,26 +155,18 @@ bool CommonModules::process(uhh2::Event & event){
   }
 
   if(jetlepcleaner){
-    if(is_mc) JLC_MC->process(event);
-    else{
-      if(event.run <= runnr_B)      JLC_B->process(event);
-      else if(event.run <= runnr_C) JLC_C->process(event);
-      else if(event.run <= runnr_D) JLC_D->process(event);
-      else if(event.run <= runnr_E) JLC_E->process(event);
-      else if(event.run <= runnr_F) JLC_F->process(event);
-      else throw runtime_error("CommonModules.cxx: run number not covered by if-statements in process-routine.");
+    if (is_mc) {
+      JLC_MC->process(event);
+    } else {
+      JLC_data->process(event);
     }
   }
 
   if(jec){
-    if(is_mc)jet_corrector_MC->process(event);
-    else{
-      if(event.run <= runnr_B)      jet_corrector_B->process(event);
-      else if(event.run <= runnr_C) jet_corrector_C->process(event);
-      else if(event.run <= runnr_D) jet_corrector_D->process(event);
-      else if(event.run <= runnr_E) jet_corrector_E->process(event);
-      else if(event.run <= runnr_F) jet_corrector_F->process(event);
-      else throw runtime_error("CommonModules.cxx: run number not covered by if-statements in process-routine.");
+    if (is_mc) {
+      jet_corrector_MC->process(event);
+    } else {
+      jet_corrector_data->process(event);
     }
   }
 
@@ -138,14 +174,15 @@ bool CommonModules::process(uhh2::Event & event){
 
   //set do_metcorrection = true in case you applied jet lepton cleaning by yourself and before calling common modules
   if((jetlepcleaner && jec) || (do_metcorrection && jec)){
-    if(is_mc) jet_corrector_MC->correct_met(event);
-    else{
-      if(event.run <= runnr_B)      jet_corrector_B->correct_met(event);
-      else if(event.run <= runnr_C) jet_corrector_C->correct_met(event);
-      else if(event.run <= runnr_D) jet_corrector_D->correct_met(event);
-      else if(event.run <= runnr_E) jet_corrector_E->correct_met(event);
-      else if(event.run <= runnr_F) jet_corrector_F->correct_met(event);
-      else throw runtime_error("CommonModules.cxx: run number not covered by if-statements in process-routine.");
+    if (is_mc) {
+      // raw pointer OK as the YearSwitcher owns it...
+      // some casting needed to get back to derived type
+      JetCorrector * jc = dynamic_cast<JetCorrector*>(jet_corrector_MC->module());
+      jc->correct_met(event);
+    } else {
+      RunSwitcher * rs = dynamic_cast<RunSwitcher*>(jet_corrector_data->module());
+      JetCorrector * jc = dynamic_cast<JetCorrector*>(rs->module(event));
+      jc->correct_met(event);
     }
   }
   // else if(jec || jetlepcleaner) cout <<"WARNING: You used CommonModules for either JEC or jet-lepton-cleaning but MET is not corrected. Please be aware of this." << endl;
@@ -224,7 +261,9 @@ void CommonModules::print_setup() const {
   }
   cout << endl;
   if (jec || jetlepcleaner || do_metcorrection) {
-    cout << "JECs: " << jec_tag << " V" << jec_ver << " for " << jec_jet_coll << endl;
+    cout << "2016 JECs: " << jec_tag_2016 << " V" << jec_ver_2016 << " for " << jec_jet_coll << endl;
+    cout << "2017 JECs: " << jec_tag_2017 << " V" << jec_ver_2017 << " for " << jec_jet_coll << endl;
+    cout << "2018 JECs: " << jec_tag_2018 << " V" << jec_ver_2018 << " for " << jec_jet_coll << endl;
   }
   cout << endl;
 

--- a/common/src/YearRunSwitchers.cxx
+++ b/common/src/YearRunSwitchers.cxx
@@ -1,0 +1,79 @@
+#include "UHH2/common/include/YearRunSwitchers.h"
+#include "UHH2/common/include/Utils.h"
+
+
+YearSwitcher::YearSwitcher():
+  module2016_(nullptr),
+  module2016v2_(nullptr),
+  module2016v3_(nullptr),
+  module2017_(nullptr),
+  module2017v1_(nullptr),
+  module2017v2_(nullptr),
+  module2018_(nullptr)
+{}
+
+bool YearSwitcher::process(uhh2::Event & event) {
+  if (isYear(event, "2016v2") && module2016v2_) {
+    return module2016v2_->process(event);
+  }
+  else if (isYear(event, "2016v3") && module2016v3_) {
+    return module2016v3_->process(event);
+  }
+  else if (isYear(event, "2016") && module2016_) {
+    return module2016_->process(event);
+  }
+
+  else if (isYear(event, "2017v1") && module2017v1_) {
+    return module2017v1_->process(event);
+  } 
+  else if (isYear(event, "2017v2") && module2017v2_) {
+    return module2017v2_->process(event);
+  }
+  else if (isYear(event, "2017") && module2017_) {
+    return module2017_->process(event);
+  }
+  
+  else if (isYear(event, "2018") && module2018_) {
+    return module2018_->process(event);
+  }
+  
+  else {
+    throw std::runtime_error("YearSwitcher cannot handle event.year = " + event.year 
+                             + ", you must use the relevant setup*() method");
+  }
+}
+
+// have to accept pointer as AnalysisModule is an abstract base class
+void YearSwitcher::setup2016(uhh2::AnalysisModule * module) {
+  module2016_.reset(module);
+}
+
+void YearSwitcher::setup2016v2(uhh2::AnalysisModule * module) {
+  module2016v2_.reset(module);
+}
+
+void YearSwitcher::setup2016v3(uhh2::AnalysisModule * module) {
+  module2016v3_.reset(module);
+}
+
+void YearSwitcher::setup2017(uhh2::AnalysisModule * module) {
+  module2017_.reset(module);
+}
+
+void YearSwitcher::setup2017v1(uhh2::AnalysisModule * module) {
+  module2017v1_.reset(module);
+}
+
+void YearSwitcher::setup2017v2(uhh2::AnalysisModule * module) {
+  module2017v2_.reset(module);
+}
+
+void YearSwitcher::setup2018(uhh2::AnalysisModule * module) {
+  module2018_.reset(module);
+}
+
+
+bool YearSwitcher::isYear(const uhh2::Event & event, const std::string & year) {
+  return event.year.find(year) != std::string::npos;
+}
+

--- a/common/src/YearRunSwitchers.cxx
+++ b/common/src/YearRunSwitchers.cxx
@@ -96,6 +96,8 @@ RunSwitcher::RunSwitcher(const std::string & year)
 }
 
 bool RunSwitcher::process(uhh2::Event & event) {
+  if (!event.isRealData) return true; // this class only makes sense for data
+
   // find which run period we are in using event.run
   // then use that to call the relevant module
   for (const auto & [key, val] : runNumberMap_) {

--- a/common/src/YearRunSwitchers.cxx
+++ b/common/src/YearRunSwitchers.cxx
@@ -108,7 +108,7 @@ bool RunSwitcher::process(uhh2::Event & event) {
       }
     }
   }
-  return false;
+  return true;
 }
 
 void RunSwitcher::setupRun(const std::string & runPeriod, uhh2::AnalysisModule * module) {

--- a/examples/config/ExampleYearRunSwitch.xml
+++ b/examples/config/ExampleYearRunSwitch.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE JobConfiguration PUBLIC "" "JobConfig.dtd">
+
+<!-- OutputLevel controls which messages are printed; set to VERBOSE or DEBUG for more verbosity, to WARNING or ERROR for less -->
+<JobConfiguration JobName="ExampleCycleJob" OutputLevel="INFO">
+    <Library Name="libSUHH2examples"/>
+    <Package Name="SUHH2examples.par" />
+
+   <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="./" PostFix="" TargetLumi="1" >
+
+        <InputData Lumi="1" NEventsMax="5" Type="DATA" Version="Data_2018" Cacheable="False">
+            <In FileName="data2018.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="5" Type="DATA" Version="Data_2016v3" Cacheable="False">
+            <In FileName="data2016v3.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="5" Type="DATA" Version="Data_2017v2" Cacheable="False">
+            <In FileName="data2017v2.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+        </InputData>
+
+        <UserConfig>
+            <!-- define which collections to read from the input. Only specify what you need to save I/O time -->
+            <Item Name="JetCollection" Value="jetsAk4CHS" />
+            <Item Name="GenJetCollection" Value="slimmedGenJets" />
+            <Item Name="METName" Value="slimmedMETs" />
+
+            <Item Name="AnalysisModule" Value="ExampleModuleYearRunSwitch" />
+
+            <!-- tell AnalysisModuleRunner NOT to use the MC event weight from SFrame; rather let
+                 MCLumiWeight (called via CommonModules) calculate the MC event weight. The MC
+                 event weight assigned by MCLumiWeight is InputData.Lumi / Cycle.TargetLumi. -->
+            <Item Name="use_sframe_weight" Value="false" />
+
+        </UserConfig>
+    </Cycle>
+</JobConfiguration>

--- a/examples/src/ExampleModuleYearRunSwitch.cxx
+++ b/examples/src/ExampleModuleYearRunSwitch.cxx
@@ -25,7 +25,7 @@ public:
     explicit DummyModule(const std::string & note):
     note_(note)
     {}
-    
+
     virtual bool process(Event & event){
         cout << note_ << endl;
         return true;
@@ -36,55 +36,101 @@ private:
 
 
 /** \brief Example of how to handle setting up modules for different years, run periods
- * 
+ *
  */
 class ExampleModuleYearRunSwitch: public AnalysisModule {
 public:
-    
+
     explicit ExampleModuleYearRunSwitch(Context & ctx);
     virtual bool process(Event & event) override;
 
 private:
-    
-    std::unique_ptr<YearSwitcher> dummyTextAll, jetCleanerAll;
+
+    std::unique_ptr<YearSwitcher> dummyTextYearSwitcher, jetCleanerYearSwitcher, megaYearSwitcher;
+    std::unique_ptr<RunSwitcher> dummyTextRun18, dummyTextRun17;
+
+    // Note that these are raw pointers
+    // FIXME: surely there must be a better way? Do these leak?
+    RunSwitcher *megaRunSwitcher16, *megaRunSwitcher17, *megaRunSwitcher18;
 
 };
 
 
 ExampleModuleYearRunSwitch::ExampleModuleYearRunSwitch(Context & ctx){
     cout << "Hello World from ExampleModuleYearRunSwitch!" << endl;
-    
+
     // Setup and instance of DummyModule module to be run for each year
     // Note that e.g. the 2016 one will be run for both 2016v2 & 2016v3 ntuples
-    dummyTextAll.reset(new YearSwitcher()); 
-    dummyTextAll->setup2016(new DummyModule("I am 2016"));
-    dummyTextAll->setup2017(new DummyModule("I am 2017"));
-    dummyTextAll->setup2018(new DummyModule("I am 2018"));
-    
+    dummyTextYearSwitcher.reset(new YearSwitcher());
+    dummyTextYearSwitcher->setup2016(new DummyModule("I am 2016"));
+    dummyTextYearSwitcher->setup2017(new DummyModule("I am 2017"));
+    dummyTextYearSwitcher->setup2018(new DummyModule("I am 2018"));
+
     // Here we specify a particular module for 2017v2 ntuples. This will be run
     // instead of the one created in setup2017() above.
     // 2017v1 ntuples will still use that one though.
-    dummyTextAll->setup2017v2(new DummyModule("I am 2017v2"));
+    dummyTextYearSwitcher->setup2017v2(new DummyModule("I am 2017v2"));
 
-    
-    // Here is a more realistic example - only for 2017, 
-    // we decide to exclude HF jets and raise the pT cut as well
-    jetCleanerAll.reset(new YearSwitcher()); 
-    jetCleanerAll->setup2016(new JetCleaner(ctx, 30.0, 5.));
-    jetCleanerAll->setup2017(new JetCleaner(ctx, 50.0, 3));
-    jetCleanerAll->setup2018(new JetCleaner(ctx, 30.0, 5));
-    
+    // Here is a more realistic example - we apply some jet cuts,
+    // but only for 2017 we decide to exclude HF jets and raise the pT cut as well
+    jetCleanerYearSwitcher.reset(new YearSwitcher());
+    jetCleanerYearSwitcher->setup2016(new JetCleaner(ctx, 30.0, 5.));
+    jetCleanerYearSwitcher->setup2017(new JetCleaner(ctx, 50.0, 3));
+    jetCleanerYearSwitcher->setup2018(new JetCleaner(ctx, 30.0, 5));
+
+
+    // Here we setup modules for specific run periods in a given year
+    dummyTextRun18.reset(new RunSwitcher("2018"));
+    dummyTextRun18->setupRun("A", new DummyModule("2018 Run A"));
+    dummyTextRun18->setupRun("B", new DummyModule("2018 Run B"));
+    dummyTextRun18->setupRun("C", new DummyModule("2018 Run C"));
+    dummyTextRun18->setupRun("D", new DummyModule("2018 Run D"));
+
+    // much easier way to iterate over all Run periods:
+    dummyTextRun17.reset(new RunSwitcher("2017"));
+    for (const auto & itr : {"B", "C", "D", "E", "F"}) {
+        dummyTextRun17->setupRun(itr, new DummyModule("2017 Run " + std::string(itr)));
+    }
+
+    // Finally, we can also combine these both
+    // Good for e.g. JECs
+    megaRunSwitcher16 = new RunSwitcher("2016");
+    for (const auto & runItr : runPeriods2016) { // runPeriods defined in common/include/Utils.h
+        megaRunSwitcher16->setupRun(runItr, new DummyModule("Super! 2016 + Run " + runItr));
+    }
+
+    megaRunSwitcher17 = new RunSwitcher("2017");
+    for (const auto & runItr : runPeriods2017) {
+        megaRunSwitcher17->setupRun(runItr, new DummyModule("Mega! 2017 + Run " + runItr));
+    }
+
+    megaRunSwitcher18 = new RunSwitcher("2018");
+    for (const auto & runItr : runPeriods2018) {
+        megaRunSwitcher18->setupRun(runItr, new DummyModule("Ausgezeichnet! 2018 + Run " + runItr));
+    }
+
+    megaYearSwitcher.reset(new YearSwitcher());
+    megaYearSwitcher->setup2016(megaRunSwitcher16);
+    megaYearSwitcher->setup2017(megaRunSwitcher17);
+    megaYearSwitcher->setup2018(megaRunSwitcher18);
+
 }
 
 
 bool ExampleModuleYearRunSwitch::process(Event & event) {
-    
+
     cout << "ExampleModuleYearRunSwitch: Starting to process event (runid, eventid) = (" << event.run << ", " << event.event << "); weight = " << event.weight << endl;
-    
-    // the YearSwitcher uses the event.year stored in the ntuple, 
+
+    // the YearSwitcher uses the event.year stored in the ntuple,
     // ignoring whatver is specified in the dataset Version
-    dummyTextAll->process(event);
-    jetCleanerAll->process(event);
+    dummyTextYearSwitcher->process(event);
+    jetCleanerYearSwitcher->process(event);
+
+    // note that for 2016, these are just ignored and all events return true
+    dummyTextRun17->process(event);
+    dummyTextRun18->process(event);
+
+    megaYearSwitcher->process(event);
 
     return true;
 }

--- a/examples/src/ExampleModuleYearRunSwitch.cxx
+++ b/examples/src/ExampleModuleYearRunSwitch.cxx
@@ -1,0 +1,96 @@
+#include <iostream>
+#include <memory>
+
+#include "UHH2/core/include/AnalysisModule.h"
+#include "UHH2/core/include/Event.h"
+#include "UHH2/common/include/CommonModules.h"
+#include "UHH2/common/include/CleaningModules.h"
+#include "UHH2/common/include/ElectronHists.h"
+#include "UHH2/common/include/NSelections.h"
+#include "UHH2/common/include/YearRunSwitchers.h"
+#include "UHH2/examples/include/ExampleSelections.h"
+#include "UHH2/examples/include/ExampleHists.h"
+
+using namespace std;
+using namespace uhh2;
+
+namespace uhh2examples {
+
+
+/**
+ * Dummy module just to print some text
+ */
+class DummyModule: public AnalysisModule {
+public:
+    explicit DummyModule(const std::string & note):
+    note_(note)
+    {}
+    
+    virtual bool process(Event & event){
+        cout << note_ << endl;
+        return true;
+    }
+private:
+    std::string note_;
+};
+
+
+/** \brief Example of how to handle setting up modules for different years, run periods
+ * 
+ */
+class ExampleModuleYearRunSwitch: public AnalysisModule {
+public:
+    
+    explicit ExampleModuleYearRunSwitch(Context & ctx);
+    virtual bool process(Event & event) override;
+
+private:
+    
+    std::unique_ptr<YearSwitcher> dummyTextAll, jetCleanerAll;
+
+};
+
+
+ExampleModuleYearRunSwitch::ExampleModuleYearRunSwitch(Context & ctx){
+    cout << "Hello World from ExampleModuleYearRunSwitch!" << endl;
+    
+    // Setup and instance of DummyModule module to be run for each year
+    // Note that e.g. the 2016 one will be run for both 2016v2 & 2016v3 ntuples
+    dummyTextAll.reset(new YearSwitcher()); 
+    dummyTextAll->setup2016(new DummyModule("I am 2016"));
+    dummyTextAll->setup2017(new DummyModule("I am 2017"));
+    dummyTextAll->setup2018(new DummyModule("I am 2018"));
+    
+    // Here we specify a particular module for 2017v2 ntuples. This will be run
+    // instead of the one created in setup2017() above.
+    // 2017v1 ntuples will still use that one though.
+    dummyTextAll->setup2017v2(new DummyModule("I am 2017v2"));
+
+    
+    // Here is a more realistic example - only for 2017, 
+    // we decide to exclude HF jets and raise the pT cut as well
+    jetCleanerAll.reset(new YearSwitcher()); 
+    jetCleanerAll->setup2016(new JetCleaner(ctx, 30.0, 5.));
+    jetCleanerAll->setup2017(new JetCleaner(ctx, 50.0, 3));
+    jetCleanerAll->setup2018(new JetCleaner(ctx, 30.0, 5));
+    
+}
+
+
+bool ExampleModuleYearRunSwitch::process(Event & event) {
+    
+    cout << "ExampleModuleYearRunSwitch: Starting to process event (runid, eventid) = (" << event.run << ", " << event.event << "); weight = " << event.weight << endl;
+    
+    // the YearSwitcher uses the event.year stored in the ntuple, 
+    // ignoring whatver is specified in the dataset Version
+    dummyTextAll->process(event);
+    jetCleanerAll->process(event);
+
+    return true;
+}
+
+// as we want to run the ExampleCycleNew directly with AnalysisModuleRunner,
+// make sure the ExampleModuleYearRunSwitch is found by class name. This is ensured by this macro:
+UHH2_REGISTER_ANALYSIS_MODULE(ExampleModuleYearRunSwitch)
+
+}

--- a/examples/src/ExampleModuleYearRunSwitch.cxx
+++ b/examples/src/ExampleModuleYearRunSwitch.cxx
@@ -61,7 +61,7 @@ ExampleModuleYearRunSwitch::ExampleModuleYearRunSwitch(Context & ctx){
 
     // Setup and instance of DummyModule module to be run for each year
     // Note that e.g. the 2016 one will be run for both 2016v2 & 2016v3 ntuples
-    dummyTextYearSwitcher.reset(new YearSwitcher());
+    dummyTextYearSwitcher.reset(new YearSwitcher(ctx));
     dummyTextYearSwitcher->setup2016(new DummyModule("I am 2016"));
     dummyTextYearSwitcher->setup2017(new DummyModule("I am 2017"));
     dummyTextYearSwitcher->setup2018(new DummyModule("I am 2018"));
@@ -73,7 +73,7 @@ ExampleModuleYearRunSwitch::ExampleModuleYearRunSwitch(Context & ctx){
 
     // Here is a more realistic example - we apply some jet cuts,
     // but only for 2017 we decide to exclude HF jets and raise the pT cut as well
-    jetCleanerYearSwitcher.reset(new YearSwitcher());
+    jetCleanerYearSwitcher.reset(new YearSwitcher(ctx));
     jetCleanerYearSwitcher->setup2016(new JetCleaner(ctx, 30.0, 5.));
     jetCleanerYearSwitcher->setup2017(new JetCleaner(ctx, 50.0, 3));
     jetCleanerYearSwitcher->setup2018(new JetCleaner(ctx, 30.0, 5));
@@ -109,7 +109,7 @@ ExampleModuleYearRunSwitch::ExampleModuleYearRunSwitch(Context & ctx){
         megaRunSwitcher18->setupRun(runItr, new DummyModule("Ausgezeichnet! 2018 + Run " + runItr));
     }
 
-    megaYearSwitcher.reset(new YearSwitcher());
+    megaYearSwitcher.reset(new YearSwitcher(ctx));
     megaYearSwitcher->setup2016(megaRunSwitcher16);
     megaYearSwitcher->setup2017(megaRunSwitcher17);
     megaYearSwitcher->setup2018(megaRunSwitcher18);


### PR DESCRIPTION
[ci skip]

This is to demonstrate how the new `RunSwitcher` and `YearSwitcher` classes would be used in CommonModules. This adds in JECs for 2016 & 2018 simply, for JECs, MET corrections, and Jet-Lepton cleaner.

I realise not everyone uses CommonModules, but people can use it as inspiration for their own code.

Also, it made me realise that MET corrections should probably be extracted into an AnalysisModule of its own - it's a tad painful having to call another method on the JetCorrector class (and doesn't even exist for e.g. GenericJetCorrector)

(note that it only makes sense to merge this after #1275 - for now it's more for demonstration. Can run CI once the other PR is merged. )