### PR TITLE
[102Xv2] JER file locating method & JetResolutionSmearer fix

### DIFF
--- a/common/include/JetCorrectionSets.h
+++ b/common/include/JetCorrectionSets.h
@@ -9,6 +9,17 @@
 namespace JERFiles{
 
   /**
+   * JERPathString returns the path of a JER file from JRDatabase for a given 
+   * tag, 
+   * jetCollection,
+   * type (i.e. SF,PtResolution, etc.).
+   * To be used for example in JetResolutionSmearer or when constructing a GenericJetResolutionSmearer
+   */
+  const std::string JERPathStringMC(const std::string & tag,
+                                  const std::string & jetCollection,
+                                  const std::string & type = "SF");  
+
+  /**
    * There are 2 ways to get access to JEC sets, needed for *JetEnergyCorrector class:
    * - use the JECFiles[DATA|MC]() functions
    * - a C++ variable, defined below with the DEFINE_* macros,

--- a/common/src/JetCorrectionSets.cxx
+++ b/common/src/JetCorrectionSets.cxx
@@ -1,6 +1,23 @@
 #include "UHH2/common/include/JetCorrectionSets.h"
 #include <string>
 
+// Getting path of a JER file from JRDatabase (e.g. SF, PtResolution, etc) for a given tag and jetCollection
+const std::string JERFiles::JERPathStringMC(const std::string & tag,
+                                          const std::string & jetCollection,
+                                          const std::string & type){
+  
+  std::string result = "JRDatabase/textFiles/";
+  result += tag;
+  result += "_MC/";
+  result += tag;
+  result += "_MC_";
+  result += type;
+  result += "_";
+  result += jetCollection;
+  result += ".txt";
+  return result;
+  }
+
 //see https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookJetEnergyCorrections#GetTxtFiles how to get the txt files with jet energy corrections from the database
 
 // The idea of the following methods is to simplify the creation of new JEC input files.

--- a/common/src/JetCorrections.cxx
+++ b/common/src/JetCorrections.cxx
@@ -847,32 +847,19 @@ JetResolutionSmearer::JetResolutionSmearer(uhh2::Context & ctx){
     throw runtime_error("JetCollection not CHS or Puppi - cannot determine filename for JetResolutionSmearer");
   }
 
-  std::string filenameAppend = jetAlgoRadius+"PF"+puName+".txt";
-
+  std::string jetCollection = jetAlgoRadius+"PF"+puName;
   const Year & year = extract_year(ctx);
-  JERSmearing::SFtype1 JER_sf = {};
-  std::string sfFilename = "";
-  std::string resFilename = "";
+  std::string jer_tag = "";
   if (year == Year::is2016v2 || year == Year::is2016v3) {
-    JER_sf = JERSmearing::SF_13TeV_Summer16_25nsV1;
-    resFilename = "2016/Summer16_25nsV1_MC_PtResolution_" + filenameAppend;
+    jer_tag = "Summer16_25nsV1";
   } else if (year == Year::is2017v1 || year == Year::is2017v2) {
-    JER_sf = JERSmearing::SF_13TeV_Fall17_V3;
-    resFilename = "2017/Fall17_V3_MC_PtResolution_" + filenameAppend;
+    jer_tag = "Fall17_V3";
   } else if (year == Year::is2018) {
-    sfFilename = "common/data/2018/Autumn18_V7_MC_SF_" + filenameAppend;
-    resFilename = "2018/Autumn18_V7_MC_PtResolution_" + filenameAppend;
+    jer_tag = "Autumn18_V7";
   } else {
     throw runtime_error("Cannot find suitable jet resolution file & scale factors for this year for JetResolutionSmearer");
   }
-
-  if (sfFilename != "") {
-    m_gjrs = new GenericJetResolutionSmearer(ctx, "jets", "genjets", sfFilename, resFilename);
-  } else if (JER_sf.size() > 0) {
-    m_gjrs = new GenericJetResolutionSmearer(ctx, "jets", "genjets", JER_sf, resFilename);
-  } else {
-    throw runtime_error("No valid JER SF either as text file nor JERSmearing::SFtype1");
-  }
+  m_gjrs = new GenericJetResolutionSmearer(ctx, "jets", "genjets", JERFiles::JERPathStringMC(jer_tag,jetCollection,"SF"), JERFiles::JERPathStringMC(jer_tag,jetCollection,"PtResolution"));
 
 }
 


### PR DESCRIPTION
This adds another method to JERFiles namespace in JetCorrectionSets for locating MC JER files from the JRDatabase in similar fashion as done for the JEC files.

Also this implements said method in the simple JetResolutionSmearer Constructor (used for example in CommonModules) and fixes the issue discussed in #1522.

[only compile]
