### PR TITLE
[102X] Handle for GenJetCleaner & quieten unused var warning

### DIFF
--- a/common/include/CleaningModules.h
+++ b/common/include/CleaningModules.h
@@ -22,15 +22,16 @@ private:
     uhh2::Event::Handle<std::vector<Jet>> hndl;
 };
 
-/// Keep only jets with a minimum pt and maximum |eta|
+/// Keep only genjets with a minimum pt and maximum |eta|
 class GenJetCleaner: public uhh2::AnalysisModule {
 public:
     
-    explicit GenJetCleaner(uhh2::Context & ctx, float minpt, float maxeta, std::string const & label_ = "jets");
+    explicit GenJetCleaner(uhh2::Context & ctx, float minpt, float maxeta, std::string const & label_ = "genjets");
     virtual bool process(uhh2::Event & event) override;
     
 private:
     GenJetId genjet_id;
+    uhh2::Event::Handle<std::vector<GenJet>> hndl;
 };
 
 

--- a/common/src/CleaningModules.cxx
+++ b/common/src/CleaningModules.cxx
@@ -24,10 +24,15 @@ bool JetCleaner::process(Event & event){
 }
 
 GenJetCleaner::GenJetCleaner(Context & ctx, float minpt, float maxeta, string const & label_):
-  genjet_id(PtEtaCut(minpt, maxeta)){}
+    genjet_id(PtEtaCut(minpt, maxeta)), hndl(ctx.get_handle<vector<GenJet>>(label_)){}
 
 bool GenJetCleaner::process(Event & event){
-    clean_collection(*event.genjets, event, genjet_id);
+    if (!event.is_valid(hndl)) {
+        cerr << "In GenJetCleaner: Handle not valid!\n";
+        assert(false);
+    }
+    vector<GenJet> & genjet_collection = event.get(hndl);
+    clean_collection(genjet_collection, event, genjet_id);
     return true;
 }
 

--- a/common/src/JetIds.cxx
+++ b/common/src/JetIds.cxx
@@ -434,6 +434,7 @@ JetPUid::JetPUid(wp working_point):m_working_point(working_point){}
 
 
 bool JetPUid::operator()(const Jet & jet, const Event &ev) const{
+  (void) ev;
   TString wp_str;
   //  int wp_id;
   switch(m_working_point){

--- a/examples/src/ExampleModuleYearRunSwitch.cxx
+++ b/examples/src/ExampleModuleYearRunSwitch.cxx
@@ -27,6 +27,7 @@ public:
     {}
 
     virtual bool process(Event & event){
+        (void) event;
         cout << note_ << endl;
         return true;
     }


### PR DESCRIPTION
Remove some unused var warnings by
- `GenJetCleaner` now can handle and collection name in its constructor (previously was only `event.genjets`, this is still the default)
- Quieten `JetIds.cxx` (need `Event` as `operator()` like other IDs)

[only compile]