### PR TITLE
[102v2] Add CMSSW packages for JEC/R

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -112,6 +112,9 @@ time git cms-init -y  # not needed if not addpkg ing
 
 # Necessary for using our FastJet
 time git cms-addpkg RecoJets/JetProducers
+# For JetCorrector, JetResolution objects
+time git cms-addpkg CondFormats/JetMETObjects
+time git cms-addpkg JetMETCorrections/Modules
 
 # Update FastJet and contribs for HOTVR and UniversalJetCluster
 FJINSTALL=$(fastjet-config --prefix)


### PR DESCRIPTION
For future use, we will be moving to use the centralised CMSSW objects, rather than our copied versions. This should bring us totally in line with CMSSW.

This is just doing addpkg to allow people to use branch with less faff later on, nothing actually uses these yet.

 [only compile]