### PR TITLE
[102Xv2] Update XML scripts

### DIFF
--- a/scripts/crab/CommentedTreeBuilder.py
+++ b/scripts/crab/CommentedTreeBuilder.py
@@ -1,0 +1,18 @@
+from xml.etree import ElementTree
+
+# Use an instance of this to parse XML whilst keeping comments
+# Usage:
+#   parser = ET.XMLParser(target=CommentedTreeBuilder())
+#   root = ET.fromstring(xml_str, parser)
+#   or
+#   root = ET.parse(filename, parser) 
+#   
+# Comment Elements have str(.tag) = "<function Comment at 0x....>", and .text is the comment text
+
+# Taken from SO: https://stackoverflow.com/a/34324359
+
+class CommentedTreeBuilder(ElementTree.TreeBuilder):
+    def comment(self, data):
+        self.start(ElementTree.Comment, {})
+        self.data(data)
+        self.end(ElementTree.Comment)

--- a/scripts/crab/combineXML.py
+++ b/scripts/crab/combineXML.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+
+"""
+Combine XML files
+
+Doesn't keep event count, user must do it afterwards.
+"""
+
+
+from __future__ import print_function
+
+import os
+import sys
+import argparse
+import xml.etree.ElementTree as ET
+import ROOT
+ROOT.PyConfig.IgnoreCommandLineOptions = True
+ROOT.gROOT.SetBatch(1)
+
+from readaMCatNloEntries import get_xml_tree
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("xml", nargs='+', help="XML files to merge")
+    parser.add_argument("output", help="Destination XML file")
+    args = parser.parse_args()
+
+    trees = []
+    for filename in args.xml:
+        if not os.path.isfile(filename):
+            print("Missing", filename, " - skipping")
+        this_tree = get_xml_tree(filename)
+        trees.append(this_tree)
+
+    with open(args.output, 'w') as outputfile:
+        for tree in trees:
+            for child in tree:
+                if "function Comment" not in str(child.tag):
+                    outputfile.write(ET.tostring(child))
+                elif "FileName" in child.text:
+                    # is comment but keep empty/bad/commented out files
+                    # basically just ignore the count at the end
+                    outputfile.write(ET.tostring(child))
+
+    print("Output written to", args.output)
+    print("If necessary, run readaMCatNloEntries.py on the new file")

--- a/scripts/crab/readaMCatNloEntries.py
+++ b/scripts/crab/readaMCatNloEntries.py
@@ -8,6 +8,8 @@
 
 import sys, multiprocessing, time, os
 import subprocess
+import xml.etree.ElementTree as ET
+from CommentedTreeBuilder import CommentedTreeBuilder
 import ROOT
 from ROOT import *
 
@@ -15,32 +17,49 @@ ROOT.PyConfig.IgnoreCommandLineOptions = True
 ROOT.gROOT.SetBatch(1)
 
 
-def read_xml(xmlFileDir):
-    xmlFile = open(str(xmlFileDir))
+def get_xml_tree(xmlFileDir):
+    with open(xmlFileDir) as f:
+        # hack to trick XML parsing - put under a root node
+        xml_str = "<data>%s</data>" % f.read()
+    parser = ET.XMLParser(target=CommentedTreeBuilder())
+    root = ET.fromstring(xml_str, parser)
+    return root
+
+
+def get_root_filenames_from_xml(xmlFileDir):
+    # skips commented out lines, no matter if it has FileName="..."
     rootFileStore = []
-    comment = False
-    for line in xmlFile:
-        if ".root" in line:
-            rootFileStore.append(line.split('"')[1])
+    root = get_xml_tree(xmlFileDir)
+    for child in root:
+        if child.tag != "In":
+            # this will also skip commented out lines
+            continue
+        filename = child.attrib['FileName']
+        if ".root" in filename:
+            rootFileStore.append(filename)
     return rootFileStore
+
 
 def read_tree(rootDir):
     numberOfweightedEntries = 0
     try:
-        # Use C++ script to count as significantly faster (~15x)
+        # Use C++ script to count as significantly faster
         cmd = "root -q -b -l 'countNumberEvents.C+(\""+rootDir+"\",false)'"
         output = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT)
-        # now have to be careful - root will return 0 even if there's an error
+        # now have to be careful - ROOT will return 0 even if there's an error
         if "error:" in output.lower():
             raise RuntimeError("Error running ROOT: " + output)
     except Exception as e:
         print 'unable to count events in root file',rootDir
         print e
     numberOfweightedEntries = float(output.splitlines()[-1])
-    return numberOfweightedEntries
+    # return tuple of (filename, num events), since the result gets used in
+    # multiprocessing, and we can't guarantee order, so keep track of filename
+    return (rootDir, numberOfweightedEntries)
+
 
 def read_treeFast(rootDir):
