### PR TITLE
[102X] 2016v2 QstarToQW 0.6 - 7.0 TeV 

### DIFF
--- a/common/datasets/RunII_102X_v1/2016v2/QstarToQW/QstarToQW_M-1200.xml
+++ b/common/datasets/RunII_102X_v1/2016v2/QstarToQW/QstarToQW_M-1200.xml
@@ -1,0 +1,3 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/izoi/RunII_102X_v1/2016v2/QstarToQW_M-1200_TuneCUETP8M2T4_13TeV-pythia8/crab_QstarToQW_M-1200_TuneCUETP8M2T4_13TeV-pythia8/190508_173150/0000/Ntuple_1.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/izoi/RunII_102X_v1/2016v2/QstarToQW_M-1200_TuneCUETP8M2T4_13TeV-pythia8/crab_QstarToQW_M-1200_TuneCUETP8M2T4_13TeV-pythia8/190508_173150/0000/Ntuple_2.root" Lumi="0.0"/>
+<!-- < NumberEntries="29256.0" Method=weights /> -->

--- a/common/datasets/RunII_102X_v1/2016v2/QstarToQW/QstarToQW_M-1400.xml
+++ b/common/datasets/RunII_102X_v1/2016v2/QstarToQW/QstarToQW_M-1400.xml
@@ -1,0 +1,3 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/izoi/RunII_102X_v1/2016v2/QstarToQW_M-1400_TuneCUETP8M2T4_13TeV-pythia8/crab_QstarToQW_M-1400_TuneCUETP8M2T4_13TeV-pythia8/190508_173312/0000/Ntuple_1.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/izoi/RunII_102X_v1/2016v2/QstarToQW_M-1400_TuneCUETP8M2T4_13TeV-pythia8/crab_QstarToQW_M-1400_TuneCUETP8M2T4_13TeV-pythia8/190508_173312/0000/Ntuple_2.root" Lumi="0.0"/>
+<!-- < NumberEntries="30000.0" Method=weights /> -->

--- a/common/datasets/RunII_102X_v1/2016v2/QstarToQW/QstarToQW_M-1800.xml
+++ b/common/datasets/RunII_102X_v1/2016v2/QstarToQW/QstarToQW_M-1800.xml
@@ -1,0 +1,3 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/izoi/RunII_102X_v1/2016v2/QstarToQW_M-1800_TuneCUETP8M2T4_13TeV-pythia8/crab_QstarToQW_M-1800_TuneCUETP8M2T4_13TeV-pythia8/190508_173601/0000/Ntuple_1.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/izoi/RunII_102X_v1/2016v2/QstarToQW_M-1800_TuneCUETP8M2T4_13TeV-pythia8/crab_QstarToQW_M-1800_TuneCUETP8M2T4_13TeV-pythia8/190508_173601/0000/Ntuple_2.root" Lumi="0.0"/>
+<!-- < NumberEntries="29661.0" Method=weights /> -->

--- a/common/datasets/RunII_102X_v1/2016v2/QstarToQW/QstarToQW_M-2000.xml
+++ b/common/datasets/RunII_102X_v1/2016v2/QstarToQW/QstarToQW_M-2000.xml
@@ -1,0 +1,3 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/izoi/RunII_102X_v1/2016v2/QstarToQW_M-2000_TuneCUETP8M2T4_13TeV-pythia8/crab_QstarToQW_M-2000_TuneCUETP8M2T4_13TeV-pythia8/190508_173726/0000/Ntuple_1.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/izoi/RunII_102X_v1/2016v2/QstarToQW_M-2000_TuneCUETP8M2T4_13TeV-pythia8/crab_QstarToQW_M-2000_TuneCUETP8M2T4_13TeV-pythia8/190508_173726/0000/Ntuple_2.root" Lumi="0.0"/>
+<!-- < NumberEntries="30000.0" Method=weights /> -->

