### PR TITLE
2018 Radion To ZZ 8.0 TeV removed wrong EMPTY comment from xml

### DIFF
--- a/common/datasets/RunII_102X_v1/2018/RadionToZZ/RadionToZZ_M-8000.xml
+++ b/common/datasets/RunII_102X_v1/2018/RadionToZZ/RadionToZZ_M-8000.xml
@@ -1,3 +1,3 @@
-<!--EMPTY <In FileName="/pnfs/desy.de/cms/tier2/store/user/izoi/RunII_102X_v1/2018/RadionToZZ_narrow_M-8000_TuneCP5_13TeV-madgraph/crab_RadionToZZ_narrow_M-8000_TuneCP5_13TeV-madgraph_Autumn18_v1/190809_155632/0000/Ntuple_1.root" Lumi="0.0"/> -->
-<!--EMPTY <In FileName="/pnfs/desy.de/cms/tier2/store/user/izoi/RunII_102X_v1/2018/RadionToZZ_narrow_M-8000_TuneCP5_13TeV-madgraph/crab_RadionToZZ_narrow_M-8000_TuneCP5_13TeV-madgraph_Autumn18_v1/190809_155632/0000/Ntuple_2.root" Lumi="0.0"/> -->
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/izoi/RunII_102X_v1/2018/RadionToZZ_narrow_M-8000_TuneCP5_13TeV-madgraph/crab_RadionToZZ_narrow_M-8000_TuneCP5_13TeV-madgraph_Autumn18_v1/190809_155632/0000/Ntuple_1.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/izoi/RunII_102X_v1/2018/RadionToZZ_narrow_M-8000_TuneCP5_13TeV-madgraph/crab_RadionToZZ_narrow_M-8000_TuneCP5_13TeV-madgraph_Autumn18_v1/190809_155632/0000/Ntuple_2.root" Lumi="0.0"/>
 <!-- < NumberEntries="-2491.88628802" Method=weights /> -->


### PR DESCRIPTION
[ci skip]
