### PR TITLE
[102X] Move to LZMA9 compression

### DIFF
--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -2095,8 +2095,8 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                     #    TestKey = cms.string("TestValue")
                                     #),
                                     fileName=cms.string("Ntuple.root"),
-                                    compressionAlgorithm=cms.string('Global'),
-                                    compressionLevel=cms.int32(1),  # Global1 is the default setting - not very compressed
+                                    compressionAlgorithm=cms.string('LZMA'),
+                                    compressionLevel=cms.int32(9),  # LZMA9 is the highest compressions, for a slight increase in CPU/RAM usage
                                     year=cms.string(year),
                                     doPV=cms.bool(True),
                                     pv_sources=cms.vstring("offlineSlimmedPrimaryVertices"),


### PR DESCRIPTION
Change default Ntuple compression from default ZLIB1 to most compressed LZMA9. This saves us ~25-30% in filesize, with a small penalty in CPU/RAM usage.
Needed as we're rapidly running out of disk space, so this should be used for all subsequent productions.

More detailed analysis: [20190528_UHH2_compression.pdf](https://github.com/UHH2/UHH2/files/3226833/20190528_UHH2_compression.pdf)

