### PR TITLE
[102X] Clone Varial package in btag script if needed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ core/python/__init__.py
 *.json
 VLQToHiggsPairProd/*
 ZprimeSemiLeptonic/*
-
+Varial
 BaconJets/*
 JECDatabase/*
 pydump.py

--- a/scripts/create-btag-effiency-histos.py
+++ b/scripts/create-btag-effiency-histos.py
@@ -1,16 +1,35 @@
 #!/usr/bin/env python
 
-import os, sys, itertools
 
-sys.path.append('/nfs/dust/cms/user/tholenhe/installs/varial-stable/Varial')
+import os, sys, itertools, subprocess
 
+
+# We need the varial library for this script
+# Clone it if it doesn't already exist
 try:
-	import varial
+    import varial
 except ImportError:
-	print 'ImportError. You need Varial for this script: '
-	print 'https://github.com/HeinerTholen/Varial'
-	print 'Exit.'
-	exit(-1)
+    varial_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'Varial')
+
+    if not os.path.isdir(varial_dir):
+        print 'Cannot find Varial. Trying to clone it...'
+        git_url = 'https://github.com/UHH2/Varial'
+        cmd = 'git clone ' + git_url
+        subprocess.check_output(cmd, shell=True)
+        # Check again
+        if not os.path.isdir(varial_dir):
+            print 'Error cloning Varial from', git_url
+            print 'Please try this manually'
+            exit(-1)
+
+    if os.path.isdir(varial_dir):
+        sys.path.append(varial_dir)
+        import varial
+    else:
+        print 'ImportError. You need Varial for this script: '
+        print 'https://github.com/HeinerTholen/Varial'
+        print 'Exit.'
+        exit(-1)
 
 if len(sys.argv) < 2:
    print "Usage:\n" \
@@ -31,9 +50,9 @@ btag_histo_names = (
     "BTagMCEffFlavUDSGTotal",
 )
 if folder=='':
-	filter_func = lambda w: w.name in btag_histo_names 
+    filter_func = lambda w: w.name in btag_histo_names
 else:
-	filter_func = lambda w: w.name in btag_histo_names and folder in w.in_file_path
+    filter_func = lambda w: w.name in btag_histo_names and folder in w.in_file_path
 input_pattern = sys.argv[1:]
 
 
@@ -45,23 +64,23 @@ pipe = list(pipe)  # pull everything through the generators
 
 # do some checks
 if len(pipe) != 6:
-	print 'Error. I need histograms for all of these names: ', btag_histo_names
-	print 'I only found these: ', list(w.in_file_path for w in pipe)
-	exit(-1)
+    print 'Error. I need histograms for all of these names: ', btag_histo_names
+    print 'I only found these: ', list(w.in_file_path for w in pipe)
+    exit(-1)
 
 empty_hists = list(w.name for w in pipe if not w.obj.Integral())
 if empty_hists:
-	print 'Error: integral of histograms "%s" is 0.0! Exit.' % empty_hists
-	exit(-1)
+    print 'Error: integral of histograms "%s" is 0.0! Exit.' % empty_hists
+    exit(-1)
 
 
 # eff histos
 pipe = varial.gen.gen_make_eff_graphs(
     pipe,
-	postfix_sub='Passing',
-	postfix_tot='Total',
-    new_postfix='Eff', 
-    yield_everything=True, 
+    postfix_sub='Passing',
+    postfix_tot='Total',
+    new_postfix='Eff',
+    yield_everything=True,
     eff_func=varial.op.div,
 )
 
@@ -71,7 +90,7 @@ outfile= 'BTagMCEfficiencyHists'+folder+'.root'
 print 'Saving histograms to file:', outfile
 f = varial.ROOT.TFile(outfile, 'RECREATE')
 for w in pipe:
-	print '  writing histogram:', w.name
-	w.obj.SetName(w.name)
-	w.obj.Write()
+    print '  writing histogram:', w.name
+    w.obj.SetName(w.name)
+    w.obj.Write()
 f.Close()


### PR DESCRIPTION
Main centralised Varial installation at `/nfs/dust/cms/user/tholenhe/installs/varial-stable/Varial` no longer exists. The btag script is the only one that relies on it, so when it is now run, it first checks if the Varial directory exists, if not it clones it from git, and then imports it. This way we are decentralised, so we don't face the same issue in the future.

It gets cloned into scripts directory - assuming this is OK as nothing else uses it? (i.e. it doesn't need to be cloned somewhere more central)

Also tidied up some formatting.

[ci skip]

