### PR TITLE
[106X] updated YearSwitcher and Utils to work with UL samples

### DIFF
--- a/common/include/Utils.h
+++ b/common/include/Utils.h
@@ -101,7 +101,9 @@ enum class Year {
     is2016v3,
     is2017v1,
     is2017v2,
-    is2018
+		is2017UL,
+		is2018,
+		is2018UL
 };
 
 /* Map from Year to string */
@@ -110,6 +112,8 @@ const std::map<Year, std::string> year_str_map = {
     {Year::is2016v3, "2016v3"},
     {Year::is2017v1, "2017v1"},
     {Year::is2017v2, "2017v2"},
+		{Year::is2017UL, "2017UL"},
+    {Year::is2018UL, "2018UL"},
     {Year::is2018,   "2018"},
 };
 // TODO: inverse map?

--- a/common/include/Utils.h
+++ b/common/include/Utils.h
@@ -102,8 +102,8 @@ enum class Year {
     is2017v1,
     is2017v2,
     is2017UL,
-    is2018,
-    is2018UL
+    is2018UL,
+    is2018
 };
 
 /* Map from Year to string */

--- a/common/include/Utils.h
+++ b/common/include/Utils.h
@@ -101,9 +101,9 @@ enum class Year {
     is2016v3,
     is2017v1,
     is2017v2,
-		is2017UL,
-		is2018,
-		is2018UL
+    is2017UL,
+    is2018,
+    is2018UL
 };
 
 /* Map from Year to string */
@@ -112,7 +112,7 @@ const std::map<Year, std::string> year_str_map = {
     {Year::is2016v3, "2016v3"},
     {Year::is2017v1, "2017v1"},
     {Year::is2017v2, "2017v2"},
-		{Year::is2017UL, "2017UL"},
+    {Year::is2017UL, "2017UL"},
     {Year::is2018UL, "2018UL"},
     {Year::is2018,   "2018"},
 };

--- a/common/include/YearRunSwitchers.h
+++ b/common/include/YearRunSwitchers.h
@@ -45,8 +45,10 @@ public:
   void setup2017(std::shared_ptr<uhh2::AnalysisModule> module);
   void setup2017v1(std::shared_ptr<uhh2::AnalysisModule> module);
   void setup2017v2(std::shared_ptr<uhh2::AnalysisModule> module);
+  void setup2017UL(std::shared_ptr<uhh2::AnalysisModule> module);
 
   void setup2018(std::shared_ptr<uhh2::AnalysisModule> module);
+  void setup2018UL(std::shared_ptr<uhh2::AnalysisModule> module);
 
 private:
   Year year_;
@@ -56,8 +58,8 @@ private:
   // shared_ptr, because the user might already own it, and we want to ensure
   // it is kept alive, or deleted as necessary if this is the only owner
   std::shared_ptr<uhh2::AnalysisModule> module2016_, module2016v2_, module2016v3_;
-  std::shared_ptr<uhh2::AnalysisModule> module2017_, module2017v1_, module2017v2_;
-  std::shared_ptr<uhh2::AnalysisModule> module2018_;
+  std::shared_ptr<uhh2::AnalysisModule> module2017_, module2017v1_, module2017v2_, module2017UL_;
+  std::shared_ptr<uhh2::AnalysisModule> module2018_, module2018UL_;
   std::shared_ptr<uhh2::AnalysisModule> theModule_;
 
 };

--- a/common/src/YearRunSwitchers.cxx
+++ b/common/src/YearRunSwitchers.cxx
@@ -161,5 +161,9 @@ void RunSwitcher::setupRun(const std::string & runPeriod, std::shared_ptr<uhh2::
 
 std::string RunSwitcher::shortYear(const std::string & year) {
   // sanitise year, chop off any v*
-  return year.substr(0, year.find("v"));
+  if (year.find("UL") != std::string::npos) {
+    return year.substr(0, year.find("UL"));
+  } else {
+    return year.substr(0, year.find("v"));
+  }
 }

--- a/common/src/YearRunSwitchers.cxx
+++ b/common/src/YearRunSwitchers.cxx
@@ -10,7 +10,9 @@ YearSwitcher::YearSwitcher(const uhh2::Context & ctx):
   module2017_(nullptr),
   module2017v1_(nullptr),
   module2017v2_(nullptr),
+  module2017UL_(nullptr),
   module2018_(nullptr),
+  module2018UL_(nullptr),
   theModule_(nullptr)
 {}
 
@@ -40,11 +42,17 @@ bool YearSwitcher::process(uhh2::Event & event) {
     else if ((year_ == Year::is2017v2) && module2017v2_) {
       theModule_ = module2017v2_;
     }
-    else if ((year_ == Year::is2017v1 || year_ == Year::is2017v2) && module2017_) {
+    else if ((year_ == Year::is2017UL) && module2017UL_) {
+      theModule_ = module2017UL_;
+    }
+    else if ((year_ == Year::is2017v1 || year_ == Year::is2017v2 || year_ == Year::is2017UL) && module2017_) {
       theModule_ = module2017_;
     }
 
-    else if ((year_ == Year::is2018) && module2018_) {
+    else if ((year_ == Year::is2018UL) && module2018UL_) {
+      theModule_ = module2018UL_;
+    }
+    else if ((year_ == Year::is2018 || year_ == Year::is2018UL) && module2018_) {
       theModule_ = module2018_;
     }
     doneInit_ = true;
@@ -84,8 +92,16 @@ void YearSwitcher::setup2017v2(std::shared_ptr<uhh2::AnalysisModule> module) {
   module2017v2_ = module;
 }
 
+void YearSwitcher::setup2017UL(std::shared_ptr<uhh2::AnalysisModule> module) {
+  module2017UL_ = module;
+}
+
 void YearSwitcher::setup2018(std::shared_ptr<uhh2::AnalysisModule> module) {
   module2018_ = module;
+}
+
+void YearSwitcher::setup2018UL(std::shared_ptr<uhh2::AnalysisModule> module) {
+  module2018UL_ = module;
 }
 
 


### PR DESCRIPTION
This adds the UL years (corresponding to the changes in `ntuple_generator.py` for UL samples) to `Util.h` and to the `YearSwitcher`.

[only compile]
