### PR TITLE
[102X] Reorder CommonModule process so returns go last

### DIFF
--- a/common/src/CommonModules.cxx
+++ b/common/src/CommonModules.cxx
@@ -168,14 +168,9 @@ bool CommonModules::process(uhh2::Event & event){
   if(!init_done){
     throw runtime_error("CommonModules::init not called (has to be called in AnalysisModule constructor)");
   }
-  if(event.isRealData && lumisel){
-    if(!lumi_selection->passes(event)) return false;
-  }
+
   for(auto & m : modules){
     m->process(event);
-  }
-  if(metfilters){
-    if(!metfilters_selection->passes(event)) return false;
   }
 
   if(jetlepcleaner){
@@ -215,6 +210,18 @@ bool CommonModules::process(uhh2::Event & event){
   if(jetptsort){
     sort_by_pt(*event.jets);
   }
+
+  // Put the return parts last, such that every other modifying module always runs
+  // This avoids bugs where this function is exited early, but the user expects
+  // the other modules to always run
+  if(event.isRealData && lumisel){
+    if(!lumi_selection->passes(event)) return false;
+  }
+
+  if(metfilters){
+    if(!metfilters_selection->passes(event)) return false;
+  }
+
   return true;
 }
 

--- a/examples/src/ExampleModule.cxx
+++ b/examples/src/ExampleModule.cxx
@@ -99,9 +99,12 @@ bool ExampleModule::process(Event & event) {
     cout << "ExampleModule: Starting to process event (runid, eventid) = (" << event.run << ", " << event.event << "); weight = " << event.weight << endl;
     
     // 1. run all modules other modules.
-    common->process(event);
+    // Note that it returns a bool, that may be False
+    // (e.g. Golden JSON, MET filters), and therefore user should return early
+    bool commonResult = common->process(event);
+    if (!commonResult) return false;
     jetcleaner->process(event);
-    
+
     // 2. test selections and fill histograms
     h_ele->fill(event);
     h_nocuts->fill(event);


### PR DESCRIPTION
This ensures that all modules are always run, irrespective of the modules that return.

This fixes bugs where the user ignored the return value, but expected (fairly) that other modules were run.

This also updates the ExampleModule to show that users should be using the return bool

[only compile]