### PR TITLE
[102X] Use LorentzVectorXYZE to handle 0 puppi weights

### DIFF
--- a/examples/src/ExampleModuleJetConstituents.cxx
+++ b/examples/src/ExampleModuleJetConstituents.cxx
@@ -121,12 +121,15 @@ LorentzVector ExampleModuleJetConstituents::constructConstituentSum(std::vector<
     if (pfparticles == nullptr) { throw std::runtime_error("pfparticles is nullptr"); }
     if (jet == nullptr) { throw std::runtime_error("Jet is nullptr"); }
 
-    LorentzVector consistSum;
+    LorentzVectorXYZE consistSum;
     for (const auto candInd : jet->pfcand_indexs()) {
         float puppiWeight = (usePuppiWeight) ? pfparticles->at(candInd).puppiWeight() : 1.;
-        consistSum += pfparticles->at(candInd).v4() * puppiWeight;
+        // Need to use XYZ representation instead of PtEtaPhi, since if the
+        // Puppi weight = 0, it will not scale correctly but instead be added.
+        LorentzVectorXYZE v4XYZ = toXYZ(pfparticles->at(candInd).v4());
+        consistSum += (v4XYZ * puppiWeight);
     }
-    return consistSum;
+    return toPtEtaPhi(consistSum);
 }
 
 LorentzVector ExampleModuleJetConstituents::constructConstituentSum(std::vector<GenParticle> * genparticles, const GenJet * genjet) {


### PR DESCRIPTION
Fix in ExampleModuleJetConstituents. `LorentzVector` doesn't scale correctly with PUPPI weight 0, whilst `LorentzVectorXYZE` does. Previously would create jet with correct pT, but really wrong eta/phi.
Now uses the latter to do the sum over constituents. Still returns a `LorentzVector` thought since pt/eta/phi more useful in general.



[only compile]

