### PR TITLE
[106Xv1] Port of #1488: added binary score for DeepBosted ZHbbvsQCD

### DIFF
--- a/core/include/TopJet.h
+++ b/core/include/TopJet.h
@@ -201,6 +201,7 @@ public:
   float btag_DeepBoosted_WvsQCD() const{return m_btag_DeepBoosted_WvsQCD;}
   float btag_DeepBoosted_ZvsQCD() const{return m_btag_DeepBoosted_ZvsQCD;}
   float btag_DeepBoosted_ZbbvsQCD() const{return m_btag_DeepBoosted_ZbbvsQCD;}
+  float btag_DeepBoosted_ZHbbvsQCD() const{return (m_btag_DeepBoosted_probZbb+m_btag_DeepBoosted_probHbb)/(m_btag_DeepBoosted_probZbb+m_btag_DeepBoosted_probHbb+btag_DeepBoosted_raw_score_qcd());}
   float btag_DeepBoosted_HbbvsQCD() const{return m_btag_DeepBoosted_HbbvsQCD;}
   float btag_DeepBoosted_H4qvsQCD() const{return m_btag_DeepBoosted_H4qvsQCD;}
 


### PR DESCRIPTION
(cherry picked from commit 7b99c97329e1a111d6d74ada065d37e560cb814c)

Port of #1488

[only compile]
