### PR TITLE
new UL18 jec tag and version

### DIFF
--- a/common/src/CommonModules.cxx
+++ b/common/src/CommonModules.cxx
@@ -34,9 +34,8 @@ CommonModules::CommonModules(){
   jec_tag_UL17 = "Summer19UL17";
   jec_ver_UL17 = "5";
 
-  // FIXME: update when official set
-  jec_tag_UL18 = "Autumn18";
-  jec_ver_UL18 = "19";
+  jec_tag_UL18 = "Summer19UL18";
+  jec_ver_UL18 = "5";
 
   jec_jet_coll = "AK4PFchs";
 }


### PR DESCRIPTION
This Pull Request will start automatic compilation, then making + testing of ntuples:

- Don't want to run any of this? (e.g. only XML files) Remove the @: [ci @ skip]

- Only want to compile, but don't make + test ntuples? (e.g. change `CommonModules.cxx`) Remove the @: [only @ compile]

Please include destination branch in title, e.g. `[102X]`, + short meaningful title

Please include an explanation message if it's something more complex than just XML dataset files:

Updated UL18 jec tag and version in CommonModules