### PR TITLE
Run ii 106 x v1-- Add config options for UL16

### DIFF
--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -294,7 +294,6 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
             "data": "102X_dataRun2_Prompt_v6",
             "mc": "102X_upgrade2018_realistic_v15",
         },
-106X_dataRun2_v27
         "UL16preVFP": {
             "data": "106X_dataRun2_v28",
             "mc": "106X_mcRun2_asymptotic_preVFP_v8",

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -55,7 +55,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
         If the year argument is not one of the allowable options
     """
     year = str(year)  # sanitise string
-    acceptable_years = ["2016v2", "2016v3", "2017v1", "2017v2", "2018", "UL17", "UL18"]
+    acceptable_years = ["2016v2", "2016v3", "2017v1", "2017v2", "2018", "UL16preVFP", "UL16postVFP", "UL17", "UL18"]
     if year not in acceptable_years:
         raise ValueError("year argument in generate_process() should be one of: %s. You provided: %s" % (acceptable_years, year))
 
@@ -80,6 +80,10 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
     elif year == "2016v3":
         process = cms.Process("USER", eras.Run2_2016, eras.run2_miniAOD_80XLegacy) 
     elif year == "2016v2":
+        process = cms.Process("USER", eras.Run2_2016)
+    elif year == "UL16preVFP":
+        process = cms.Process("USER", eras.Run2_2016_HIPM)
+    elif year == "UL16postVFP":
         process = cms.Process("USER", eras.Run2_2016)
     elif year == "UL17":
         process = cms.Process("USER", eras.Run2_2017)
@@ -289,6 +293,15 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
         "2018": {
             "data": "102X_dataRun2_Prompt_v6",
             "mc": "102X_upgrade2018_realistic_v15",
+        },
+106X_dataRun2_v27
+        "UL16preVFP": {
+            "data": "106X_dataRun2_v28",
+            "mc": "106X_mcRun2_asymptotic_preVFP_v8",
+        },
+        "UL16postVFP": {
+            "data": "106X_dataRun2_v28",
+            "mc": "106X_mcRun2_asymptotic_v13",
         },
         "UL17": {
             "data": "106X_dataRun2_v28",
@@ -1872,6 +1885,8 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
         "2017v1": ele_iso_17,
         "2017v2": ele_iso_17,
         "2018": ele_iso_17,
+        "UL16preVFP": ele_iso_17,
+        "UL16postVFP": ele_iso_17,
         "UL17": ele_iso_17,
         "UL18": ele_iso_17,
     }

--- a/core/python/ntuplewriter_data_UL16postVFP.py
+++ b/core/python/ntuplewriter_data_UL16postVFP.py
@@ -1,0 +1,24 @@
+import FWCore.ParameterSet.Config as cms
+from UHH2.core.ntuple_generator import generate_process  # use CMSSW type path for CRAB
+from UHH2.core.optionsParse import setup_opts, parse_apply_opts
+
+
+"""NTuple config for UL16postVFP Data datasets.
+
+You should try and put any centralised changes in generate_process(), not here.
+"""
+
+
+process = generate_process(year="UL16postVFP", useData=True)
+
+# Please do not commit changes to source filenames - used for consistency testing
+process.source.fileNames = cms.untracked.vstring([
+    '/store/data/Run2016F/JetHT/MINIAOD/21Feb2020_UL2016-v1/20000/0A917D93-1CCE-8D47-ABFB-24E36E58575F.root'
+])
+
+# Do this after setting process.source.fileNames, since we want the ability to override it on the commandline
+options = setup_opts()
+parse_apply_opts(process, options)
+
+with open('pydump_data_UL16postVFP.py', 'w') as f:
+    f.write(process.dumpPython())

--- a/core/python/ntuplewriter_data_UL16preVFP.py
+++ b/core/python/ntuplewriter_data_UL16preVFP.py
@@ -1,0 +1,24 @@
+import FWCore.ParameterSet.Config as cms
+from UHH2.core.ntuple_generator import generate_process  # use CMSSW type path for CRAB
+from UHH2.core.optionsParse import setup_opts, parse_apply_opts
+
+
+"""NTuple config for UL16preVFP Data datasets.
+
+You should try and put any centralised changes in generate_process(), not here.
+"""
+
+
+process = generate_process(year="UL16preVFP", useData=True)
+
+# Please do not commit changes to source filenames - used for consistency testing
+process.source.fileNames = cms.untracked.vstring([
+    '/store/data/Run2016B/JetHT/MINIAOD/21Feb2020_ver1_UL2016_HIPM-v1/240000/07EDE82B-253D-EA4E-B120-2F82BB60DA5F.root'
+])
+
+# Do this after setting process.source.fileNames, since we want the ability to override it on the commandline
+options = setup_opts()
+parse_apply_opts(process, options)
+
+with open('pydump_data_UL16preVFP.py', 'w') as f:
+    f.write(process.dumpPython())

--- a/core/python/ntuplewriter_mc_UL16postVFP.py
+++ b/core/python/ntuplewriter_mc_UL16postVFP.py
@@ -1,0 +1,24 @@
+import FWCore.ParameterSet.Config as cms
+from UHH2.core.ntuple_generator import generate_process  # use CMSSW type path for CRAB
+from UHH2.core.optionsParse import setup_opts, parse_apply_opts
+
+
+"""NTuple config for UL16postVFP MC datasets.
+
+You should try and put any centralised changes in generate_process(), not here.
+"""
+
+
+process = generate_process(year="UL16postVFP", useData=False)
+
+# Please do not commit changes to source filenames - used for consistency testing
+process.source.fileNames = cms.untracked.vstring([
+    '/store/mc/RunIISummer19UL16MiniAOD/QCD_HT1000to1500_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8/MINIAODSIM/106X_mcRun2_asymptotic_v13-v2/230000/00CFE673-174D-9841-95ED-8B0A3338FFC3.root'
+])
+
+# Do this after setting process.source.fileNames, since we want the ability to override it on the commandline
+options = setup_opts()
+parse_apply_opts(process, options)
+
+with open('pydump_mc_UL16postVFP.py', 'w') as f:
+    f.write(process.dumpPython())

--- a/core/python/ntuplewriter_mc_UL16preVFP.py
+++ b/core/python/ntuplewriter_mc_UL16preVFP.py
@@ -1,0 +1,24 @@
+import FWCore.ParameterSet.Config as cms
+from UHH2.core.ntuple_generator import generate_process  # use CMSSW type path for CRAB
+from UHH2.core.optionsParse import setup_opts, parse_apply_opts
+
+
+"""NTuple config for UL16preVFP MC datasets.
+
+You should try and put any centralised changes in generate_process(), not here.
+"""
+
+
+process = generate_process(year="UL16preVFP", useData=False)
+
+# Please do not commit changes to source filenames - used for consistency testing
+process.source.fileNames = cms.untracked.vstring([
+    '/store/mc/RunIISummer19UL16MiniAODAPV/QCD_HT1000to1500_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8/MINIAODSIM/106X_mcRun2_asymptotic_preVFP_v8-v1/100000/0130586D-78FE-8348-AB7A-E2E76657F87E.root'
+])
+
+# Do this after setting process.source.fileNames, since we want the ability to override it on the commandline
+options = setup_opts()
+parse_apply_opts(process, options)
+
+with open('pydump_mc_UL16preVFP.py', 'w') as f:
+    f.write(process.dumpPython())


### PR DESCRIPTION
Add variables in ntuple_generator to handle UL16 pre and post VFP according to https://twiki.cern.ch/twiki/bin/view/CMS/PdmV#RunII_Legacy_ReReco