### PR TITLE
[102X] Make ntuplewriter work for GEN input

### DIFF
--- a/core/plugins/NtupleWriter.h
+++ b/core/plugins/NtupleWriter.h
@@ -160,7 +160,7 @@ class NtupleWriter : public edm::EDFilter {
       edm::EDGetTokenT<double> prefweightup_token;
       edm::EDGetTokenT<double> prefweightdown_token;
 
-      bool newrun, setup_output_branches_done;
+      bool newrun, setup_output_branches_done, firstEvent;
 
       edm::EDGetTokenT<edm::TriggerResults> triggerBits_;
       edm::EDGetTokenT<edm::TriggerResults>  metfilterBits_;

--- a/core/python/ntuplewriter_mc_2016v3_GEN_ONLY.py
+++ b/core/python/ntuplewriter_mc_2016v3_GEN_ONLY.py
@@ -1,0 +1,71 @@
+import FWCore.ParameterSet.Config as cms
+from UHH2.core.ntuple_generator import generate_process  # use CMSSW type path for CRAB
+from UHH2.core.optionsParse import setup_opts, parse_apply_opts
+
+
+"""NTuple config for 2016 GEN-only MC samples.
+We turn off everything except for Gen info & GenJets.
+Not that there are no genParticles in the input file either.
+
+You should try and put any centralised changes in generate_process(), not here.
+"""
+
+
+process = generate_process(year="2016v3", useData=False)
+
+# Please do not commit changes to source filenames - used for consistency testing
+process.source.fileNames = cms.untracked.vstring([
+    'file:/pnfs/desy.de/cms/tier2/store/user/hinzmann/dijetangular/dijet_angular/jobtmp_pythia8_ci_m1500_1900_13000_1_0_0_13TeV_Nov14-0/GEN.root'
+])
+
+process.MyNtuple.doRho = cms.untracked.bool(False)
+process.MyNtuple.save_lepton_keys = cms.bool(False)
+process.MyNtuple.doPV = cms.bool(False)
+process.MyNtuple.doElectrons = cms.bool(False)
+process.MyNtuple.doMuons = cms.bool(False)
+process.MyNtuple.doTaus = cms.bool(False)
+process.MyNtuple.doPhotons = cms.bool(False)
+process.MyNtuple.doJets = cms.bool(False)
+process.MyNtuple.doMET = cms.bool(False)
+process.MyNtuple.doGenMET = cms.bool(False)
+process.MyNtuple.doTopJets = cms.bool(False)
+process.MyNtuple.doTrigger = cms.bool(False)
+process.MyNtuple.doL1seed = cms.bool(False)
+process.MyNtuple.doEcalBadCalib = cms.bool(False)
+process.MyNtuple.doPrefire = cms.bool(False)
+
+# Master switch for geninfo, genparticles, etc
+process.MyNtuple.doGenInfo = cms.bool(True)
+process.MyNtuple.genparticle_source = cms.InputTag("genparticles")
+process.MyNtuple.doStableGenParticles = cms.bool(False)
+
+process.MyNtuple.doGenJets = cms.bool(True)
+process.MyNtuple.genjet_sources = cms.vstring("ak4GenJets")
+process.MyNtuple.genjet_ptmin = cms.double(10.0)
+process.MyNtuple.genjet_etamax = cms.double(5.0)
+process.MyNtuple.doGenJetConstituentsNjets = cms.uint32(0) #store constituents for N leading genjets, where N is parameter
+process.MyNtuple.doGenJetConstituentsMinJetPt = cms.double(-1)
+
+process.MyNtuple.doGenTopJets = cms.bool(False)
+
+process.MyNtuple.doAllPFParticles = cms.bool(False)
+
+process.MyNtuple.doXCone = cms.bool(False)
+process.MyNtuple.doHOTVR = cms.bool(False)
+process.MyNtuple.doGenHOTVR = cms.bool(False)
+process.MyNtuple.doGenXCone = cms.bool(False)
+process.MyNtuple.doXCone_dijet = cms.bool(False)
+process.MyNtuple.doGenXCone_dijet = cms.bool(False)
+
+# Remove other modules
+rm_modules = ['prefiringweight', 'ecalBadCalibReducedMINIAODFilter', 'BadPFMuonFilter']
+for mod in rm_modules:
+    if hasattr(process, mod):
+        process.p.remove(getattr(process, mod))
+
+# Do this after setting process.source.fileNames, since we want the ability to override it on the commandline
+options = setup_opts()
+parse_apply_opts(process, options)
+
+with open('pydump_mc_2016v2.py', 'w') as f:
+    f.write(process.dumpPython())

--- a/examples/config/ExampleGenOnly.xml
+++ b/examples/config/ExampleGenOnly.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE JobConfiguration PUBLIC "" "JobConfig.dtd">
+
+<!-- OutputLevel controls which messages are printed; set to VERBOSE or DEBUG for more verbosity, to WARNING or ERROR for less -->
+<JobConfiguration JobName="ExampleCycleJob" OutputLevel="INFO">
+    <Library Name="libSUHH2examples"/>
+    <Package Name="SUHH2examples.par" />
+
+   <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="./" PostFix="" TargetLumi="1" >
+
+        <!-- Verion attribute must have year in it, same as used in ntuple config, e.g. 2018, 2016v3, etc -->
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ExampleGenOnly_2016v3" Cacheable="False">
+            <In FileName="Ntuple.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+        </InputData>
+
+        <UserConfig>
+            <!-- define which collections to read from the input. Only specify what you need to save I/O time -->
+            <Item Name="GenJetCollection" Value="ak4GenJets" />
+
+            <!-- the class name of the AnalysisModule subclasses to run: -->
+            <Item Name="AnalysisModule" Value="ExampleModuleGenOnly" />
+
+            <!-- Important, stops it from reading trigger bits etc (see AnalysisModuleRunnerImpl::begin_input_data()) -->
+            <Item Name="readTrigger" Value="false" />
+
+            <!-- tell AnalysisModuleRunner NOT to use the MC event weight from SFrame; rather let
+                 MCLumiWeight (called via CommonModules) calculate the MC event weight. The MC
+                 event weight assigned by MCLumiWeight is InputData.Lumi / Cycle.TargetLumi. -->
+            <Item Name="use_sframe_weight" Value="false" />
+
+        </UserConfig>
+    </Cycle>
+</JobConfiguration>

--- a/examples/src/ExampleModuleGenOnly.cxx
+++ b/examples/src/ExampleModuleGenOnly.cxx
@@ -1,0 +1,46 @@
+#include <iostream>
+#include <memory>
+
+#include "UHH2/core/include/AnalysisModule.h"
+#include "UHH2/core/include/Event.h"
+#include "UHH2/common/include/GenJetsHists.h"
+
+using namespace std;
+using namespace uhh2;
+
+namespace uhh2examples {
+
+/** \brief Basic analysis example of module running on GEN-only ntuples
+ * that only have GenInfo and genjets
+ * (made with core/python/ntuplewriter_mc_2016v3_GEN_ONLY.py)
+ */
+class ExampleModuleGenOnly: public AnalysisModule {
+public:
+
+    explicit ExampleModuleGenOnly(Context & ctx);
+    virtual bool process(Event & event) override;
+
+private:
+    std::unique_ptr<Hists> genjetHists;
+};
+
+
+ExampleModuleGenOnly::ExampleModuleGenOnly(Context & ctx){
+    cout << "Hello World from ExampleModuleGenOnlyGenOnly!" << endl;
+    genjetHists.reset(new GenJetsHists(ctx, "genjets"));
+}
+
+
+bool ExampleModuleGenOnly::process(Event & event) {
+    cout << "ExampleModuleGenOnly: Starting to process event (runid, eventid) = (" << event.run << ", " << event.event << "); weight = " << event.weight << endl;
+
+    for (const auto gj : *event.genjets) {
+        cout << gj.pt() << " : " << gj.eta() << " : " << gj.phi() << endl;
+    }
+    genjetHists->fill(event);
+    return true;
+}
+
+UHH2_REGISTER_ANALYSIS_MODULE(ExampleModuleGenOnly)
+
+}


### PR DESCRIPTION
Changes to make ntuplewriter work with GEN input (i.e. super minimal, only genjets). No changes to the info stored, just more checks to stop it crashing, e.g. if genparticles exist, if genjet flavour exists. Normal ntuples should be unaffected. Also adds ntuple config, and example module to test it runs + special XML option needed to bypass trigger info.

Will let it run full suite, although we don't have a GEN input to test (just to make sure normal config not affected in any way).