### PR TITLE
[102X] Add compatibility for all btag algorithms

### DIFF
--- a/common/include/JetHists.h
+++ b/common/include/JetHists.h
@@ -120,12 +120,11 @@ static const std::vector<float> BTagMCEffBinsPt = {20., 30., 50., 70., 100., 140
  * jets_handle_name should point to a handle of type vector<Jet> _or_
  * vector<TopJet>, were in the latter case all of the subjets are used.
  */
-template<typename btagger>
 class BTagMCEfficiencyHists: public uhh2::Hists {
 public:
   BTagMCEfficiencyHists(uhh2::Context & ctx,
                         const std::string & dirname,
-                        const typename btagger::wp & working_point,
+			const JetId & jet_id,
                         const std::string & jets_handle_name="jets");
 
   virtual void fill(const uhh2::Event & ev) override;
@@ -133,7 +132,7 @@ public:
 protected:
   void do_fill(const std::vector<TopJet> & jets, const uhh2::Event & event);
 
-  btagger btag_;
+  JetId btag_;
   TH2F * hist_b_passing_;
   TH2F * hist_b_total_;
   TH2F * hist_c_passing_;

--- a/common/include/JetIds.h
+++ b/common/include/JetIds.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "UHH2/core/include/Event.h"
-
+#include "UHH2/common/include/ObjectIdUtils.h"
 // see comments in ElectronIds.h for general comments on IDs.
 
 /** \brief The CSV V2 b-tag as jet id
@@ -14,10 +14,31 @@
  * 
  * Note that this will certainly need updates once 13TeV recommendations are available.
  */
+class BTag {
+  // wrapper class to hold btag id and algorithm/working point information
+ public:
+  enum algo {CSVV2, DEEPCSV, DEEPJET};
+  enum wp {WP_LOOSE  = 0,
+	   WP_MEDIUM = 1,
+	   WP_TIGHT  = 2 };
+  explicit BTag(algo tagger, wp working_point);
+
+  bool operator()(const Jet & jet, const uhh2::Event & event) {return jet_id(jet,event);}
+
+  std::string GetTagger() {return m_algo;}
+  int GetWorkingPoint() {return m_working_point;}
+ private:
+  std::string m_algo;
+  int m_working_point;
+  JetId jet_id;
+};
+
 class CSVBTag {
 public:
-    enum wp {WP_LOOSE, WP_MEDIUM, WP_TIGHT };
-    
+  enum wp {WP_LOOSE  = 0,
+	   WP_MEDIUM = 1,
+	   WP_TIGHT  = 2 };
+  
     explicit CSVBTag(wp working_point);
     explicit CSVBTag(float float_point);
 
@@ -29,8 +50,10 @@ private:
 
 class DeepCSVBTag {
 public:
-    enum wp {WP_LOOSE, WP_MEDIUM, WP_TIGHT };
-    
+  enum wp {WP_LOOSE  = 0,
+	   WP_MEDIUM = 1,
+	   WP_TIGHT  = 2 };
+  
     explicit DeepCSVBTag(wp working_point);
     explicit DeepCSVBTag(float float_point);
 
@@ -42,8 +65,10 @@ private:
 
 class DeepJetBTag {
 public:
-    enum wp {WP_LOOSE, WP_MEDIUM, WP_TIGHT };
-    
+  enum wp {WP_LOOSE  = 0,
+	   WP_MEDIUM = 1,
+	   WP_TIGHT  = 2 };
+  
     explicit DeepJetBTag(wp working_point);
     explicit DeepJetBTag(float float_point);
 
@@ -52,8 +77,6 @@ private:
     float deepjet_threshold;
     wp m_working_point;
 };
-
-
 
 /**
  * Jet Id following recomendations from JetMET for RunII

--- a/common/include/MCWeight.h
+++ b/common/include/MCWeight.h
@@ -220,7 +220,8 @@ class BTagCalibrationReader;  // forward declaration
 class MCBTagScaleFactor: public uhh2::AnalysisModule {
  public:
   explicit MCBTagScaleFactor(uhh2::Context & ctx,
-                             const CSVBTag::wp & working_point,
+			     BTag::algo tagger,
+			     BTag::wp wp,
                              const std::string & jets_handle_name="jets",
                              const std::string & sysType="central",
                              const std::string & measType_bc="mujets",
@@ -237,7 +238,7 @@ class MCBTagScaleFactor: public uhh2::AnalysisModule {
                                                   uhh2::Event & event);
   std::pair<float, float> get_SF_btag(float pt, float abs_eta, int flav);
 
-  CSVBTag btag_;
+  BTag btag_;
   std::unique_ptr<BTagCalibrationReader> calib_up_;
   std::unique_ptr<BTagCalibrationReader> calib_;
   std::unique_ptr<BTagCalibrationReader> calib_down_;

--- a/common/src/JetHists.cxx
+++ b/common/src/JetHists.cxx
@@ -258,15 +258,14 @@ template<typename T>
 }
 
 //Btag stuff
-template<typename btagger>
-BTagMCEfficiencyHists<btagger>::BTagMCEfficiencyHists(
+BTagMCEfficiencyHists::BTagMCEfficiencyHists(
   uhh2::Context & ctx,
   const std::string & dirname,
-  const typename btagger::wp & working_point,
+  const JetId & jet_id,
   const std::string & jets_handle_name
 ):
   Hists(ctx, dirname),
-  btag_(btagger(working_point)),
+  btag_(jet_id),
   hist_b_passing_(   book<TH2F>("BTagMCEffFlavBPassing",    ";jet pt;jet eta", BTagMCEffBinsPt.size()-1, BTagMCEffBinsPt.data(), BTagMCEffBinsEta.size()-1, BTagMCEffBinsEta.data())),
   hist_b_total_(     book<TH2F>("BTagMCEffFlavBTotal",      ";jet pt;jet eta", BTagMCEffBinsPt.size()-1, BTagMCEffBinsPt.data(), BTagMCEffBinsEta.size()-1, BTagMCEffBinsEta.data())),
   hist_c_passing_(   book<TH2F>("BTagMCEffFlavCPassing",    ";jet pt;jet eta", BTagMCEffBinsPt.size()-1, BTagMCEffBinsPt.data(), BTagMCEffBinsEta.size()-1, BTagMCEffBinsEta.data())),
@@ -277,8 +276,7 @@ BTagMCEfficiencyHists<btagger>::BTagMCEfficiencyHists(
   h_jets_(   ctx.get_handle<vector<Jet>>(   jets_handle_name))
 {}
 
-template<typename btagger>
-void BTagMCEfficiencyHists<btagger>::fill(const Event & event)
+void BTagMCEfficiencyHists::fill(const Event & event)
 {
   if (event.is_valid(h_topjets_)) {
     do_fill(event.get(h_topjets_), event);
@@ -290,8 +288,7 @@ void BTagMCEfficiencyHists<btagger>::fill(const Event & event)
   }
 }
 
-template<typename btagger>
-void BTagMCEfficiencyHists<btagger>::do_fill(const std::vector<TopJet> & jets, const Event & event)
+void BTagMCEfficiencyHists::do_fill(const std::vector<TopJet> & jets, const Event & event)
 {
   for (const auto & topjet : jets) { for (const auto & jet : topjet.subjets()) {
 
@@ -318,22 +315,3 @@ void BTagMCEfficiencyHists<btagger>::do_fill(const std::vector<TopJet> & jets, c
 
   }}
 }
-
-template BTagMCEfficiencyHists<CSVBTag>::BTagMCEfficiencyHists(
-  uhh2::Context & ctx,
-  const std::string & dirname,
-  const CSVBTag::wp & working_point,
-  const std::string & jets_handle_name
-);
-template BTagMCEfficiencyHists<DeepCSVBTag>::BTagMCEfficiencyHists(
-  uhh2::Context & ctx,
-  const std::string & dirname,
-  const DeepCSVBTag::wp & working_point,
-  const std::string & jets_handle_name
-);
-template BTagMCEfficiencyHists<DeepJetBTag>::BTagMCEfficiencyHists(
-  uhh2::Context & ctx,
-  const std::string & dirname,
-  const DeepJetBTag::wp & working_point,
-  const std::string & jets_handle_name
-);

--- a/common/src/JetIds.cxx
+++ b/common/src/JetIds.cxx
@@ -3,6 +3,26 @@
 using namespace std;
 using namespace uhh2;
 
+BTag::BTag(algo tagger, wp working_point) {
+  m_working_point = (int) working_point;
+  switch (tagger) {
+  case CSVV2 :
+    jet_id = CSVBTag((CSVBTag::wp) m_working_point);
+    m_algo = "CSVv2";
+    break;
+  case DEEPCSV :
+    jet_id = DeepCSVBTag((DeepCSVBTag::wp) m_working_point);
+    m_algo = "DeepCSV";
+    break;
+  case DEEPJET :
+    jet_id = DeepJetBTag((DeepJetBTag::wp) m_working_point);
+    m_algo = "DeepJet";
+    break;
+  default:
+    throw invalid_argument("invalid b-tagging algorithm passed to BTag");
+  }
+}
+
 CSVBTag::CSVBTag(wp working_point) {
   m_working_point = working_point;
 }

--- a/common/src/MCWeight.cxx
+++ b/common/src/MCWeight.cxx
@@ -631,15 +631,16 @@ bool MCElecScaleFactor::process(uhh2::Event & event) {
 
 
 MCBTagScaleFactor::MCBTagScaleFactor(uhh2::Context & ctx,
-                                     const CSVBTag::wp & working_point,
-                                     const std::string & jets_handle_name,
+				     BTag::algo tagger,
+				     BTag::wp wp,
+				     const std::string & jets_handle_name,
                                      const std::string & sysType,
                                      const std::string & measType_bc,
                                      const std::string & measType_udsg,
                                      const std::string & xml_param_name,
 				     const std::string & weights_name_postfix,
 				     const std::string & xml_calib_name):
-  btag_(CSVBTag(working_point)),
+  btag_(BTag(tagger, wp)),
   h_jets_(ctx.get_handle<std::vector<Jet>>(jets_handle_name)),
   h_topjets_(ctx.get_handle<std::vector<TopJet>>(jets_handle_name)),
   sysType_(sysType),
@@ -675,10 +676,8 @@ MCBTagScaleFactor::MCBTagScaleFactor(uhh2::Context & ctx,
   eff_file.Close();
 
   // https://twiki.cern.ch/twiki/bin/viewauth/CMS/BTagCalibration
-  BTagCalibration calib_data("CSVv2", ctx.get(xml_calib_name));
-  auto op = working_point == CSVBTag::WP_LOOSE ? BTagEntry::OP_LOOSE : (
-                working_point == CSVBTag::WP_MEDIUM ? BTagEntry::OP_MEDIUM :
-                    BTagEntry::OP_TIGHT);
+  BTagCalibration calib_data(btag_.GetTagger(), ctx.get(xml_calib_name));
+  BTagEntry::OperatingPoint op = (BTagEntry::OperatingPoint) btag_.GetWorkingPoint();
 
   calib_up_.reset(new BTagCalibrationReader(op, "up"));
   calib_.reset(new BTagCalibrationReader(op, "central"));


### PR DESCRIPTION
[only compile]

* Changed the BTagMCEfficiencyHists to take JetId as argument, to make it work independent of b-tagging algorithm choice
* Added BTag wrapper class to create and hold btag JetId, used tagging algorithm and working point
* Implement the wrapper class in the MCBTagScaleFactor class to make it work with all b-tagging algorithms in the framework
