### PR TITLE
[102Xv2] Remove calls to getUsernameFromSiteDB, which no longer exists and is not needed

### DIFF
--- a/scripts/crab/CrabScript.py
+++ b/scripts/crab/CrabScript.py
@@ -3,7 +3,7 @@
 from CRABAPI.RawCommand import crabCommand
 from CRABClient.ClientExceptions import ClientException
 from httplib import HTTPException
-from CRABClient.UserUtilities import config, getUsernameFromSiteDB
+from CRABClient.UserUtilities import config
 
 from multiprocessing import Process
 

--- a/scripts/crab/crab_template.py
+++ b/scripts/crab/crab_template.py
@@ -107,8 +107,10 @@ year = result.group()
 config.Data.outLFNDirBase = '/store/group/uhh/uhh2ntuples/RunII_102X_v2/%s/' % (year)
 
 # If you want to run some private production and not put it in the group area, use this instead:
-# from CRABClient.UserUtilities import getUsernameFromSiteDB
-# config.Data.outLFNDirBase = '/store/user/%s/RunII_102X_v1/%s/' % (getUsernameFromSiteDB(), year)
+# replacing YOUR_CERN_USERNAME_HERE as appropriate
+# config.Data.outLFNDirBase = '/store/user/YOUR_CERN_USERNAME_HERE/RunII_102X_v2/%s/' % (year)
+if 'YOUR_CERN_USERNAME_HERE' in config.Data.outLFNDirBase:
+    raise RuntimeError("You didn't insert your CERN username in config.Data.outLFNDirBase, please fix it")
 
 config.Data.publication = False
 config.JobType.sendExternalFolder = True


### PR DESCRIPTION
`getUsernameFromSiteDB()` doesn't exist (note: there is a workaround: https://hypernews.cern.ch/HyperNews/CMS/get/computing-tools/5591/2/1/1/1/2/1/1/1.html)

Now add comment to crab template about specifying username in output dir, with a check the user actually did it

[ci skip]