--- a/common/datasets/RunII_102X_v1/2016v2/QstarToQW/QstarToQW_M-2500.xml
+++ b/common/datasets/RunII_102X_v1/2016v2/QstarToQW/QstarToQW_M-2500.xml
@@ -1,0 +1,3 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/izoi/RunII_102X_v1/2016v2/QstarToQW_M-2500_TuneCUETP8M2T4_13TeV-pythia8/crab_QstarToQW_M-2500_TuneCUETP8M2T4_13TeV-pythia8/190508_173848/0000/Ntuple_1.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/izoi/RunII_102X_v1/2016v2/QstarToQW_M-2500_TuneCUETP8M2T4_13TeV-pythia8/crab_QstarToQW_M-2500_TuneCUETP8M2T4_13TeV-pythia8/190508_173848/0000/Ntuple_2.root" Lumi="0.0"/>
+<!-- < NumberEntries="30000.0" Method=weights /> -->

--- a/common/datasets/RunII_102X_v1/2016v2/QstarToQW/QstarToQW_M-3500.xml
+++ b/common/datasets/RunII_102X_v1/2016v2/QstarToQW/QstarToQW_M-3500.xml
@@ -1,0 +1,3 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/izoi/RunII_102X_v1/2016v2/QstarToQW_M-3500_TuneCUETP8M2T4_13TeV-pythia8/crab_QstarToQW_M-3500_TuneCUETP8M2T4_13TeV-pythia8/190508_174152/0000/Ntuple_1.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/izoi/RunII_102X_v1/2016v2/QstarToQW_M-3500_TuneCUETP8M2T4_13TeV-pythia8/crab_QstarToQW_M-3500_TuneCUETP8M2T4_13TeV-pythia8/190508_174152/0000/Ntuple_2.root" Lumi="0.0"/>
+<!-- < NumberEntries="30000.0" Method=weights /> -->

--- a/common/datasets/RunII_102X_v1/2016v2/QstarToQW/QstarToQW_M-4000.xml
+++ b/common/datasets/RunII_102X_v1/2016v2/QstarToQW/QstarToQW_M-4000.xml
@@ -1,0 +1,3 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/izoi/RunII_102X_v1/2016v2/QstarToQW_M-4000_TuneCUETP8M2T4_13TeV-pythia8/crab_QstarToQW_M-4000_TuneCUETP8M2T4_13TeV-pythia8/190508_174315/0000/Ntuple_1.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/izoi/RunII_102X_v1/2016v2/QstarToQW_M-4000_TuneCUETP8M2T4_13TeV-pythia8/crab_QstarToQW_M-4000_TuneCUETP8M2T4_13TeV-pythia8/190508_174315/0000/Ntuple_2.root" Lumi="0.0"/>
+<!-- < NumberEntries="29703.0" Method=weights /> -->

--- a/common/datasets/RunII_102X_v1/2016v2/QstarToQW/QstarToQW_M-4500.xml
+++ b/common/datasets/RunII_102X_v1/2016v2/QstarToQW/QstarToQW_M-4500.xml
@@ -1,0 +1,3 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/izoi/RunII_102X_v1/2016v2/QstarToQW_M-4500_TuneCUETP8M2T4_13TeV-pythia8/crab_QstarToQW_M-4500_TuneCUETP8M2T4_13TeV-pythia8/190508_174447/0000/Ntuple_1.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/izoi/RunII_102X_v1/2016v2/QstarToQW_M-4500_TuneCUETP8M2T4_13TeV-pythia8/crab_QstarToQW_M-4500_TuneCUETP8M2T4_13TeV-pythia8/190508_174447/0000/Ntuple_2.root" Lumi="0.0"/>
+<!-- < NumberEntries="30000.0" Method=weights /> -->

--- a/common/datasets/RunII_102X_v1/2016v2/QstarToQW/QstarToQW_M-5000.xml
+++ b/common/datasets/RunII_102X_v1/2016v2/QstarToQW/QstarToQW_M-5000.xml
@@ -1,0 +1,3 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/izoi/RunII_102X_v1/2016v2/QstarToQW_M-5000_TuneCUETP8M2T4_13TeV-pythia8/crab_QstarToQW_M-5000_TuneCUETP8M2T4_13TeV-pythia8_Summer16_v2/190612_164252/0000/Ntuple_1.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/izoi/RunII_102X_v1/2016v2/QstarToQW_M-5000_TuneCUETP8M2T4_13TeV-pythia8/crab_QstarToQW_M-5000_TuneCUETP8M2T4_13TeV-pythia8_Summer16_v2/190612_164252/0000/Ntuple_2.root" Lumi="0.0"/>
+<!-- < NumberEntries="30000.0" Method=weights /> -->

