### PR TITLE
[102X] Fix bug commenting out non-empty files in XMLs

### DIFF
--- a/scripts/crab/readaMCatNloEntries.py
+++ b/scripts/crab/readaMCatNloEntries.py
@@ -71,12 +71,20 @@ def readEntries(worker, xmlfiles, fast=False):
 
 
 def commentOutEmptyRootFiles(xmlfile, entries_per_rootfile,fast=False):
+    """Edit the XML file so that ROOT files with 0 events are commented out
+
+    This is because sframe can crash if the first file has 0 events.
+    (For some reason CRAB makes these empty files)
+
+    Note that we need != 0 as some files have -ve entries due to weights
+    (we assume the user knows how to handle that scenario)
+    """
     newText = []
     with open(xmlfile, "U") as file:
         i_ = 0
         for line in file.readlines():
             if '.root' in line:
-                newText.append(line if entries_per_rootfile[i_]>0 else '<!--EMPTY <In FileName="'+line.split('"')[1]+'" Lumi="0.0"/> -->\n')
+                newText.append(line if entries_per_rootfile[i_]!=0 else '<!--EMPTY <In FileName="'+line.split('"')[1]+'" Lumi="0.0"/> -->\n')
                 i_ += 1
         if len(entries_per_rootfile)!= i_: print "ERROR", len(entries_per_rootfile), i_
     with open(xmlfile, "w") as outputfile:


### PR DESCRIPTION
Script would also comment out ntuples with -ve entries (which is possible if counting using weights). This fixes it.

(We assume user knows how to handle -ve # events in a file)

Note that there are some genuinely empty files in 2016 data, so these are OK

[ci skip]


PS incase need to manually remove "EMPTY" from XMLs:

`find <YOURSTARTDIR> -name "*.xml" -exec grep -l "EMPTY" {} \; | xargs sed -i -r 's|<!--EMPTY (.*) -->|\1|'
`