### PR TITLE
[102X]  fixed wrong index in deltaR_ak4jet topjet histogram 

### DIFF
--- a/common/src/JetHists.cxx
+++ b/common/src/JetHists.cxx
@@ -230,7 +230,7 @@ void TopJetHists::fill(const Event & event){
             const auto & ak4jet = ak4jets[j];
             double deltaRtopjetak4jet = deltaR(jet, ak4jet);
             deltaR_ak4jet->Fill(deltaRtopjetak4jet,w);
-            invmass_topjetak4jet->Fill((jet.v4()+ak4jet.v4()).M(),w);
+            invmass_topjetak4jet->Fill(inv_mass_safe(jet.v4()+ak4jet.v4())); 
          }
       if (jet.has_tag(jet.tagname2tag("mass"))) HTT_mass ->Fill(jet.get_tag(jet.tagname2tag("mass")),w);
       if (jet.has_tag(jet.tagname2tag("fRec"))) fRec ->Fill(jet.get_tag(jet.tagname2tag("fRec")),w);

--- a/common/src/JetHists.cxx
+++ b/common/src/JetHists.cxx
@@ -227,7 +227,7 @@ void TopJetHists::fill(const Event & event){
 
       for (unsigned int j = 0; j <ak4jets.size(); j++)
          {
-            const auto & ak4jet = ak4jets[i];
+            const auto & ak4jet = ak4jets[j];
             double deltaRtopjetak4jet = deltaR(jet, ak4jet);
             deltaR_ak4jet->Fill(deltaRtopjetak4jet,w);
             invmass_topjetak4jet->Fill((jet.v4()+ak4jet.v4()).M(),w);


### PR DESCRIPTION
[only compile]
also now using invariant mass safe for invmass_topjetak4jet hist 
