### PR TITLE
[102X] missing masses for 2018 Radion samples

### DIFF
--- a/common/datasets/RunII_102X_v1/2018/RadionToWW/RadionToWW_M-1800.xml
+++ b/common/datasets/RunII_102X_v1/2018/RadionToWW/RadionToWW_M-1800.xml
@@ -1,0 +1,4 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/izoi/RunII_102X_v1/2018/RadionToWW_narrow_M-1800_TuneCP5_13TeV-madgraph/crab_RadionToWW_narrow_M-1800_TuneCP5_13TeV-madgraph_Autumn18_v1/190809_152631/0000/Ntuple_1.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/izoi/RunII_102X_v1/2018/RadionToWW_narrow_M-1800_TuneCP5_13TeV-madgraph/crab_RadionToWW_narrow_M-1800_TuneCP5_13TeV-madgraph_Autumn18_v1/190809_152631/0000/Ntuple_2.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/izoi/RunII_102X_v1/2018/RadionToWW_narrow_M-1800_TuneCP5_13TeV-madgraph/crab_RadionToWW_narrow_M-1800_TuneCP5_13TeV-madgraph_Autumn18_v1/190809_152631/0000/Ntuple_3.root" Lumi="0.0"/>
+<!-- < NumberEntries="49885.7763973" Method=weights /> -->

--- a/common/datasets/RunII_102X_v1/2018/RadionToZZ/RadionToZZ_M-5000.xml
+++ b/common/datasets/RunII_102X_v1/2018/RadionToZZ/RadionToZZ_M-5000.xml
@@ -1,0 +1,3 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/izoi/RunII_102X_v1/2018/RadionToZZ_narrow_M-5000_TuneCP5_13TeV-madgraph/crab_RadionToZZ_narrow_M-5000_TuneCP5_13TeV-madgraph_Autumn18_v1/190814_093240/0000/Ntuple_1.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/izoi/RunII_102X_v1/2018/RadionToZZ_narrow_M-5000_TuneCP5_13TeV-madgraph/crab_RadionToZZ_narrow_M-5000_TuneCP5_13TeV-madgraph_Autumn18_v1/190814_093240/0000/Ntuple_2.root" Lumi="0.0"/>
+<!-- < NumberEntries="47045.2805152" Method=weights /> -->


### PR DESCRIPTION
[ci skip]
- 1.8 TeV RadionToWW
- 5.0 TeV RadionToZZ