### PR TITLE
[102X] Update SCRAM_ARCH if EL7 machine

### DIFF
--- a/scripts/install.csh
+++ b/scripts/install.csh
@@ -12,6 +12,8 @@ set MAKEFLAGS="-j${cores}"
 # Get CMSSW
 source /cvmfs/cms.cern.ch/cmsset_default.csh
 setenv SCRAM_ARCH slc6_amd64_gcc700
+set kernel=`uname -r`
+if ( "$kernel" =~ *el7* ) setenv SCRAM_ARCH slc7_amd64_gcc700
 set CMSREL=CMSSW_10_2_10
 eval `cmsrel ${CMSREL}`
 cd ${CMSREL}/src

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -90,6 +90,11 @@ time git clone https://github.com/UHH2/SFrame.git
 
 # Get CMSSW
 export SCRAM_ARCH=slc6_amd64_gcc700
+KERNEL=$(uname -r)
+# Update for EL7 (i.e. CC7/SL7) - should work for lxplus and NAF EL7 machines
+if [[ "$KERNEL" == *el7* ]]; then
+	export SCRAM_ARCH=slc7_amd64_gcc700
+fi
 CMSREL=CMSSW_10_2_10
 eval `cmsrel ${CMSREL}`
 cd ${CMSREL}/src


### PR DESCRIPTION
Add check in `install.sh` to see if EL7 machine, in which case modify SCRAM_ARCH as necessary.
Should work on lxplus and NAF EL7 machines.

Can't test it properly on CI with EL7 as not set up, but still compiling to check it didn't adversely affect the normal SL6 setup

Also updated csh script accordingly

[only compile]
