### PR TITLE
[102X] TopPtReweight flat at 500 GeV

### DIFF
--- a/common/src/TopPtReweight.cxx
+++ b/common/src/TopPtReweight.cxx
@@ -40,8 +40,8 @@ bool TopPtReweight::process(uhh2::Event& event){
   if (ttbargen.DecayChannel() != TTbarGen::e_notfound) {
     float tpt1 = ttbargen.Top().v4().Pt();
     float tpt2 = ttbargen.Antitop().v4().Pt();
-    tpt1 = std::min(tpt1, float(400.));
-    tpt2 = std::min(tpt2, float(400.));
+    tpt1 = std::min(tpt1, float(500.));
+    tpt2 = std::min(tpt2, float(500.));
     wgt = sqrt(exp(a_+b_*tpt1)*exp(a_+b_*tpt2));
   }
 


### PR DESCRIPTION
This Pull Request will start automatic compilation, then making + testing of ntuples:

- Don't want to run any of this? (e.g. only XML files) Remove the @: [ci @ skip]

- Only want to compile, but don't make + test ntuples? (e.g. change `CommonModules.cxx`) Remove the @: [only  compile]

Please include destination branch in title, e.g. `[102X]`, + short meaningful title

Please include an explanation message if it's something more complex than just XML dataset files:

Following the new recommendations at https://twiki.cern.ch/twiki/bin/viewauth/CMS/TopPtReweighting the TopPtReweigh factor should be flat for pT > 500. Made the change from 400 to 500 in our framework.

