### PR TITLE
[102Xv2] Add extra bits to make the LHERunInfoProduct in beginRun() usable

### DIFF
--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -574,6 +574,8 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
     genparticle_token = consumes<reco::GenParticleCollection>(iConfig.getParameter<edm::InputTag>("genparticle_source"));
     generator_token = consumes<GenEventInfoProduct>( edm::InputTag("generator"));
     lhe_token = consumes<LHEEventProduct> ( edm::InputTag("externalLHEProducer"));
+    // this one is necessary to read the LHERunInfoProduct:
+    consumes<LHERunInfoProduct, edm::InRun>({"externalLHEProducer"});
     pus_token = consumes<std::vector<PileupSummaryInfo> > ( edm::InputTag("slimmedAddPileupInfo"));
     if(doStableGenParticles) stablegenparticle_token = consumes<edm::View<reco::Candidate> >(iConfig.getParameter<edm::InputTag>("stablegenparticle_source"));
     event->genInfo = new GenInfo();

--- a/core/plugins/NtupleWriter.h
+++ b/core/plugins/NtupleWriter.h
@@ -7,6 +7,7 @@
 #include "FWCore/Framework/interface/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/Run.h"
 
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "DataFormats/JetReco/interface/GenJet.h"


### PR DESCRIPTION
Missing bits to make the LHERunInfoProduct dump in `beginRun()` work correctly.

Otherwise get this error:

```
::getByLabel: An attempt was made to read a Run product before endRun() was called.
The product is of type 'LHERunInfoProduct'.
The specified ModuleLabel was 'externalLHEProducer'.
The specified productInstanceName was ''.
%MSG
----- Begin Fatal Exception 04-Jun-2020 13:27:25 CEST-----------------------
An exception of category 'ProductNotFound' occurred while
   [0] Processing global begin Run run: 1
   [1] Calling method for module NtupleWriter/'MyNtuple'
Exception Message:
Principal::getByLabel: Found zero products matching all criteria
Looking for type: LHERunInfoProduct
Looking for module label: externalLHEProducer
Looking for productInstanceName: 
```

Note that for some reason `edmDumpEventContent` doesn't show the `LHERunInfoProduct`, only `LHEEventProduct` type for `externalLHEProducer`, so it must do some sort of magic unpacking.

[only compile] since it doesn't affect ntuple content/classes