### PR TITLE
[102X] Make PFParticle getters const

### DIFF
--- a/core/include/PFParticle.h
+++ b/core/include/PFParticle.h
@@ -26,9 +26,9 @@ public:
   ~PFParticle(){
   };
 
-  EParticleID particleID(){return m_particleID;}
-  float puppiWeight(){return m_puppi_weight;}
-  float puppiWeightNoLep(){return m_puppi_weight_nolep;}
+  EParticleID particleID() const {return m_particleID;}
+  float puppiWeight() const {return m_puppi_weight;}
+  float puppiWeightNoLep() const {return m_puppi_weight_nolep;}
 
   void set_particleID(EParticleID id){m_particleID = id;}
   void set_puppiWeight(float e){m_puppi_weight = e;}


### PR DESCRIPTION
Class getters should be const otherwise you can end up with  e.g.

```error: passing 'const PFParticle' as 'this' argument discards qualifiers```

when using getters on const objects (which by definition should be fine).
This fixes it for `PFParticle`, I think all other object classes are OK.

[only compile]

