### PR TITLE
[106X] Update setup so it compiles

### DIFF
--- a/core/plugins/NtupleWriterJets.h
+++ b/core/plugins/NtupleWriterJets.h
@@ -4,7 +4,7 @@
 #include "DataFormats/PatCandidates/interface/Jet.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/ESHandle.h"
-#include "CommonTools/Utils/interface/TMVAEvaluator.h"
+#include "CommonTools/MVAUtils/interface/TMVAEvaluator.h"
 #include "RecoBTau/JetTagComputer/interface/JetTagComputer.h"
 #include "DataFormats/JetReco/interface/JetCollection.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"

--- a/scripts/install.csh
+++ b/scripts/install.csh
@@ -11,9 +11,15 @@ set MAKEFLAGS="-j${cores}"
 
 # Get CMSSW
 source /cvmfs/cms.cern.ch/cmsset_default.csh
-setenv SCRAM_ARCH slc6_amd64_gcc700
+setenv SCRAM_ARCH slc7_amd64_gcc700
 set kernel=`uname -r`
-if ( "$kernel" =~ *el7* ) setenv SCRAM_ARCH slc7_amd64_gcc700
+if ( "$kernel" =~ *el7* ) then
+    :
+else
+    echo "This release requires an EL7 machine, e.g. naf-cms-el7.desy.de"
+    echo "Please log into one and run this again"
+    exit 1
+endif
 set CMSREL=CMSSW_10_6_5
 eval `cmsrel ${CMSREL}`
 cd ${CMSREL}/src

--- a/scripts/install.csh
+++ b/scripts/install.csh
@@ -100,7 +100,7 @@ time scram b $MAKEFLAGS
 
 # Get the UHH2 repo & JEC,JER files
 cd ${CMSSW_BASE}/src
-git clone -b RunII_102X_v2 https://github.com/UHH2/UHH2.git
+git clone -b RunII_106X_v1 https://github.com/UHH2/UHH2.git
 cd UHH2
 git clone https://github.com/cms-jet/JECDatabase.git
 git clone https://github.com/cms-jet/JRDatabase.git

--- a/scripts/install.csh
+++ b/scripts/install.csh
@@ -14,7 +14,7 @@ source /cvmfs/cms.cern.ch/cmsset_default.csh
 setenv SCRAM_ARCH slc6_amd64_gcc700
 set kernel=`uname -r`
 if ( "$kernel" =~ *el7* ) setenv SCRAM_ARCH slc7_amd64_gcc700
-set CMSREL=CMSSW_10_2_16
+set CMSREL=CMSSW_10_6_5
 eval `cmsrel ${CMSREL}`
 cd ${CMSREL}/src
 eval `scramv1 runtime -csh`

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -95,7 +95,7 @@ KERNEL=$(uname -r)
 if [[ "$KERNEL" == *el7* ]]; then
 	export SCRAM_ARCH=slc7_amd64_gcc700
 fi
-CMSREL=CMSSW_10_2_16
+CMSREL=CMSSW_10_6_5
 eval `cmsrel ${CMSREL}`
 cd ${CMSREL}/src
 eval `scramv1 runtime -sh`

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -83,6 +83,34 @@ setupFastjet() {
 	cd ..
 }
 
+checkArch() {
+	# Check if this machine is compatible, because at DESY the default is SL6,
+	# whereas we need EL7
+	# Note that lxplus machines have uname e.g. 3.10.0-1062.4.1.el7.x86_64
+	# so just checking for el7 is OK
+	# To complicate matters, we need to handle gitlab CI as well,
+	# however there uname is useless, it just gives e.g. 4.19.68-coreos. 
+	# Instead we must rely on the IMAGE variable that we set in .gitlab-ci.yml
+	# (yes that is a horrible dependence)
+	if [ -n "$IMAGE" ]
+	then
+		# here is on gitlab CI
+		if [[ "$IMAGE" != *cc7* ]]; then
+			echo "This release requires a CC7 image"
+			echo "Please update .gitlab-ci.yml and/or testPR.sh and run this again"
+			exit 1
+		fi
+	else
+		# here is normal running e.g. on NAF
+		KERNEL=$(uname -r)
+		if [[ "$KERNEL" != *el7* ]]; then
+			echo "This release requires an EL7 machine, e.g. naf-cms-el7.desy.de"
+			echo "Please log into one and run this again"
+			exit 1
+		fi
+	fi
+}
+
 source /cvmfs/cms.cern.ch/cmsset_default.sh
 
 # Get SFrame, do not compile it until we have the right ROOT etc
@@ -90,16 +118,7 @@ time git clone https://github.com/UHH2/SFrame.git
 
 # Get CMSSW
 export SCRAM_ARCH=slc7_amd64_gcc700
-KERNEL=$(uname -r)
-# Check if this machine is compatible, because at DESY the default is SL6,
-# whereas we need EL7
-# Note that lxplus machines have uname e.g. 3.10.0-1062.4.1.el7.x86_64
-# so just checking for el7 is OK
-if [[ "$KERNEL" != *el7* ]]; then
-    echo "This release requires an EL7 machine, e.g. naf-cms-el7.desy.de"
-    echo "Please log into one and run this again"
-    exit 1
-fi
+checkArch
 CMSREL=CMSSW_10_6_5
 eval `cmsrel ${CMSREL}`
 cd ${CMSREL}/src

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -89,11 +89,16 @@ source /cvmfs/cms.cern.ch/cmsset_default.sh
 time git clone https://github.com/UHH2/SFrame.git
 
 # Get CMSSW
-export SCRAM_ARCH=slc6_amd64_gcc700
+export SCRAM_ARCH=slc7_amd64_gcc700
 KERNEL=$(uname -r)
-# Update for EL7 (i.e. CC7/SL7) - should work for lxplus and NAF EL7 machines
-if [[ "$KERNEL" == *el7* ]]; then
-	export SCRAM_ARCH=slc7_amd64_gcc700
+# Check if this machine is compatible, because at DESY the default is SL6,
+# whereas we need EL7
+# Note that lxplus machines have uname e.g. 3.10.0-1062.4.1.el7.x86_64
+# so just checking for el7 is OK
+if [[ "$KERNEL" != *el7* ]]; then
+    echo "This release requires an EL7 machine, e.g. naf-cms-el7.desy.de"
+    echo "Please log into one and run this again"
+    exit 1
 fi
 CMSREL=CMSSW_10_6_5
 eval `cmsrel ${CMSREL}`

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -141,7 +141,7 @@ time scram b $MAKEFLAGS
 
 # Get the UHH2 repo & JEC,JER files
 cd $CMSSW_BASE/src
-time git clone -b RunII_102X_v2 https://github.com/UHH2/UHH2.git
+time git clone -b RunII_106X_v1 https://github.com/UHH2/UHH2.git
 cd UHH2
 time git clone https://github.com/cms-jet/JECDatabase.git
 time git clone https://github.com/cms-jet/JRDatabase.git


### PR DESCRIPTION
- Used latest 10_6_X release (was 10_6_1)

- Now checks system architecture and exits if you are on an incompatible machine, since 10_6_X now requires EL7

Let's see if this compiles on gitlab - may require some tweaks...

[only compile] for now as no configs