### PR TITLE
[106X] updated to v14 with CMSSW 10_6_13

### DIFF
--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -1173,6 +1173,10 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
     )
     task.add(process.rekeyPackedPatJetsAk8PuppiJets)
 
+    #### update PUPPI to v14
+    from CommonTools.PileupAlgos.customizePuppiTune_cff import UpdatePuppiTuneV14
+    UpdatePuppiTuneV14(process, not useData)
+
     # Update DeepBoosted training to V2 for everything but 2016v2
     # Check https://twiki.cern.ch/twiki/bin/view/CMS/DeepAKXTagging for latest recommendations
     # e.g. 2018 specific training

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -119,7 +119,7 @@ time git clone https://github.com/UHH2/SFrame.git
 # Get CMSSW
 export SCRAM_ARCH=slc7_amd64_gcc700
 checkArch
-CMSREL=CMSSW_10_6_8
+CMSREL=CMSSW_10_6_13
 eval `cmsrel ${CMSREL}`
 cd ${CMSREL}/src
 eval `scramv1 runtime -sh`


### PR DESCRIPTION
I have changed the install script to CMSSW_10_6_13 which makes it easier to use the new default PUPPI tune v14 for UL production.

I also added the UpdatePuppiTuneV14 from
https://github.com/cms-sw/cmssw/blob/CMSSW_10_6_13/CommonTools/PileupAlgos/python/customizePuppiTune_cff.py

which updates our PUPPI jet collections with the latest tune.
