### PR TITLE
[102X] set JER MCTruth to 0 for all jets with pt<35 in 2017

### DIFF
--- a/common/src/JetCorrections.cxx
+++ b/common/src/JetCorrections.cxx
@@ -1162,7 +1162,8 @@ float GenericJetResolutionSmearer::getResolution(float eta, float rho, float pt)
     resolution = res_formula->Eval(pt);
     if (isnan(resolution)) {
       // resolution can be nan if bad formula parameters
-      if (fabs(eta) > 2.3 && pt < 30) { // leniency in this problematic region hopefully fixed in future version of JER
+      //      if (fabs(eta) > 2.3 && pt < 30) { // leniency in this problematic region hopefully fixed in future version of JER
+      if (pt < 35) { // leniency in this problematic region hopefully fixed in future version of JER
         cout << "WARNING: GenericJetResolutionSmearer::getResolution() evaluated to nan. Since this jet is in problematic region, it will instead be set to 0." << endl;
         cout << "Input eta : rho : pt = " << eta << " : " << rho << ": " << pt << endl;
         resolution = 0.;


### PR DESCRIPTION
Unfortunately 2017 JER MCTruth issue presented for PUPPI jets in the barrel too. Therefore eta cut removed from definition of the "bad" region and pt cut is extended a bit to cover all cases found with ZprimeToTTbar signal samples.