### PR TITLE
[102X] Add checking for 'TTTo' in ttbar file name in TopPtReweight

### DIFF
--- a/common/src/TopPtReweight.cxx
+++ b/common/src/TopPtReweight.cxx
@@ -31,7 +31,7 @@ TopPtReweight::TopPtReweight(uhh2::Context& ctx,
 
 
 bool TopPtReweight::process(uhh2::Event& event){
-  if (event.isRealData || (!boost::algorithm::contains(version_,"ttbar") && !boost::algorithm::contains(version_,"ttjets")) ) {
+  if (event.isRealData || (!boost::algorithm::contains(version_,"ttbar") && !boost::algorithm::contains(version_,"ttjets") && !boost::algorithm::starts_with(version_,"ttto")) ) {
     return true;
   }
   const TTbarGen& ttbargen = !ttgen_name_.empty() ? event.get(h_ttbargen_) : TTbarGen(*event.genparticles,false);


### PR DESCRIPTION
 [only @ compile]

added another check to the list of possible names for ttbar samples.
In 2017 and 2018 the ttbar samples usually are named "TTTo[...]", which was not captured before.
Now it checks if the name starts with "TTTo"