### PR TITLE
[102X] add PU id

### DIFF
--- a/common/include/JetIds.h
+++ b/common/include/JetIds.h
@@ -84,3 +84,16 @@ class JetPFID {
   bool tightLepVetoID2018(const Jet & jet) const;
 
 };
+
+/**
+ * Jet PU Id following recomendations from JetMET for RunII
+ */
+
+class JetPUid {
+ public:
+  enum wp {WP_LOOSE, WP_TIGHT, WP_MEDIUM};
+  explicit JetPUid(wp working_point);
+  bool operator()(const Jet&, const uhh2::Event&) const;
+ private:
+  wp m_working_point;
+};

--- a/common/src/JetIds.cxx
+++ b/common/src/JetIds.cxx
@@ -404,3 +404,34 @@ bool JetPFID::tightLepVetoID2016(const Jet & jet) const{
   return true;
 
 }
+
+//////// Jet PU id
+JetPUid::JetPUid(wp working_point):m_working_point(working_point){}
+
+// JetPUid::JetPUid(wp working_point) {
+//   m_working_point = working_point;
+// }
+
+
+bool JetPUid::operator()(const Jet & jet, const Event &ev) const{
+  TString wp_str;
+  //  int wp_id;
+  switch(m_working_point){
+  case WP_LOOSE:
+    wp_str = "pileup_loose";
+    // wp_id = 0;
+    break;
+  case WP_MEDIUM:
+    //wp_id = 1;
+    wp_str = "pileup_medium";
+    break;
+  case WP_TIGHT:
+    //wp_id = 2;
+    wp_str = "pileup_tight";
+    break;
+  default:
+    throw invalid_argument("invalid working point passed to JetPUid");
+    }
+  return jet.get_tag(jet.tagname2tag(wp_str.Data()))>0;
+  //return jet.get_tag(wp_id)>0;
+}


### PR DESCRIPTION
[only compile]
Add access to PU id stored in the ntuples. Should be used in similar fashion as Jet PF ID:
https://github.com/UHH2/BaconJets/blob/RunII_102X_v1/src/AnalysisModule_DiJetTrg.cxx#L937-L938
https://github.com/UHH2/BaconJets/blob/RunII_102X_v1/src/AnalysisModule_DiJetTrg.cxx#L1211

