### PR TITLE
Add method to comment out empty ntuples automatically

### DIFF
--- a/scripts/crab/readaMCatNloEntries.py
+++ b/scripts/crab/readaMCatNloEntries.py
@@ -6,7 +6,7 @@
 
 
 
-import sys, multiprocessing, time
+import sys, multiprocessing, time, os
 from ROOT import *
 
 def read_xml(xmlFileDir):
@@ -101,7 +101,8 @@ def commentOutEmptyRootFiles(xmlfile, entries_per_rootfile):
         if entries_per_rootfile[i] == 0:
             empty_root_files.append(root_files[i])
     xml = open(str(xmlfile))
-    xml_temporary = open(str(xmlfile)+".tmp","w+")
+    temp_filename = str(xmlfile)+".tmp"
+    xml_temporary = open(temp_filename,"w+")
     for line in xml:
         newline = line
         for rf in empty_root_files:
@@ -110,6 +111,7 @@ def commentOutEmptyRootFiles(xmlfile, entries_per_rootfile):
         xml_temporary.write(newline)
     xml.close()
     xml_temporary.close()
+    os.rename(temp_filename,xmlfile)
     return empty_root_files
 
 if __name__ == "__main__":

--- a/scripts/crab/readaMCatNloEntries.py
+++ b/scripts/crab/readaMCatNloEntries.py
@@ -10,23 +10,25 @@ import sys, multiprocessing, time
 from ROOT import *
 
 def read_xml(xmlFileDir):
-    #try:
     xmlFile = open(str(xmlFileDir))
     rootFileStore = []
-    comment =False
-    for line in xmlFile:
-        if '<!--' in line and not '-->': 
-            comment = True
-            continue
-        if '-->' in line: 
-            comment=False
-            continue
-        rootFileStore.append(line.split('"')[1])
+    comment = False                      # Think this code through via this example:
+    for line in xmlFile:                 #
+        if '<!--' in line:               # asdfasdfasdfasdfasdf
+            if '-->' in line:            # asdfasdfasdfasdfasdf
+                continue                 # <!-- asfdasdfasdfasdfasdf -->
+            else:                        # asdfasdfasdfasdfasdf
+                comment = True           # <!-- asdfasdfasfdasdfasdf
+                continue                 # asdfasdfasdfasdfasdf
+        if comment == True:              # asdfasdfasdfasdfasdf -->
+            if not '-->' in line:        # asdfasdfasdfasdfasdf
+                continue                 # 
+            else:                        # Not waterproof if comment starts mid-line (or violates this scheme in another
+                comment = False          # way) but mid-line comments should not exist in these files in the first place
+                continue
+        if comment == False:
+            rootFileStore.append(line.split('"')[1])
     return rootFileStore
-    #except:
-    #    print "No able to read file Dir", xmlFileDir
-    #    return 
-
 
 def write_xml_entry_tag(xmlFile,result,fast):
     xmlFile = open(str(xmlFile),'a')

--- a/scripts/crab/readaMCatNloEntries.py
+++ b/scripts/crab/readaMCatNloEntries.py
@@ -89,13 +89,38 @@ def readEntries(worker, xmlfiles, fast=False):
         pool.join()
         xml_result = sum(result.get())
         print "number of events in",xml,xml_result
-        sum_list.append(xml_result)
+        sum_list.append([r for r in result.get()])
         write_xml_entry_tag(xml,xml_result, fast)
     return sum_list
-        
+
+def commentOutEmptyRootFiles(xmlfile, entries_per_rootfile):
+    root_files = read_xml(xmlfile)
+    if len(root_files) != len(entries_per_rootfile): print "Something's really wrong."
+    empty_root_files = []
+    for i in range(len(root_files)):
+        if entries_per_rootfile[i] == 0:
+            empty_root_files.append(root_files[i])
+    xml = open(str(xmlfile))
+    xml_temporary = open(str(xmlfile)+".tmp","w+")
+    for line in xml:
+        newline = line
+        for rf in empty_root_files:
+            if str(rf) in line:
+                newline = "<!--EMPTY "+line.strip("\n")+"-->\n"
+        xml_temporary.write(newline)
+    xml.close()
+    xml_temporary.close()
+    return empty_root_files
 
 if __name__ == "__main__":
     xmllist = sys.argv[2:-1]
     meth = eval(sys.argv[-1])
-    readEntries(sys.argv[1],xmllist,meth)
-    
+    sum_list = readEntries(sys.argv[1],xmllist,meth)
+
+    print "Searching for NTuples which are empty as a consequence of a relatively common crab error which has been around for a long time now..."
+    for i in range(len(xmllist)):
+        empty_files = commentOutEmptyRootFiles(xmllist[i], sum_list[i])
+        if len(empty_files) > 0:
+            print str(xmllist[i])+":    Found and commented out empty root files:"
+            for ef in empty_files: print str(ef)
+        else: print "\033[0;40;32m"+"No empty root files detected. Yay!\033[0m" # green color


### PR DESCRIPTION
[ci skip] After readaMCatNloEntries has finished to do its usual task, it will now also search for root files in the respective xml, which are empty and would cause SFrame to crash if it is the first ntuple file to be opened by sframe_main. After searching for these empty root files, the respective lines in the xml will be commented out.
NB: If you want to check the code by running it yourself, I can provide a minimal xml file with some regular and some empty ntuples listed in it.