### PR TITLE
[102X] Add endInputData() method to AnalysisModule

### DIFF
--- a/core/include/AnalysisModule.h
+++ b/core/include/AnalysisModule.h
@@ -14,7 +14,7 @@
 namespace uhh2 {
 
 /**  \brief Abstract base class for all analysis modules, independent of SFrame
- * 
+ *
  * To implement an analysis, derive from this class and override the 'process' method, which
  * will be called for each event.
  *
@@ -73,11 +73,11 @@ public:
  *  - "dataset_lumi" is the integrated luminosity ('Lumi') of the dataset in pb^-1, as given in the SFrame xml file
  *  - "dataset_year" is the year of data/MC set as 'Year' parameter in xml file
  *  - "target_lumi" is the target luminosity in pb^-1 for MC reweighting, as specified in the SFrame xml in Cycle in 'TargetLumi'
- * 
+ *
  * Also, all the dataset-metadata is added with the prefix "meta_" (refer to the Metadata documentation for details).
  * Other keys can either be specified in the SFrame xml configuration file (see ExampleModule), or set
  * by other classes, in particular by the top-level AnalysisModule before constructing other AnalysisModules.
- * 
+ *
  * When running in CMSSW, none of the above keys is set by the framework, but all of them can be set explicitly
  * as cms.string in the 'AnalysisModule' PSet in the EDFilter configuration of NtuplerWriter.
  *
@@ -137,16 +137,16 @@ public:
     void set(const std::string & key, const std::string & value) {
         settings[key] = value;
     }
-    
+
     /** \brief Set sample metadata
-     * 
+     *
      * The metadata will be available via 'get' with the key "meta_" + name. Unlike other
      * settings, it will be written to the output root file, and read in from the root file.
-     * 
+     *
      * A metadata name must not contain the sequence "===" or end with "=". The value must not contain any of "\r\n\0".
      * (This ensures that all metadata can be stored in a simple format name1===value1\nname2====value2\n...
      * in a single string).
-     * 
+     *
      * In general, metadata is sample-wide immutable data, so *changing* a metadata value is something
      * delicate and is generally not recommended. If it has to be done anyway (e.g. because a wrong value
      * has been written which should now be corrected), make sure to do it *very* early in the processing,

--- a/core/include/AnalysisModule.h
+++ b/core/include/AnalysisModule.h
@@ -50,14 +50,13 @@ public:
     /**
      * \brief Method to call after finishing last event in a given InputData block
      *
+     * e.g. Printing statistics, finalizing a histogram contents
+     *
+     * Note that AnalysisModules only last for a given InputData block,
+     * after which they are destroyed, and a new object created for the next InputData.
+     * Hence it doesn't make sense to also have an equivalent "endCycle" at the end of each Cycle.
      */
     virtual void endInputData();
-
-    /**
-     * \brief Method to call after finishing last event in a given Cycle
-     *
-     */
-    virtual void endCycle();
 
     virtual ~AnalysisModule();
 };

--- a/core/include/AnalysisModule.h
+++ b/core/include/AnalysisModule.h
@@ -47,6 +47,18 @@ public:
      */
     virtual bool process(Event & event) = 0;
 
+    /**
+     * \brief Method to call after finishing last event in a given InputData block
+     *
+     */
+    virtual void endInputData();
+
+    /**
+     * \brief Method to call after finishing last event in a given Cycle
+     *
+     */
+    virtual void endCycle();
+
     virtual ~AnalysisModule();
 };
 

