### PR TITLE
[102X] Add _backup to requestname, since sometimes used instead of ext*

### DIFF
--- a/scripts/crab/crab_template.py
+++ b/scripts/crab/crab_template.py
@@ -48,6 +48,8 @@ def get_request_name(dataset_name):
         modified_name += '_ext2'
     elif 'ext' in dataset_name:
         modified_name += '_ext'
+    elif 'backup' in dataset_name:
+        modified_name += '_backup'
 
     # For e.g. Run2016B which is split into 2
     if "ver1" in dataset_name:


### PR DESCRIPTION
e.g. 
/QCD_Pt_470to600_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM
and
/QCD_Pt_470to600_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv3-PUMoriond17_backup_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM

[ci skip]
