### PR TITLE
[102X] Check jet resolution formula evalutaion, handle if nan

### DIFF
--- a/common/src/JetCorrections.cxx
+++ b/common/src/JetCorrections.cxx
@@ -7,6 +7,7 @@
 #include "UHH2/JetMETObjects/interface/JetCorrectorParameters.h"
 
 #include <string>
+#include <cmath>
 
 using namespace std;
 using namespace uhh2;
@@ -1088,6 +1089,16 @@ float GenericJetResolutionSmearer::getResolution(float eta, float rho, float pt)
   if(valid){
     res_formula->SetParameters(par0,par1,par2,par3);
     resolution = res_formula->Eval(pt);
+    if (isnan(resolution)) {
+      // resolution can be nan if bad formula parameters
+      if (fabs(eta) > 2.3 && pt < 30) { // leniency in this problematic region hopefully fixed in future version of JER
+        cout << "WARNING: GenericJetResolutionSmearer::getResolution() evaluated to nan. Since this jet is in problematic region, it will instead be set to 0." << endl;
+        cout << "Input eta : rho : pt = " << eta << " : " << rho << ": " << pt << endl;
+        resolution = 0.;
+      } else {
+        throw std::runtime_error("GenericJetResolutionSmearer::getResolution() evaluated to nan. Input eta : rho : pt = " + double2string(eta) + " : " + double2string(rho) + " : " + double2string(pt));
+      }
+    }
   }
 
   return resolution;


### PR DESCRIPTION
Has been observed that sometimes the evaluation of the jet energy resolution can be broken and return nan. This then turns the jet pT = nan. Which then screws up cuts etc.

This so far has only been observed for low pt jets in the endcap in 2017 (using Fall17 V3 JER). For now, since endcap low pT is so problematic, we set resolution to 0 and carry on - these jets will probably be removed by cuts in the user's analysis later anyway.

For higher pT or non-endcap jets, throw, because we really don't expect it.

Hopefully this gets fixed in the next set of JERs, at which point we can remove the endcap exemption.

[only compile]


For future reference:
observed in /pnfs/desy.de/cms/tier2/store/user/pgunnell/RunII_102X_v1/QCD_Pt_30to50_TuneCP5_13TeV_pythia8/crab_QCD_Pt_30to50_TuneCP5_13TeV_pythia8/190611_143212/0001/Ntuple_1223.root

in event 13600103 using AK4 PUPPI jets

```
jet1: 16.333 : 2.80057 : 0.696603
jet2: 15.5082 : 2.84979 : -1.80765
genjet1: 33.7026 : 2.44389 : 0.860694
genjet2: 19.0163 : 2.54877 : -2.72455
```

e.g. for the first jet,

```
eta : rho : pt = 2.80057 : 38.626 : 16.333
par0: -18.52
par1: 11.51
par2: -0.03733
par3: -1.663
          res_formula : sqrt([0]*abs([0])/(x*x)+[1]*[1]*pow(x,[3])+[2]*[2]) Ndim= 1, Npar= 4, Number= 0
 Formula expression:
	sqrt([p0]*abs([p0])/(x*x)+[p1]*[p1]*pow(x,[p3])+[p2]*[p2])
resolution eval: -nan
```
