### PR TITLE
[102X] Use DeepBoosted V02 training

### DIFF
--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -1161,6 +1161,19 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
     )
     task.add(process.rekeyPackedPatJetsAk8PuppiJets)
 
+    # Update DeepBoosted training to V2 for everything but 2016v2
+    # Check https://twiki.cern.ch/twiki/bin/view/CMS/DeepAKXTagging for latest recommendations
+    # e.g. 2018 specific training
+    if (year != "2016v2"):
+        from RecoBTag.MXNet.pfDeepBoostedJet_cff import pfDeepBoostedJetTags, pfMassDecorrelatedDeepBoostedJetTags
+        from RecoBTag.MXNet.Parameters.V02.pfDeepBoostedJetPreprocessParams_cfi import pfDeepBoostedJetPreprocessParams as pfDeepBoostedJetPreprocessParamsV02
+        from RecoBTag.MXNet.Parameters.V02.pfMassDecorrelatedDeepBoostedJetPreprocessParams_cfi import pfMassDecorrelatedDeepBoostedJetPreprocessParams as pfMassDecorrelatedDeepBoostedJetPreprocessParamsV02
+        pfDeepBoostedJetTags.preprocessParams = pfDeepBoostedJetPreprocessParamsV02
+        pfDeepBoostedJetTags.model_path = 'RecoBTag/Combined/data/DeepBoostedJet/V02/full/resnet-symbol.json'
+        pfDeepBoostedJetTags.param_path = 'RecoBTag/Combined/data/DeepBoostedJet/V02/full/resnet-0000.params'
+        pfMassDecorrelatedDeepBoostedJetTags.preprocessParams = pfMassDecorrelatedDeepBoostedJetPreprocessParamsV02
+        pfMassDecorrelatedDeepBoostedJetTags.model_path = 'RecoBTag/Combined/data/DeepBoostedJet/V02/decorrelated/resnet-symbol.json'
+        pfMassDecorrelatedDeepBoostedJetTags.param_path = 'RecoBTag/Combined/data/DeepBoostedJet/V02/decorrelated/resnet-0000.params'
 
     ###############################################
     # Do deep flavours & deep tagging

--- a/scripts/install.csh
+++ b/scripts/install.csh
@@ -14,7 +14,7 @@ source /cvmfs/cms.cern.ch/cmsset_default.csh
 setenv SCRAM_ARCH slc6_amd64_gcc700
 set kernel=`uname -r`
 if ( "$kernel" =~ *el7* ) setenv SCRAM_ARCH slc7_amd64_gcc700
-set CMSREL=CMSSW_10_2_10
+set CMSREL=CMSSW_10_2_16
 eval `cmsrel ${CMSREL}`
 cd ${CMSREL}/src
 eval `scramv1 runtime -csh`

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -95,7 +95,7 @@ KERNEL=$(uname -r)
 if [[ "$KERNEL" == *el7* ]]; then
 	export SCRAM_ARCH=slc7_amd64_gcc700
 fi
-CMSREL=CMSSW_10_2_10
+CMSREL=CMSSW_10_2_16
 eval `cmsrel ${CMSREL}`
 cd ${CMSREL}/src
 eval `scramv1 runtime -sh`


### PR DESCRIPTION
Use V02 training for DeepBoosted classifiers. This training was derived on 94X (2017) MC, and is recommended for everything except 2016v2.

Since this is a fairly important change, I have made this PR against a new base **RunII_102X_v2** branch (which used the head of RunII_102X_v1 as the start).

This PR also requires a newer CMSSW release (gone for the latest 102X), hence changes in install.[c]sh

If in earlier CMSSW release, to avoid shifting releases, can also do:

```
cd $CMSSW_BASE
git cms-merge-topic 26370
mkdir -p $CMSSW_BASE/external/$SCRAM_ARCH/data/RecoBTag/Combined/data/DeepBoostedJet
cp -r /cvmfs/cms.cern.ch/$SCRAM_ARCH/cms/cmssw/CMSSW_10_2_15/external/$SCRAM_ARCH/data/RecoBTag/Combined/data/DeepBoostedJet/V02 $CMSSW_BASE/external/$SCRAM_ARCH/data/RecoBTag/Combined/data/DeepBoostedJet
scram build -j9
```

Note that this will checkout a load of packages, and scram b will take a while longer.

Twiki reference: https://twiki.cern.ch/twiki/bin/view/CMS/DeepAKXTagging

Validation studies currently ongoing. Let's see how the test samples behave - should see a difference in the discriminator values.

Please don't merge yet - I just wanted to start the CI tests rolling in parallel with our own studies.