### PR TITLE
[102X] adding missing mass point 3.5 TeV for Qstar QW 2018

### DIFF
--- a/common/datasets/RunII_102X_v1/2018/QstarToQW/QstarToQW_M-3500.xml
+++ b/common/datasets/RunII_102X_v1/2018/QstarToQW/QstarToQW_M-3500.xml
@@ -1,0 +1,4 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/izoi/RunII_102X_v1/2018//QstarToQW_M-3500_TuneCP2_13TeV-pythia8/crab_QstarToQW_M-3500_TuneCP2_13TeV-pythia8/190508_092618/0000/Ntuple_1.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/izoi/RunII_102X_v1/2018//QstarToQW_M-3500_TuneCP2_13TeV-pythia8/crab_QstarToQW_M-3500_TuneCP2_13TeV-pythia8/190508_092618/0000/Ntuple_2.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/izoi/RunII_102X_v1/2018//QstarToQW_M-3500_TuneCP2_13TeV-pythia8/crab_QstarToQW_M-3500_TuneCP2_13TeV-pythia8/190508_092618/0000/Ntuple_3.root" Lumi="0.0"/>
+<!-- < NumberEntries="49923.0474956" Method=weights /> -->


### PR DESCRIPTION
[ci skip]