--- a/core/include/AnalysisModuleRunner.h
+++ b/core/include/AnalysisModuleRunner.h
@@ -17,16 +17,16 @@ namespace uhh2 {
 class SFrameContext;
 
 /** \brief The SFrame cycle used to run an AnalysisModule
- * 
+ *
  * This is the component which runs within the SFrame framework and provides
  * the bridge to the AnalysisModule-based framework.
- * 
+ *
  * It takes care of
  *  - preparing the input tree according to the configuration
  *  - constructing the AnalysisModule class
  *  - calling AnalysisModule::process for each event
  *  - writing the tree of selected events
- * 
+ *
  * For details on the configuration, refer to the example xml files, in particular
  * examples/config/Example.xml which lists all configuration options.
  */
@@ -34,9 +34,9 @@ class AnalysisModuleRunner: public SCycleBase{
 public:
     // make GetOutputFile public for SFrameContext;
     using SCycleBase::GetOutputFile;
-    
+
     AnalysisModuleRunner();
-    
+
     // called at the beginning of the cycle, but for proof only in one process!
     void BeginCycle() override {}
     void EndCycle() override;
@@ -48,18 +48,18 @@ public:
     // called at the beginning of an input file, on the proof nodes:
     void BeginInputFile( const SInputData& ) override;
     void ExecuteEvent( const SInputData&, Double_t ) override;
-    
+
     // called after processing the dataset, only on the proof master, not on the proof nodes:
     void EndMasterInputData(const SInputData &) override;
-    
+
     void CloseOutputFile() override;
     virtual void Initialize( TXMLNode* node ) override;
     virtual void SetConfig(const SCycleConfig& config) override;
-    
+
     virtual ~AnalysisModuleRunner();
-        
+
     ClassDefOverride(AnalysisModuleRunner, 0);
-  
+
 
     class AnalysisModuleRunnerImpl;
     std::unique_ptr<AnalysisModuleRunnerImpl> pimpl;

--- a/core/include/AnalysisModuleRunner.h
+++ b/core/include/AnalysisModuleRunner.h
@@ -39,11 +39,11 @@ public:
     
     // called at the beginning of the cycle, but for proof only in one process!
     void BeginCycle() override {}
-    void EndCycle() override {}
+    void EndCycle() override;
 
     // called at the beginning of the input data, on all proof nodes:
     void BeginInputData( const SInputData& ) override;
-    void EndInputData  ( const SInputData& ) override {}
+    void EndInputData  ( const SInputData& ) override {};
 
     // called at the beginning of an input file, on the proof nodes:
     void BeginInputFile( const SInputData& ) override;

--- a/core/include/AnalysisModuleRunner.h
+++ b/core/include/AnalysisModuleRunner.h
@@ -39,7 +39,7 @@ public:
 
     // called at the beginning of the cycle, but for proof only in one process!
     void BeginCycle() override {}
-    void EndCycle() override;
+    void EndCycle() override {}
 
     // called at the beginning of the input data, on all proof nodes:
     void BeginInputData( const SInputData& ) override;

--- a/core/src/AnalysisModule.cxx
+++ b/core/src/AnalysisModule.cxx
@@ -5,6 +5,11 @@ using namespace uhh2;
 
 AnalysisModule::~AnalysisModule(){}
 
+void AnalysisModule::endInputData(){}
+
+void AnalysisModule::endCycle(){}
+
+
 Context::Context(GenericEventStructure & ges_): ges(ges_) {}
 
 Context::~Context(){}
@@ -50,6 +55,8 @@ public:
     virtual bool process(Event &){
         return true;
     }
+    virtual void endInputData(){}
+    virtual void endCycle(){}
 };
 
 UHH2_REGISTER_ANALYSIS_MODULE(NoopAnalysisModule)

--- a/core/src/AnalysisModule.cxx
+++ b/core/src/AnalysisModule.cxx
@@ -46,7 +46,7 @@ void Context::set_metadata(const std::string & name, const std::string & value, 
 }
 
 /** \brief AnalysisModule which does nothing and lets all events pass
- * 
+ *
  * Only useful for testing.
  */
 class NoopAnalysisModule: public AnalysisModule {

--- a/core/src/AnalysisModule.cxx
+++ b/core/src/AnalysisModule.cxx
@@ -7,8 +7,6 @@ AnalysisModule::~AnalysisModule(){}
 
 void AnalysisModule::endInputData(){}
 
-void AnalysisModule::endCycle(){}
-
 
 Context::Context(GenericEventStructure & ges_): ges(ges_) {}
 
@@ -56,7 +54,6 @@ public:
         return true;
     }
     virtual void endInputData(){}
-    virtual void endCycle(){}
 };
 
 UHH2_REGISTER_ANALYSIS_MODULE(NoopAnalysisModule)