--- a/common/datasets/RunII_102X_v1/2016v2/QstarToQW/QstarToQW_M-600.xml
+++ b/common/datasets/RunII_102X_v1/2016v2/QstarToQW/QstarToQW_M-600.xml
@@ -1,0 +1,3 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/izoi/RunII_102X_v1/2016v2/QstarToQW_M-600_TuneCUETP8M2T4_13TeV-pythia8/crab_QstarToQW_M-600_TuneCUETP8M2T4_13TeV-pythia8/190508_172727/0000/Ntuple_1.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/izoi/RunII_102X_v1/2016v2/QstarToQW_M-600_TuneCUETP8M2T4_13TeV-pythia8/crab_QstarToQW_M-600_TuneCUETP8M2T4_13TeV-pythia8/190508_172727/0000/Ntuple_2.root" Lumi="0.0"/>
+<!-- < NumberEntries="30000.0" Method=weights /> -->

--- a/common/datasets/RunII_102X_v1/2016v2/QstarToQW/QstarToQW_M-6000.xml
+++ b/common/datasets/RunII_102X_v1/2016v2/QstarToQW/QstarToQW_M-6000.xml
@@ -1,0 +1,3 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/izoi/RunII_102X_v1/2016v2/QstarToQW_M-6000_TuneCUETP8M2T4_13TeV-pythia8/crab_QstarToQW_M-6000_TuneCUETP8M2T4_13TeV-pythia8/190508_174747/0000/Ntuple_1.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/izoi/RunII_102X_v1/2016v2/QstarToQW_M-6000_TuneCUETP8M2T4_13TeV-pythia8/crab_QstarToQW_M-6000_TuneCUETP8M2T4_13TeV-pythia8/190508_174747/0000/Ntuple_2.root" Lumi="0.0"/>
+<!-- < NumberEntries="29689.0" Method=weights /> -->

--- a/common/datasets/RunII_102X_v1/2016v2/QstarToQW/QstarToQW_M-7000.xml
+++ b/common/datasets/RunII_102X_v1/2016v2/QstarToQW/QstarToQW_M-7000.xml
@@ -1,0 +1,3 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/izoi/RunII_102X_v1/2016v2/QstarToQW_M-7000_TuneCUETP8M2T4_13TeV-pythia8/crab_QstarToQW_M-7000_TuneCUETP8M2T4_13TeV-pythia8/190508_174924/0000/Ntuple_1.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/izoi/RunII_102X_v1/2016v2/QstarToQW_M-7000_TuneCUETP8M2T4_13TeV-pythia8/crab_QstarToQW_M-7000_TuneCUETP8M2T4_13TeV-pythia8/190508_174924/0000/Ntuple_2.root" Lumi="0.0"/>
+<!-- < NumberEntries="29769.0" Method=weights /> -->

--- a/common/datasets/RunII_102X_v1/2016v2/QstarToQW/QstarToQW_M-800.xml
+++ b/common/datasets/RunII_102X_v1/2016v2/QstarToQW/QstarToQW_M-800.xml
@@ -1,0 +1,3 @@
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/izoi/RunII_102X_v1/2016v2/QstarToQW_M-800_TuneCUETP8M2T4_13TeV-pythia8/crab_QstarToQW_M-800_TuneCUETP8M2T4_13TeV-pythia8/190508_172851/0000/Ntuple_1.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/izoi/RunII_102X_v1/2016v2/QstarToQW_M-800_TuneCUETP8M2T4_13TeV-pythia8/crab_QstarToQW_M-800_TuneCUETP8M2T4_13TeV-pythia8/190508_172851/0000/Ntuple_2.root" Lumi="0.0"/>
+<!-- < NumberEntries="30000.0" Method=weights /> -->


### PR DESCRIPTION
[ci skip]
1.0, 1.6, 3.0, 5.5, 6.5, 7.5, 8.0 missing