### PR TITLE
[102Xv1] Add C++ ROOT macro to do weighted event counting for speedup

### DIFF
--- a/scripts/crab/countNumberEvents.C
+++ b/scripts/crab/countNumberEvents.C
@@ -1,0 +1,62 @@
+#include <iostream>
+#include <vector>
+#include <iomanip>      // std::setprecision
+
+#include "TFile.h"
+#include "TTree.h"
+#include "TTreeReader.h"
+#include "TTreeReaderValue.h"
+#include "TTreeReaderArray.h"
+
+#include "UHH2/core/include/GenInfo.h"
+
+using namespace std;
+
+/**
+ * Standalone utility to count number of events in a Ntuple tree.
+ *
+ * ignoreWeights: true to ignore event weights, false to sum over them
+ *
+ * Should ONLY print number of events...although ROOT also prints gubbins
+ * Done in C++ for speed (neccessary when iterating over all events in tree)
+ *
+ * Run:
+ * root -q -b 'countNumberEvents.C+("/a/b/c.root",false)'
+ *
+ * DO NOT PUT SPACES INBETWEEN ARGS
+ *
+ * root:
+ * > .x countNumberEvents("/a/b/c.root", false)
+ *
+ * In a bash script with args $1, $2:
+ *
+ * root -q -b -l 'countNumberEvents.C+("'${1}'",'${2}')'
+ */
+
+void countNumberEvents(string filename, bool ignoreWeights) {
+  TFile * f = TFile::Open(filename.c_str());
+  if (f == nullptr || f->IsZombie()) {
+    throw std::runtime_error("Cannot open " + filename);
+  }
+  TTree * tree = (TTree*) f->Get("AnalysisTree");
+  if (tree == nullptr || tree->IsZombie()) {
+    throw std::runtime_error("Cannot get TTree");
+  }
+  if (ignoreWeights) {
+    cout << tree->GetEntriesFast() << endl;
+  } else {
+    TTreeReader reader(tree);
+    TTreeReaderValue<GenInfo> genInfo(reader, "genInfo");
+    double sum = 0.; // MUST be double otherwise loses precision
+    while (reader.Next()) {
+      // yes I should do a check here, but the ROOT example doesn't work so bah
+      sum += genInfo->weights()[0];
+    }
+    cout << setprecision(9) << sum << endl;
+  }
+  f->Close();
+}
+
+int main(int argc, char * argv[]){
+  countNumberEvents(argv[0], bool(argv[1]));
+}


### PR DESCRIPTION
When counting number of weighted events, now use C++ macro instead of PyROOT, since the latter is super slow.

The macro can also be used standalone.

e.g. on `/pnfs/desy.de/cms/tier2/store/user/pgunnell/RunII_102X_v1/ZZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8/crab_ZZTo2L2Q_13TeV_powheg_pythia8/190724_111935/0000/Ntuple_644.root`

it takes ~2s with C++ macro, ~12s with PyROOT

[ci skip]
