### PR TITLE
[102Xv1] Clone UHH2-datasets repo as part of install script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -141,3 +141,9 @@ cd $CMSSW_BASE/src
 time git clone -b RunII_102X_v1 https://github.com/UHH2/UHH2.git
 cd UHH2
 time git clone https://github.com/cms-jet/JECDatabase.git
+cd common
+time git clone https://github.com/UHH2/UHH2-datasets.git
+cd UHH2-datasets
+git remote rename origin UHH2
+git branch -u UHH2/master
+cd ../..


### PR DESCRIPTION
Clone the UHH2-datasets repo as part of the standard install

(Probably should remove the common/datasets dir at some point, but may cause issues for people who havent pulled in a while?)

[only compile]