-    fastentries =0
+    fastentries = 0
     try:
         ntuple = TFile(str(rootDir))
         AnalysisTree = ntuple.Get("AnalysisTree")
@@ -48,7 +67,10 @@ def read_treeFast(rootDir):
     except Exception as e:
         print 'unable to count events in root file',rootDir
         print e
-    return fastentries
+    # return tuple of (filename, num events), since the result gets used in
+    # multiprocessing, and we can't guarantee order, so keep track of filename
+    return (rootDir, fastentries)
+
 
 def readEntries(worker, xmlfiles, fast=False):
     if fast: print 'Going to use the Fast Method, no weights used'
@@ -57,8 +79,8 @@ def readEntries(worker, xmlfiles, fast=False):
     result_list = []
     for xml in xmlfiles:
         pool = multiprocessing.Pool(processes=int(worker))
-        print "open XML file:",xml
-        rootFileStore = read_xml(xml)
+        print "open XML file:", xml
+        rootFileStore = get_root_filenames_from_xml(xml)
         numberXMLFiles = len(rootFileStore)
         result = None
         if(fast):
@@ -66,25 +88,30 @@ def readEntries(worker, xmlfiles, fast=False):
         else:
             result = pool.map_async(read_tree,rootFileStore)
 
-        print result._number_left ,numberXMLFiles,result._chunksize
+        print result._number_left, numberXMLFiles, result._chunksize
         while result._number_left>0:
             sys.stdout.write("\033[F")
             missing = round(float(result._number_left)*float(result._chunksize)/float(numberXMLFiles)*100)
-            if(missing > 100):
-                missing =100
+            if (missing > 100):
+                missing = 100
             print "Missing [%]", missing
             time.sleep(10)
         pool.close()
         pool.join()
         entries_per_rootfile = [r for r in result.get()]
-        print "number of events in",xml,sum(entries_per_rootfile)
-        result_list.append(sum(entries_per_rootfile))
-        commentOutEmptyRootFiles(xml, entries_per_rootfile,fast)
+        total_entries = sum(x[1] for x in entries_per_rootfile)
+        # convert list of tuples to dict for easier lookup by filename
+        entries_per_rootfile = dict(entries_per_rootfile)
+        print "number of events in", xml, total_entries
+        result_list.append(total_entries)
+        updateXMLfile(xml, entries_per_rootfile, fast)
     return result_list
 
 
-def commentOutEmptyRootFiles(xmlfile, entries_per_rootfile,fast=False):
-    """Edit the XML file so that ROOT files with 0 events are commented out
+def updateXMLfile(xmlfile, entries_per_rootfile, fast=False):
+    """Edit the XML file to add total, and comment out files with 0 events
+
+    entries_per_rootfile is a dict of {filename : number of events}
 
     This is because sframe can crash if the first file has 0 events.
     (For some reason CRAB makes these empty files)
@@ -93,18 +120,22 @@ def commentOutEmptyRootFiles(xmlfile, entries_per_rootfile,fast=False):
     (we assume the user knows how to handle that scenario)
     """
     newText = []
-    with open(xmlfile, "U") as file:
-        i_ = 0
-        for line in file.readlines():
-            if '.root' in line:
-                newText.append(line if entries_per_rootfile[i_]!=0 else '<!--EMPTY <In FileName="'+line.split('"')[1]+'" Lumi="0.0"/> -->\n')
-                i_ += 1
-        if len(entries_per_rootfile)!= i_: print "ERROR", len(entries_per_rootfile), i_
+    root = get_xml_tree(xmlfile)
     with open(xmlfile, "w") as outputfile:
-        for line in newText:
-            outputfile.write(line)
+        for child in root:
+            if child.tag == "In":
+                filename = child.attrib['FileName']
+                if entries_per_rootfile[filename] != 0:
+                    outputfile.write(ET.tostring(child))
+                else:
+                    # is empty file
+                    outputfile.write("<!--EMPTY %s -->\n" % ET.tostring(child).strip())
+            else:
+                # is a comment
+                outputfile.write(ET.tostring(child))
+
         method = 'fast' if fast else 'weights'
-        outputfile.write('<!-- < NumberEntries="'+str(sum(entries_per_rootfile))+'" Method='+method+' /> -->')
+        outputfile.write('<!-- < NumberEntries="'+str(sum(entries_per_rootfile.values()))+'" Method='+method+' /> -->')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Update `readaMCatNloEntries.py` to parse XML properly (keeping comments, via a custom parser class), such that it doesn't now try to count the number of events in commented out lines (this was causing issues with missing/hanging files). However, it does keep them for posterity.

I also updated some of the methods/returns to be clearer, since they might be useful in other scripts.

Also added script to combine XML files, `combineXML.py`, although it doesn't keep track of the number of entries.

[ci skip]