### PR TITLE
[102Xv2] Add scripts to create CRAB jobs for missing files

### DIFF
--- a/scripts/commentOutBadXML.sh
+++ b/scripts/commentOutBadXML.sh
@@ -1,0 +1,45 @@
+#!/bin/bash -e
+#
+# Create a copy of an XML file,
+# commenting out any filepath in a list of "bad" files
+#
+# Usage:
+#
+#   ./comment_out_bad_XML.sh <XML filename> <txt file with list>
+#
+
+set -u
+
+XML="$1"
+BADLIST="$2"
+
+if [ -z $XML ]; then
+    echo "Missing XML filename"
+    exit 1
+fi
+
+if [ -z $BADLIST ]; then
+    echo "Missing bad list filename"
+    exit 1
+fi
+
+newfile=${XML/.xml/_nobad.xml}
+if [ -f $newfile ]; then
+    rm $newfile
+fi
+
+while IFS= read -r line
+do
+    filename=${line#*/pnfs}
+    filename=${filename%\" Lumi=\"0.0\"/>}
+    filename="/pnfs$filename"
+    filename=${filename//\/\//\/}  # convert // to /, assumes BADLIST doesn't have them
+    if grep -q "$filename" "$BADLIST"; then
+        echo "Found bad $filename"
+        echo "<!-- BAD $line -->" >> $newfile
+    else
+        echo $line >> $newfile
+    fi
+done < "$XML"
+
+echo "Written updated file $newfile"

--- a/scripts/crab/DasQuery.py
+++ b/scripts/crab/DasQuery.py
@@ -1,29 +1,50 @@
 #!/usr/bin/env python
 
+
+from __future__ import print_function
+
 import json
 import sys
-
+from subprocess import call
 from Utilities.General.cmssw_das_client import get_data
 
+
+def check_voms():
+    """Checks if the user has a valid VOMS proxy, returns True if so, False otherwise"""
+    cmd = "voms-proxy-info -e"
+    return_code = call(cmd.split())
+    if return_code != 0:
+        print("You need a valid voms proxy. Please run:")
+        print("")
+        print("    voms-proxy-init -voms cms")
+        print("")
+        return False
+    return True
+
+
 def autocomplete_Datasets(data):
+    """Ask DAS to auto-complete dataset names
+
+    data: list[str] of dataset names, can include wildcards
+    """
     result_array =[]
 
     for element in data:
         if '*' in element:
             jsondict = get_data(host='https://cmsweb.cern.ch',query="dataset="+element,idx=0,limit=0,threshold=300)
-            #print json.dumps(jsondict, indent=4, sort_keys=True)
-            #print json.dumps(jsondict['data'], indent=4, sort_keys=True)
+            #print(json.dumps(jsondict, indent=4, sort_keys=True))
+            #print(json.dumps(jsondict['data'], indent=4, sort_keys=True))
             try:
                 for i in range(len(jsondict['data'])):
                     result_array.append(jsondict['data'][i]['dataset'][0]['name'])
             except:
-                print '='*10
-                print 'Not found',element
-                print '='*10
+                print('='*10)
+                print('Not found',element)
+                print('='*10)
         else:
             result_array.append(element)
     if len(result_array) == 0: 
-        print "No samples found"
+        print("No samples found")
         return []
     # Do this to remove duplicates but maintain order of insertion
     # We get duplicates because it queries ALL databases not just the main one

--- a/scripts/dump_lumilist.C
+++ b/scripts/dump_lumilist.C
@@ -31,16 +31,16 @@ using namespace std;
  * Done in C++ for speed (neccessary when iterating over all events in tree)
  *
  * Run:
- * root -q -b 'dump_lumilist.C+("/a/b/c.root",false)'
+ * root -q -b 'dump_lumilist.C+("/a/b/c.root","output.json")'
  *
  * DO NOT PUT SPACES INBETWEEN ARGS
  *
  * root:
- * > .x dump_lumilist("/a/b/c.root", false)
+ * > .x dump_lumilist("/a/b/c.root","output.json")
  *
  * In a bash script with args $1, $2:
  *
- * root -q -b -l 'dump_lumilist.C+("'${1}'",'${2}')'
+ * root -q -b -l 'dump_lumilist.C+("'${1}'","'${2}'")'
  */
 
 

--- a/scripts/dump_lumilist.C
+++ b/scripts/dump_lumilist.C
@@ -1,0 +1,217 @@
+#include <iostream>
+#include <vector>
+#include <set>
+#include <map>
+#include <exception>
+
+#include "TFile.h"
+#include "TChain.h"
+#include "TTree.h"
+#include "TTreeReader.h"
+#include "TTreeReaderValue.h"
+#include "TTreeReaderArray.h"
+
+#include "UHH2/core/include/Event.h"
+
+#include <boost/algorithm/string/predicate.hpp>
+
+using namespace std;
+
+
+/**
+ * Standalone utility to produce LumiList of run : lumisections from Ntuple(s)
+ *
+ * The output can then be used with the standard LumiList tools:
+ * https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideGoodLumiSectionsJSONFile
+ *
+ * fileName: Ntuple filename (can use wildcard for globbing),
+ *           or text file with list of Ntuple filenames
+ * outputFile: output JSON filename
+ *
+ * Done in C++ for speed (neccessary when iterating over all events in tree)
+ *
+ * Run:
+ * root -q -b 'dump_lumilist.C+("/a/b/c.root",false)'
+ *
+ * DO NOT PUT SPACES INBETWEEN ARGS
+ *
+ * root:
+ * > .x dump_lumilist("/a/b/c.root", false)
+ *
+ * In a bash script with args $1, $2:
+ *
+ * root -q -b -l 'dump_lumilist.C+("'${1}'",'${2}')'
+ */
+
+
+/**
+ * Get map of {run number : [lumisection, lumisection...]} for tree in fileName
+ * (i.e. "runs-and-lumis" format)
+ *
+ * @param fileName Ntuple filename (can use wildcards for globbing)
+ * @returns map with data
+ */
+map<int, set<int> > getRunLumiData(const string & fileName) {
+  TChain * chain = new TChain("AnalysisTree");
+  chain->Add(fileName.c_str());
+  TTreeReader reader(chain);
+  TTreeReaderValue<int> run(reader, "run");
+  TTreeReaderValue<int> luminosityBlock(reader, "luminosityBlock");
+
+  // Store lumisections in a set, since many events have the same LS,
+  // but we only want one copy of each. It also automatically sorts it.
+  // I guess we could speed things up by storing the last LS and checking
+  // against it, but no guarantee events are ordered such that all events
+  // of a given LS are together.
+  map<int, set<int> > lumiData;
+  int counter = 0;
+  while (reader.Next()) {
+    if (lumiData.count(*run) == 0) {
+      lumiData[*run] = {};
+    }
+    lumiData[*run].insert(*luminosityBlock);
+    counter++;
+  }
+
+  delete chain;
+
+  cout << "Ran over " << counter << " events" << endl;
+  return lumiData;
+}
+
+
+/**
+ * Convert from run-and-lumis format to compact format,
+ * since the latter is the only one LumiList can parse from file
+ *
+ * Logic taken from __init__ of LumiList.py
+ */
+map<int, vector<pair<int, int>> > convertRunAndLumisToCompact(const map<int, set<int>> & lumiData) {
+  map<int, vector<pair<int, int>> > compactList;
+  for (auto & runLumi : lumiData) {
+    int run = runLumi.first;
+    auto lumiList = runLumi.second;
+    int lastLumi = -1000;
+    compactList[run] = {};
+    for (auto & lumi : lumiList) {
+      if (lumi == lastLumi) {
+        // do nothing, originally designed to store duplicates
+      } else if (lumi != lastLumi + 1) { // Break in lumi sequence
+        compactList[run].push_back(make_pair(lumi, lumi));
+      } else {
+        compactList[run].back().second = lumi;
+      }
+      lastLumi = lumi;
+    }
+  }
+  return compactList;
+}
+
+
+/**
+ * Save Run-lumisection map to JSON file
+ *
+ * @param lumiData   Compact format of runs & lumisections, from convertRunAndLumisToCompact()
+ * @param outputFile JSON filename
+ */
+void dumpCompactRunLumiDataToJSON(map<int, vector<pair<int, int> > > & lumiData, const string & outputFile) {
+  // Do it manually, since boost propertytree makes everything a string
+  // Can't use ROOT - TBuffer::ToJSON only in 6.13+
+  // So hand-roll our own...
+  // Format is the compact format:
+  // {
+  // "run" : [[LS, LS], [LS, LS]],
+  // "run" : [[LS, LS], [LS, LS]
+  // }
+  //
+  // Just hard to handle those dangling commas with map/sets, hence all the
+  // conversions to vectors
+
+  // map keys to vector
+  vector<int> runKeys;
+  for (auto & runLumi : lumiData) {
+    runKeys.push_back(runLumi.first);
+  }
+
+  ofstream jsonFile;
+  jsonFile.open(outputFile);
+
+  jsonFile << "{" << endl;
+  for (uint runInd=0; runInd<runKeys.size(); runInd++) {
+    int runNum = runKeys.at(runInd);
+    jsonFile << "\"" << runNum << "\": [";
+
+    const auto & lumis = lumiData[runNum];
+
+    for (uint lumiInd=0; lumiInd<lumis.size(); lumiInd++) {
+      auto & lumiPair = lumis.at(lumiInd);
+      jsonFile << "[" << lumiPair.first << ", " << lumiPair.second << "]";
+      if (lumiInd < lumis.size()-1) {
+        jsonFile << ", ";
+      }
+    }
+    jsonFile << "]";
+    if (runInd < runKeys.size()-1) {
+      jsonFile << ",";
+    }
+    jsonFile << endl;
+  }
+  jsonFile << "}" << endl;
+  jsonFile.close();
+}
+
+
+void dump_lumilist(const string & fileName, const string & outputFile) {
+
+  if (!(boost::ends_with(outputFile, ".json") || boost::ends_with(outputFile, ".JSON"))) {
+    throw runtime_error("outputFile must be *.json");
+  }
+
+  // Create temporary filename for run-and-lumis format JSON,
+  // user's choice will have the compact format
+
+  if (boost::ends_with(fileName, ".root")) {
+    // handle ROOT filename(s)
+    cout << "Assuming ROOT file(s)..." << endl;
+    auto lumiData = getRunLumiData(fileName);
+    auto compactList = convertRunAndLumisToCompact(lumiData);
+    dumpCompactRunLumiDataToJSON(compactList, outputFile);
+
+  } else {
+    // handle list of ROOT files
+    cout << "Assuming list of ROOT file(s)..." << endl;
+    ifstream infile(fileName);
+    if (infile.is_open()) {
+      map<int, set<int> > allLumiData;
+      string line;
+      while (getline(infile, line)) {
+        if (!boost::ends_with(line, ".root")) continue;
+        auto lumiData = getRunLumiData(line);
+
+        // merge new map in with old - can't use insert() as it doesn't combine sets,
+        // so have to do manually
+        for (auto & runLS : lumiData) {
+          auto run = runLS.first;
+          auto ls = runLS.second;
+          if (allLumiData.count(run) == 0) {
+            allLumiData[run] = {};
+          }
+          allLumiData[run].insert(ls.begin(), ls.end());
+        }
+      }
+      auto compactList = convertRunAndLumisToCompact(allLumiData);
+      dumpCompactRunLumiDataToJSON(compactList, outputFile);
+
+    } else {
+      cout << "Couldn't open " << fileName << endl;
+    }
+
+  }
+
+  cout << "Written JSON to " << outputFile << endl;
+}
+
+int main(int argc, char * argv[]){
+  cout << "Calling main" << endl;
+  dump_lumilist(argv[0], argv[1]);
+}

--- a/scripts/lumi_list_from_das.py
+++ b/scripts/lumi_list_from_das.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+
+
+"""
+Script to create lumilist of lumisections for MC sample
+
+It is designed to only work on *one* sample (& its ext, if it exists),
+not multiple:
+
+e.g.:
+    OK:     /QCD_Pt_300to470_TuneCP5_13TeV_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic*/MINIAODSIM
+    Not OK: /QCD_Pt_*to*_TuneCP5_13TeV_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic*/MINIAODSIM
+
+Requires you to have a valid voms proxy, as it calls DAS.
+"""
+
+
+from __future__ import print_function
+
+import sys,os
+import argparse
+import FWCore.PythonUtilities.LumiList as LumiList
+from Utilities.General.cmssw_das_client import get_data
+sys.path.append(os.environ["CMSSW_BASE"]+"/src/UHH2/scripts/crab")
+from DasQuery import autocomplete_Datasets,check_voms
+
+
+def get_mc_lumi_list(inputDataset="/QCD_Pt_300to470_TuneCP5_13TeV_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic*/MINIAODSIM"):
+    """Get the LumiList object(s) for dataset(s) matching `inputDataset`
+
+    inputDataset:
+        if a str, will ask DAS to autocomplate (can contain wildcards)
+        if a list/tuple/set[str], will iterate over each entry in the list, without asking DAS to autocomplete.
+        This is because the user might have cached the dataset names before calling this function, and we don't want to call DAS more than necessary.
+
+    returns: a dict with an entry for each dataset user inputs with das string as key and LumiList as value (assumes MC samples with only one run "1")
+
+    raises RuntimeError if no valid voms proxy
+    raises TypeError if inputDataset incorrect type
+    """
+    if not check_voms():
+        raise RuntimeError("Missing voms proxy")
+
+    if isinstance(inputDataset, str):
+        inputDatasets = autocomplete_Datasets([inputDataset])
+    elif not isinstance(inputDataset, (list, set, tuple)):
+        raise TypeError('get_mc_lumi_list: `inputDataset` expects str or list/tuple/set[str]')
+
+    result = {}
+    for dataset in inputDatasets:
+        print(dataset)
+        json_dict = get_data(host='https://cmsweb.cern.ch', query="lumi file dataset="+dataset, idx=0, limit=0, threshold=300)
+        lumi_list = LumiList.LumiList()
+        try:
+            n_files = len(json_dict['data'])
+            for i, file_info in enumerate(json_dict['data']):
+                if (i>n_files):
+                    break
+                lumi_list += LumiList.LumiList(runsAndLumis={'1': file_info['lumi'][0]['number']})
+        except:
+            print('Did not find lumis for', dataset)
+        result.update({dataset:lumi_list})
+    return result
+
+
+def write_lumi_list(inputDataset="/QCD_Pt_1000to1400_TuneCP5_13TeV_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14*/MINIAODSIM", filename="test.json"):
+    """Get lumilist for datasets matching `inputDataset`, and write result to `filename`
+
+    If another matching dataset, writes to `filename` but with an extra '_ext' before the file extension.
+
+    raises ValueError if inputDataset matches more than 2 samples (we allow 2 incase we have nominal+ext sample),
+    or matches 0 samples
+    """
+    inputDatasets = autocomplete_Datasets([inputDataset])
+    if len(inputDatasets) > 2:
+        for d in inputDatasets:
+            print(d)
+        raise ValueError("The given inputDataset DAS string corresponds to more than two samples. This is a bit unusual. "
+                         "Since this script can only handle up to 2 datasets, please use a more specific dataset pattern.")
+    elif len(inputDatasets) == 0:
+        raise ValueError("No matching datasets for the dataset pattern")
+
+    results = get_mc_lumi_list(inputDataset)
+
+    results_keys = list(results.keys())
+    if len(results) == 1:
+        results[results_keys[0]].writeJSON(fileName=filename)
+    elif len(results) > 1:
+        # if there are two results assume its nominal+ext sample:
+        # but it might sort the "ext" sample first, so we should
+        # check which is which.
+        def _print_save(key, fname):
+            print("Saved", key, "to", fname)
+            results[key].writeJSON(fileName=fname)
+
+        stem, ext = os.path.splitext(filename)
+        ext_filename = stem + "_ext" + ext
+        if '_ext' in results_keys[0]:
+            _print_save(results_keys[0], ext_filename)
+            _print_save(results_keys[1], filename)
+        else:
+            _print_save(results_keys[0], filename)
+            _print_save(results_keys[1], ext_filename)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("dataset", help="Dataset name to get lumilist")
+    parser.add_argument("output", help="Output JSON filename")
+    args = parser.parse_args()
+
+    write_lumi_list(inputDataset=args.dataset, filename=args.output)

--- a/scripts/splitAndDumpLumiList.sh
+++ b/scripts/splitAndDumpLumiList.sh
@@ -1,0 +1,32 @@
+#!/bin/bash -e
+
+set -u
+
+# Divide up txt list of files into separate files
+# that are shorter, and run dump_lumilist.C on each.
+# Then combine the resultant lumilists to make a grand one.
+
+TXT="$1"
+JSON="$2"
+
+
+if [[ "$TXT" != *".txt" ]]; then
+    echo "text file should end .txt"
+    exit 1
+fi
+
+PREFIX="${TXT/.txt/_part.txt}"
+# 1000 lines should take about 10 minutes
+split -d --lines=1000 "$TXT" "$PREFIX"
+declare -a jsons;
+for f in $PREFIX*; do
+    IND="${f#$PREFIX}"
+    JSONPART="${JSON/.json/$IND.json}"
+    jsons+=($JSONPART)
+    echo $f $JSONPART
+    nohup nice -n 10 root -q -b -l 'dump_lumilist.C+("'${f}'","'${JSONPART}'")' > dump_${f}.log &
+    sleep 10 # to allow it to compile once, instead of parallel compilations that fail
+done
+echo "Once finished, run: "
+echo "mergeJSON.py ${jsons[@]} --output $JSON"
+

--- a/scripts/splitGoldenJSONbyRunPeriod.sh
+++ b/scripts/splitGoldenJSONbyRunPeriod.sh
@@ -1,0 +1,64 @@
+#!/bin/bash -e
+
+set -u
+
+# Split a Golden JSON into the run periods, automatically downloads it
+# 
+# Usage:
+#
+#  ./splitGoldenJSONbyRunPeriod.sh <year>
+#  
+#   where <year> is one of 2016, 2017, 2018
+
+YEAR=$1
+
+if [ -z $YEAR ]; then
+    echo "Missing YEAR argument"
+    exit 1
+fi
+
+URL=""
+# Load up run number periods into associative array
+# Fake multidimensionality by using | to separate start/end run numbers
+declare -A run_periods;
+if [[ $YEAR == "2016" ]]; then
+    run_periods["B"]="272007|275376"
+    run_periods["C"]="275657|276283"
+    run_periods["D"]="276315|276811"
+    run_periods["E"]="276831|277420"
+    run_periods["F"]="277772|278808"
+    run_periods["G"]="278820|280385"
+    run_periods["H"]="280919|284044"
+    URL="https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_ReReco_07Aug2017_Collisions16_JSON.txt"
+elif [[ $YEAR == "2017" ]]; then
+    # A has no lumi in Golden JSON
+    run_periods["B"]="297046|299329"
+    run_periods["C"]="299368|302029"
+    run_periods["D"]="302030|303434"
+    run_periods["E"]="303824|304797"
+    run_periods["F"]="305040|306462"
+    # this "v1" has an extra bad ECAL LS removed: https://hypernews.cern.ch/HyperNews/CMS/get/physics-validation/3067.html
+    URL="https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON_v1.txt"
+elif [[ $YEAR == "2018" ]]; then
+    run_periods["A"]="315252|316995"
+    run_periods["B"]="316998|319312"
+    run_periods["C"]="319313|320393"
+    run_periods["D"]="320394|325273"
+    # has a few extra LS wrt prompt JSON
+    URL="https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions18/13TeV/ReReco/Cert_314472-325175_13TeV_17SeptEarlyReReco2018ABC_PromptEraD_Collisions18_JSON.txt"
+else
+    echo "bad YEAR argument, should be one of 2016, 2017, 2018"
+    exit 1
+fi
+
+# Download the golden json
+JSON="Golden_$YEAR.json"
+wget -O "$JSON" "$URL"
+# Split it by run period
+for period in "${!run_periods[@]}"; do
+    startend=${run_periods[$period]}
+    START=${startend%|*}
+    END=${startend#*|}
+    echo $period $START $END
+    filterJSON.py --min $START --max $END "$JSON" --output "Golden_${YEAR}_Run${period}.json"
+done

--- a/scripts/xmlToTxt.sh
+++ b/scripts/xmlToTxt.sh
@@ -1,0 +1,41 @@
+#!/bin/bash -e
+#
+# Convert XML list of ntuples to plain text list
+#
+# Usage:
+#   ./xmlToTxt.sh <XML input filename> <txt output filename>
+#
+
+set -u
+
+XML="$1"
+TXT="$2"
+
+if [ -z $XML ]; then
+    echo "Missing XML filename"
+    exit 1
+fi
+
+if [ -z $TXT ]; then
+    echo "Missing output filename"
+    exit 1
+fi
+
+if [ -f $TXT ]; then
+    rm $TXT
+fi
+
+while IFS= read -r line
+do
+    if [[ $line =~ "<!--" ]]; then
+        continue
+    fi
+    if [[ $line == *".root"* ]]; then
+        filename=${line#*/pnfs}
+        filename=${filename%\" Lumi=\"0.0\"/>}
+        filename="/pnfs$filename"
+        echo $filename >> $TXT
+    fi
+done < "$XML"
+
+echo "Written txt file $TXT"


### PR DESCRIPTION
To tackle the missing files from the broken dCache drive, added some scripts to figure out the runs & lumisections in the "bad" files, and create a JSON mask for them, to be using in a CRAB config (e.g. `crab_template.py`).

## commentOutBadXML.sh

Create a copy of a XML file, commenting out ntuples listed in a plain txt file

## xmlToTxt.sh

Convert XML file of ntuples to plain text file of them, ignoring any commented-out lines

## dump_lumilist.C

ROOT script to save all the run numbers & lumisections in ntuple(s) to JSON. Can either accept a filepath (with globbing), or a text file with a list of Ntuple filenames.
The lumi JSON can then be used with the standard lumilist tools: https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideGoodLumiSectionsJSONFile

Also have `splitAndDumpLumiList.sh` to do this in parallel on groups of 1000 ntuples (needs a txt file with list of ntuples).

## splitGoldenJSONbyRunPeriod.sh

Download Golden JSON for a chosen year, and split it into individual JSON files for each run period.

## lumi_list_from_das.py

Gets lumilist for dataset from DAS. Only accepts one dataset (& its ext sample, if it exists).

# Usage

1. Create XML excluding missing ntuples:

```
./commentOutBadXML.sh <XML filename> <list of missing ntuples>
```

makes `X_nobad.xml`

2. Convert that into plain txt:

```
./xmlToTxt.sh X_nobad.xml X_nobad.txt
```

3. Create lumilist from txt file (this may take a while!):

```
root -q -b 'dump_lumilist.C("X_nobad.txt","lumilist_X_nobad.json")'
```

4. Only for **data**: if not already done, create Golden JSON per Run period:

```
./splitGoldenJSONbyRunPeriod.sh 2016
```

Then diff the reference Golden JSON & your json of "good" lumisections, e.g.:

```
compareJSON.py --sub Golden_2016_RunA.json lumilist_X_nobad.json missing_2016_RunA.json
```

You can then use `missing_2016_RunA.json` in your `crab_template.py` in the `config.Data.lumiMask` attribute.

5. Only for **MC**: create a reference lumilist JSON for your sample:

```
./lumi_list_from_das.py <DATASET NAME> dataset_all.json
```

Then diff the reference and your json of "good" lumisections, e.g.:

```
compareJSON.py --sub dataset_all.json lumilist_X_nobad.json missing.json
```

You can then use `missing.json` in your `crab_template.py` in the `config.Data.lumiMask` attribute.

[ci skip]