### PR TITLE
[106X] JER file locating method

### DIFF
--- a/common/include/JetCorrectionSets.h
+++ b/common/include/JetCorrectionSets.h
@@ -9,6 +9,17 @@
 namespace JERFiles{
 
   /**
+   * JERPathString returns the path of a JER file from JRDatabase for a given 
+   * tag, 
+   * jetCollection,
+   * type (i.e. SF,PtResolution, etc.).
+   * To be used for example in JetResolutionSmearer or when constructing a GenericJetResolutionSmearer
+   */
+  const std::string JERPathStringMC(const std::string & tag,
+                                  const std::string & jetCollection,
+                                  const std::string & type = "SF");  
+
+  /**
    * There are 2 ways to get access to JEC sets, needed for *JetEnergyCorrector class:
    * - use the JECFiles[DATA|MC]() functions
    * - a C++ variable, defined below with the DEFINE_* macros,

--- a/common/src/JetCorrectionSets.cxx
+++ b/common/src/JetCorrectionSets.cxx
@@ -1,6 +1,23 @@
 #include "UHH2/common/include/JetCorrectionSets.h"
 #include <string>
 
+// Getting path of a JER file from JRDatabase (e.g. SF, PtResolution, etc) for a given tag and jetCollection
+const std::string JERFiles::JERPathStringMC(const std::string & tag,
+                                          const std::string & jetCollection,
+                                          const std::string & type){
+  
+  std::string result = "JRDatabase/textFiles/";
+  result += tag;
+  result += "_MC/";
+  result += tag;
+  result += "_MC_";
+  result += type;
+  result += "_";
+  result += jetCollection;
+  result += ".txt";
+  return result;
+  }
+
 //see https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookJetEnergyCorrections#GetTxtFiles how to get the txt files with jet energy corrections from the database
 
 // The idea of the following methods is to simplify the creation of new JEC input files.

--- a/common/src/JetCorrections.cxx
+++ b/common/src/JetCorrections.cxx
@@ -619,10 +619,8 @@ GenericJetResolutionSmearer::GenericJetResolutionSmearer(uhh2::Context& ctx, con
   h_gentopjets_ = ctx.get_handle<std::vector<GenTopJet> >(genjet_label);
 
   //read in file for jet resolution (taken from https://github.com/cms-jet/JRDatabase/blob/master/textFiles/)
-  TString scaleFactorFilename_ = scaleFactorFilename.Contains("JRDatabase/textFiles/")? scaleFactorFilename : "JRDatabase/textFiles/"+scaleFactorFilename;
-  TString resolutionFilename_ = resolutionFilename.Contains("JRDatabase/textFiles/")?  resolutionFilename  : "JRDatabase/textFiles/"+resolutionFilename;
-  res_sf_ = JME::JetResolutionScaleFactor(locate_file(scaleFactorFilename_.Data()));
-  resolution_ = JME::JetResolution(locate_file(resolutionFilename_.Data()));
+  res_sf_ = JME::JetResolutionScaleFactor(locate_file(scaleFactorFilename.Data()));
+  resolution_ = JME::JetResolution(locate_file(resolutionFilename.Data()));
 
 }
 

--- a/common/src/JetCorrections.cxx
+++ b/common/src/JetCorrections.cxx
@@ -566,6 +566,7 @@ JetResolutionSmearer::JetResolutionSmearer(uhh2::Context & ctx){
 
   // Official recommendations:
   // https://twiki.cern.ch/twiki/bin/view/CMS/JetResolution#JER_Scaling_factors_and_Uncertai
+  std::string jetCollection = jetAlgoRadius+"PF"+puName;
   const Year & year = extract_year(ctx);
   std::string version = "";
   if (year == Year::is2016v2 || year == Year::is2016v3) {
@@ -577,16 +578,12 @@ JetResolutionSmearer::JetResolutionSmearer(uhh2::Context & ctx){
   }  else if (year == Year::isUL17) {
     version = "Summer19UL17_JRV2";
   } else if (year == Year::isUL18) {
-    version = "Autumn18_V7";
-    std::cout << "WARNING: UL18 JER need updating - currently no recommendation" << std::endl;
+    version = "Summer19UL18_JRV2";
   } else {
     throw runtime_error("Cannot find suitable jet resolution file & scale factors for this year for JetResolutionSmearer");
   }
 
-  std::string scaleFactorFilename  = "JRDatabase/textFiles/"+version+"_MC/"+version+"_MC_SF_"+jetAlgoRadius+"PF"+puName+".txt";
-  std::string resolutionFilename = "JRDatabase/textFiles/"+version+"_MC/"+version+"_MC_PtResolution_"+jetAlgoRadius+"PF"+puName+".txt";
-
-  m_gjrs = new GenericJetResolutionSmearer(ctx, "jets", "genjets", scaleFactorFilename, resolutionFilename);
+  m_gjrs = new GenericJetResolutionSmearer(ctx, "jets", "genjets",JERFiles::JERPathStringMC(version,jetCollection,"SF"), JERFiles::JERPathStringMC(version,jetCollection,"PtResolution"));
 
 }
 


### PR DESCRIPTION
Port from 102XV2 (#1536), so:

> This adds another method to JERFiles namespace in JetCorrectionSets for locating MC JER files from the JRDatabase in similar fashion as done for the JEC files.

Also updates the recommended JER file version for UL18 (from the mentioned [TWiki)]( https://twiki.cern.ch/twiki/bin/view/CMS/JetResolution#JER_Scaling_factors_and_Uncertai) - is this correct?

I noticed there are some checks on whether the JER-filenames contain `JRDatabase/textFiles/` (in [JetCorrections.cxx#L625](https://github.com/UHH2/UHH2/blob/0210ca1861eff68dc71c9b9e0041b5dde42176f5/common/src/JetCorrections.cxx#L625) ). These are now redundant, correct? Should i remove those two lines and add a commit to this PR?

[only compile]