### PR TITLE
[102X] fix bug in MCPileupReweight

### DIFF
--- a/common/src/MCWeight.cxx
+++ b/common/src/MCWeight.cxx
@@ -44,8 +44,10 @@ bool MCLumiWeight::process(uhh2::Event & event){
 
 MCPileupReweight::MCPileupReweight(Context & ctx, const std::string & sysType):
     h_pu_weight_(ctx.declare_event_output<float>("weight_pu")),
-    h_npu_data_up(ctx.declare_event_output<float>("weight_pu_down")),
-    h_npu_data_down(ctx.declare_event_output<float>("weight_pu_up")),
+    h_pu_weight_up_(ctx.declare_event_output<float>("weight_pu_down")),
+    h_pu_weight_down_(ctx.declare_event_output<float>("weight_pu_up")),
+    h_npu_data_up(0),
+    h_npu_data_down(0),
     sysType_(sysType)
 {
     auto dataset_type = ctx.get("dataset_type");

--- a/common/src/MCWeight.cxx
+++ b/common/src/MCWeight.cxx
@@ -44,8 +44,8 @@ bool MCLumiWeight::process(uhh2::Event & event){
 
 MCPileupReweight::MCPileupReweight(Context & ctx, const std::string & sysType):
     h_pu_weight_(ctx.declare_event_output<float>("weight_pu")),
-    h_npu_data_up(0),
-    h_npu_data_down(0),
+    h_npu_data_up(ctx.declare_event_output<float>("weight_pu_down")),
+    h_npu_data_down(ctx.declare_event_output<float>("weight_pu_up")),
     sysType_(sysType)
 {
     auto dataset_type = ctx.get("dataset_type");
@@ -113,7 +113,6 @@ MCPileupReweight::MCPileupReweight(Context & ctx, const std::string & sysType):
         {
             throw runtime_error("MCPileupReweight: pile-up histograms for data_up and MC have different axis ranges");
         }
-        h_pu_weight_up_ = ctx.declare_event_output<float>("weight_pu_up");
     }
     if (pileup_directory_data_down.length()) {
         TFile file_data_down(locate_file(pileup_directory_data_down).c_str());
@@ -128,7 +127,6 @@ MCPileupReweight::MCPileupReweight(Context & ctx, const std::string & sysType):
         {
             throw runtime_error("MCPileupReweight: pile-up histograms for data_down and MC have different axis ranges");
         }
-        h_pu_weight_down_ = ctx.declare_event_output<float>("weight_pu_down");
     }
 }
 


### PR DESCRIPTION
[only compile]
fix a bug, where MCPileupReweight crashed, when the module was ran, without using up/down variation files