--- a/core/src/AnalysisModuleRunner.cxx
+++ b/core/src/AnalysisModuleRunner.cxx
@@ -852,11 +852,6 @@ void AnalysisModuleRunner::EndMasterInputData(const SInputData &) {
     }
 }
 
-void AnalysisModuleRunner::EndCycle() {
-    // Allow analysis module to finish up
-    pimpl->analysis->endCycle();
-}
-
 ClassImp(uhh2::AnalysisModuleRunner);
 
 #endif

--- a/core/src/AnalysisModuleRunner.cxx
+++ b/core/src/AnalysisModuleRunner.cxx
@@ -78,7 +78,7 @@ void connect_input_branch(TBranch * branch, const std::type_info & ti, void ** a
     if (res > 0) {
         throw runtime_error("input branch '" + string(branch->GetName()) + "': error reading type information");
     }
-    
+
     // get address type:
     TClass * address_class = TBuffer::GetClass(ti);
     EDataType address_dtype = kNoType_t;
@@ -88,7 +88,7 @@ void connect_input_branch(TBranch * branch, const std::type_info & ti, void ** a
     }
     if(branch_dtype == kLong64_t && address_dtype==kInt_t)
       address_dtype=kLong64_t;
-    
+
     // compare if they match; note that it's an error if the class or data type has not been found:
     if ((branch_class && address_class) && ((branch_class == address_class) || (branch_class->GetTypeInfo() == address_class->GetTypeInfo()))) {
         if (addr == 0) {
@@ -134,9 +134,9 @@ void connect_input_branch(TBranch * branch, const std::type_info & ti, void ** a
 namespace uhh2 {
 
 /** \brief The SFrame specific implementation for the Context
- * 
+ *
  * See the Context class for a description of the methods.
- * 
+ *
  * This class is intended to be used from a SCycle; see AnalysisModuleRunner for
  * an example use:
  *  - create a new instance of SFrameContext in SCycle::BeginInputData and set the dataset_type and dataset_version
@@ -145,7 +145,7 @@ namespace uhh2 {
  */
 class SFrameContext: public uhh2::Context {
 public:
-    
+
     SFrameContext(AnalysisModuleRunner & base, const SInputData& sin, GenericEventStructure & es);
 
     virtual void put(const std::string & path, TH1 * t) override;
@@ -158,14 +158,14 @@ public:
     void begin_event(Event & event);
     void setup_output(Event & event); // should be called after processing the first event which is written to the output
     void check_output(Event & event); // checks if all objetcs written to the output have been assigned a correct value during the process routine; called at the end of each event
-    
+
     void write_metadata_tree();
     void first_input_file(); // called for the first input file of the dataset, in addition to begin_input_file, but with no event (yet)
 
     std::string event_treename;
-    
+
     TTree * outtree = nullptr; // output tree. Can be 0 in case no output should be written.
-    
+
     void do_declare_event_input_handle(const std::type_info & ti, const std::string & bname, const GenericEvent::RawHandle & handle);
     void do_declare_event_output_handle(const std::type_info & ti, const std::string & bname, const GenericEvent::RawHandle & handle);
 
@@ -379,7 +379,7 @@ void SFrameContext::begin_input_file(Event & event) {
         EventAccess_::set_unmanaged(event, bi.ti, bi.handle, bi.addr);
         bi.branch = branch;
     }
-    
+
     // check consistency of file metadata with previous metadata.
     auto dir = input_tree->GetDirectory();
     assert(dir);
@@ -499,9 +499,9 @@ private:
     bool m_userEventFormat;
 
     bool setup_output_done;
-    
+
     bool use_sframe_weight;
-    
+
     std::vector<std::string> additional_branches;
     bool first_file = true;
 
@@ -586,12 +586,12 @@ void AnalysisModuleRunner::SetConfig(const SCycleConfig& config) {
 void AnalysisModuleRunner::AnalysisModuleRunnerImpl::begin_input_data(AnalysisModuleRunner & base, const SInputData& in) {
     ges.reset(new GenericEventStructure);
     context.reset(new SFrameContext(base, in, *ges));
-    
+
     // 1. setup common event data members / branches:
     m_userEventFormat = string2bool(context->get("userEventFormat", "false"));
-    
+
     if(!m_userEventFormat){
-    
+
         eh.reset(new EventHelper(*context));
 
         eh->setup_pvs(context->get("PrimaryVertexCollection", ""));
@@ -627,7 +627,7 @@ void AnalysisModuleRunner::AnalysisModuleRunnerImpl::begin_input_data(AnalysisMo
 	  catch(const std::runtime_error& error){
 	    std::cout<<"Problem with genParticleCollection in AnalysisModuleRunner.cxx"<<std::endl;
 	    std::cout<<error.what();
-	  }	  
+	  }
 	    eh->setup_genmet(context->get("genMETName", ""));
         }
 
@@ -635,14 +635,14 @@ void AnalysisModuleRunner::AnalysisModuleRunnerImpl::begin_input_data(AnalysisMo
         if (m_readTrigger) {
             eh->setup_trigger();
         }
-        
+
         use_sframe_weight = string2bool(context->get("use_sframe_weight", "true"));
     }
-    
+
     else{
         m_readTrigger = false;
     }
-    
+
     // 2. prepare reading additional branches from input:
     additional_branches = split(context->get("additionalBranches", ""));
     first_file = true;
@@ -691,7 +691,7 @@ void AnalysisModuleRunner::BeginInputFile(const SInputData&) {
         tnb->SetAddress(oldaddr_tnb);
         pimpl->eh->set_infile_triggernames(move(run2triggernames));
     }
-    
+
     // setup additional branches, if not done yet:
     if(pimpl->first_file && !pimpl->additional_branches.empty()){
         TTree* intree = GetInputTree(pimpl->context->event_treename.c_str());
@@ -713,7 +713,7 @@ void AnalysisModuleRunner::BeginInputFile(const SInputData&) {
             pimpl->context->do_declare_event_output_handle(ti, bname, handle);
         }
     }
-    
+
     // In case this is the first file in the dataset: construct AnalysisModule now.
     // This is done now (and not earlier, e.g. in BeginInputData) because only now we know
     // the metadata and the additional branches (the latter is needed to fix the event structure).
@@ -727,7 +727,7 @@ void AnalysisModuleRunner::BeginInputFile(const SInputData&) {
         }
         pimpl->first_file = false;
     }
-    
+
     pimpl->context->begin_input_file(*pimpl->event);
 }
 
@@ -740,7 +740,7 @@ void AnalysisModuleRunner::ExecuteEvent(const SInputData&, Double_t w) {
     }
 
     uhh2::Event & event = *pimpl->event;
-    
+
     // setup weight depending on the "use_sframe_weight" configuration option:
     if(pimpl->use_sframe_weight && !event.isRealData){
         event.weight = w;

--- a/core/src/AnalysisModuleRunner.cxx
+++ b/core/src/AnalysisModuleRunner.cxx
@@ -787,6 +787,9 @@ void AnalysisModuleRunner::CloseOutputFile(){
 }
 
 void AnalysisModuleRunner::EndMasterInputData(const SInputData &) {
+    // Allow analysis module to finish up
+    pimpl->analysis->endInputData();
+
     TList * l = GetHistOutput();
     TIter next(l);
     TObject * obj;
@@ -847,6 +850,11 @@ void AnalysisModuleRunner::EndMasterInputData(const SInputData &) {
         }
         out.print(cout);
     }
+}
+
+void AnalysisModuleRunner::EndCycle() {
+    // Allow analysis module to finish up
+    pimpl->analysis->endCycle();
 }
 
 ClassImp(uhh2::AnalysisModuleRunner);


### PR DESCRIPTION
This adds in a new method, `AnalysisModule::endInputData()`, that runs after all events in a given InputData block have been processed.
This is like a "finalize()" method, useful for e.g. printing stats, filling a histogram that requires knowledge about all events, etc.
The user can then override this method call in their own analysis module.

Unlike `AnalysisModule::process()`, the user isn't required to implement it in their derived class.

I haven't given it any input arguments (e.g. the event) - I figure that info would already be stored in the derived class' member variables, plus it wouldn't make sense (you are doing something after all the events are finished).

[only compile]

