### PR TITLE
[102X] cherry-pick: Fix order in CommonModules so exits first

### DIFF
--- a/common/src/CommonModules.cxx
+++ b/common/src/CommonModules.cxx
@@ -169,6 +169,15 @@ bool CommonModules::process(uhh2::Event & event){
     throw runtime_error("CommonModules::init not called (has to be called in AnalysisModule constructor)");
   }
 
+  // Must run these first, otherwise e.g. JEC that depend on valid run number will crash
+  if(event.isRealData && lumisel){
+    if(!lumi_selection->passes(event)) return false;
+  }
+
+  if(metfilters){
+    if(!metfilters_selection->passes(event)) return false;
+  }
+
   for(auto & m : modules){
     m->process(event);
   }
@@ -209,17 +218,6 @@ bool CommonModules::process(uhh2::Event & event){
 
   if(jetptsort){
     sort_by_pt(*event.jets);
-  }
-
-  // Put the return parts last, such that every other modifying module always runs
-  // This avoids bugs where this function is exited early, but the user expects
-  // the other modules to always run
-  if(event.isRealData && lumisel){
-    if(!lumi_selection->passes(event)) return false;
-  }
-
-  if(metfilters){
-    if(!metfilters_selection->passes(event)) return false;
   }
 
   return true;


### PR DESCRIPTION
This means that invalid runs won't be passed onto later
modules, e.g. JECs, that depend on run number.

The previous idea about being 'safer' was wrong -
only by using the return value can the analyzer
properly handle things.

This Pull Request will start automatic compilation, then making + testing of ntuples:
[only compile]


