### PR TITLE
[102X] Fixed small bugs

### DIFF
--- a/common/datasets/RunII_102X_v1/2016v3/MC_WWToLNuQQ.xml
+++ b/common/datasets/RunII_102X_v1/2016v3/MC_WWToLNuQQ.xml
@@ -358,7 +358,7 @@
 <In FileName="/pnfs/desy.de/cms/tier2/store/user/anmalara/RunII_102X_v1/2016v3/WWToLNuQQ_13TeV-powheg/crab_WWToLNuQQ_13TeV-powheg_Summer16_ext1_v2/190625_141329/0000/Ntuple_95.root" Lumi="0.0"/>
 <In FileName="/pnfs/desy.de/cms/tier2/store/user/anmalara/RunII_102X_v1/2016v3/WWToLNuQQ_13TeV-powheg/crab_WWToLNuQQ_13TeV-powheg_Summer16_ext1_v2/190625_141329/0000/Ntuple_96.root" Lumi="0.0"/>
 <In FileName="/pnfs/desy.de/cms/tier2/store/user/anmalara/RunII_102X_v1/2016v3/WWToLNuQQ_13TeV-powheg/crab_WWToLNuQQ_13TeV-powheg_Summer16_ext1_v2/190625_141329/0000/Ntuple_97.root" Lumi="0.0"/>
-<IE FileName="/pnfs/desy.de/cms/tier2/store/user/anmalara/RunII_102X_v1/2016v3/WWToLNuQQ_13TeV-powheg/crab_WWToLNuQQ_13TeV-powheg_Summer16_ext1_v2/190625_141329/0000/Ntuple_98.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2/store/user/anmalara/RunII_102X_v1/2016v3/WWToLNuQQ_13TeV-powheg/crab_WWToLNuQQ_13TeV-powheg_Summer16_ext1_v2/190625_141329/0000/Ntuple_98.root" Lumi="0.0"/>
 <In FileName="/pnfs/desy.de/cms/tier2/store/user/anmalara/RunII_102X_v1/2016v3/WWToLNuQQ_13TeV-powheg/crab_WWToLNuQQ_13TeV-powheg_Summer16_ext1_v2/190625_141329/0000/Ntuple_99.root" Lumi="0.0"/>
 <!-- < NumberEntries="1999200" Method=fast /> -->
 <!-- < NumberEntries="6655400" Method=fast /> -->

--- a/common/src/CommonModules.cxx
+++ b/common/src/CommonModules.cxx
@@ -262,7 +262,7 @@ void CommonModules::print_setup() const {
     {"JECs", jec},
     {"JER smearing", jersmear},
     {"Jet-Lepton cleaning", jetlepcleaner},
-    {"MET Type-1 corrections", do_metcorrection},
+    {"MET Type-1 corrections", ((jetlepcleaner && jec) || (do_metcorrection && jec))},
     {"MET filters", metfilters},
     {"PV filter", pvfilter},
     {"Jet pT sorting", jetptsort},


### PR DESCRIPTION
 [only  compile]

- Removed stray letter in one WW -> LNuQQ sample that caused sframe to break

- The 'MET Type-1 corrections' printout from CommonModules now prints the value of the bool that actually decides if type-1 corrections are applied or not. The previously used 'do_metcorrections' bool is only used to enforce type-1 correction if no jet-lepton cleaning is performed.

