### PR TITLE
[106X] Using Puppi v15 in Ntuple generator (re-installation of UHH2 required since newer CMSSW version is needed)

### DIFF
--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -1187,23 +1187,21 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
     )
     task.add(process.rekeyPackedPatJetsAk8PuppiJets)
 
-    #### update PUPPI to v14
-    from CommonTools.PileupAlgos.customizePuppiTune_cff import UpdatePuppiTuneV14
-    UpdatePuppiTuneV14(process, not useData)
+    #### update PUPPI to v15
+    from CommonTools.PileupAlgos.customizePuppiTune_cff import UpdatePuppiTuneV15
+    UpdatePuppiTuneV15(process, not useData)
 
     # Update DeepBoosted training to V2 for everything but 2016v2
     # Check https://twiki.cern.ch/twiki/bin/view/CMS/DeepAKXTagging for latest recommendations
     # e.g. 2018 specific training
     if (year != "2016v2"):
-        from RecoBTag.MXNet.pfDeepBoostedJet_cff import pfDeepBoostedJetTags, pfMassDecorrelatedDeepBoostedJetTags
-        from RecoBTag.MXNet.Parameters.V02.pfDeepBoostedJetPreprocessParams_cfi import pfDeepBoostedJetPreprocessParams as pfDeepBoostedJetPreprocessParamsV02
-        from RecoBTag.MXNet.Parameters.V02.pfMassDecorrelatedDeepBoostedJetPreprocessParams_cfi import pfMassDecorrelatedDeepBoostedJetPreprocessParams as pfMassDecorrelatedDeepBoostedJetPreprocessParamsV02
+        from RecoBTag.ONNXRuntime.pfDeepBoostedJet_cff import pfDeepBoostedJetTags, pfMassDecorrelatedDeepBoostedJetTags
+        from RecoBTag.ONNXRuntime.Parameters.DeepBoostedJet.V02.pfDeepBoostedJetPreprocessParams_cfi import pfDeepBoostedJetPreprocessParams as pfDeepBoostedJetPreprocessParamsV02
+        from RecoBTag.ONNXRuntime.Parameters.DeepBoostedJet.V02.pfMassDecorrelatedDeepBoostedJetPreprocessParams_cfi import pfMassDecorrelatedDeepBoostedJetPreprocessParams as pfMassDecorrelatedDeepBoostedJetPreprocessParamsV02
         pfDeepBoostedJetTags.preprocessParams = pfDeepBoostedJetPreprocessParamsV02
-        pfDeepBoostedJetTags.model_path = 'RecoBTag/Combined/data/DeepBoostedJet/V02/full/resnet-symbol.json'
-        pfDeepBoostedJetTags.param_path = 'RecoBTag/Combined/data/DeepBoostedJet/V02/full/resnet-0000.params'
+        pfDeepBoostedJetTags.model_path = 'RecoBTag/Combined/data/DeepBoostedJet/V02/full/resnet.onnx'
         pfMassDecorrelatedDeepBoostedJetTags.preprocessParams = pfMassDecorrelatedDeepBoostedJetPreprocessParamsV02
-        pfMassDecorrelatedDeepBoostedJetTags.model_path = 'RecoBTag/Combined/data/DeepBoostedJet/V02/decorrelated/resnet-symbol.json'
-        pfMassDecorrelatedDeepBoostedJetTags.param_path = 'RecoBTag/Combined/data/DeepBoostedJet/V02/decorrelated/resnet-0000.params'
+        pfMassDecorrelatedDeepBoostedJetTags.model_path = 'RecoBTag/Combined/data/DeepBoostedJet/V02/decorrelated/resnet.onnx'
 
     ###############################################
     # Do deep flavours & deep tagging

--- a/core/python/ntuplewriter_data_UL17.py
+++ b/core/python/ntuplewriter_data_UL17.py
@@ -13,9 +13,8 @@ process = generate_process(year="UL17", useData=True)
 
 # Please do not commit changes to source filenames - used for consistency testing
 process.source.fileNames = cms.untracked.vstring([
-    '/store/data/Run2017D/JetHT/MINIAOD/09Aug2019_UL2017-v1/50000/8320FFCD-A41A-1849-A506-52EF233246F4.root'
-    # '/store/data/Run2017D/SingleElectron/MINIAOD/09Aug2019_UL2017-v1/270000/9CEAFD24-9D9D-304D-BEC0-3FE3B4903429.root'
-    # '/store/data/Run2017D/SingleMuon/MINIAOD/09Aug2019_UL2017-v1/50000/ACB10C92-4B9B-5749-8C96-60942152E15C.root'
+    '/store/data/Run2017D/SingleElectron/MINIAOD/UL2017_MiniAODv2-v1/280000/04778A16-A43B-CC48-9384-D49E50278A54.root'
+    # '/store/data/Run2017D/SingleMuon/MINIAOD/UL2017_MiniAODv2-v1/280000/01BDB8D7-E428-5F48-ABF5-EAAD3C540E56.root'
 ])
 
 # Do this after setting process.source.fileNames, since we want the ability to override it on the commandline

--- a/core/python/ntuplewriter_data_UL17_leadingjetConstits.py
+++ b/core/python/ntuplewriter_data_UL17_leadingjetConstits.py
@@ -13,9 +13,8 @@ process = generate_process(year="UL17", useData=True)
 
 # Please do not commit changes to source filenames - used for consistency testing
 process.source.fileNames = cms.untracked.vstring([
-    '/store/data/Run2017D/JetHT/MINIAOD/09Aug2019_UL2017-v1/50000/8320FFCD-A41A-1849-A506-52EF233246F4.root'
-    # '/store/data/Run2017D/SingleElectron/MINIAOD/09Aug2019_UL2017-v1/270000/9CEAFD24-9D9D-304D-BEC0-3FE3B4903429.root'
-    # '/store/data/Run2017D/SingleMuon/MINIAOD/09Aug2019_UL2017-v1/50000/ACB10C92-4B9B-5749-8C96-60942152E15C.root'
+    '/store/data/Run2017D/SingleElectron/MINIAOD/UL2017_MiniAODv2-v1/280000/04778A16-A43B-CC48-9384-D49E50278A54.root'
+    # '/store/data/Run2017D/SingleMuon/MINIAOD/UL2017_MiniAODv2-v1/280000/01BDB8D7-E428-5F48-ABF5-EAAD3C540E56.root'
 ])
 
 # Turn on jet constituent storing for leading three AK4 jets

--- a/core/python/ntuplewriter_mc_UL17.py
+++ b/core/python/ntuplewriter_mc_UL17.py
@@ -13,7 +13,7 @@ process = generate_process(year="UL17", useData=False)
 
 # Please do not commit changes to source filenames - used for consistency testing
 process.source.fileNames = cms.untracked.vstring([
-    '/store/mc/RunIISummer19UL17MiniAOD/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/106X_mc2017_realistic_v6-v2/30000/BE7AE880-FE10-334A-89DC-35CCB590D9DD.root'
+    '/store/mc/RunIISummer20UL17MiniAOD/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/106X_mc2017_realistic_v6-v2/00000/1DF4761B-CDF0-B646-92FE-2E40D977394D.root'
 ])
 
 # Do this after setting process.source.fileNames, since we want the ability to override it on the commandline

--- a/core/python/ntuplewriter_mc_UL17_leadingjetConstits.py
+++ b/core/python/ntuplewriter_mc_UL17_leadingjetConstits.py
@@ -13,7 +13,7 @@ process = generate_process(year="UL17", useData=False)
 
 # Please do not commit changes to source filenames - used for consistency testing
 process.source.fileNames = cms.untracked.vstring([
-    '/store/mc/RunIISummer19UL17MiniAOD/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/106X_mc2017_realistic_v6-v2/30000/BE7AE880-FE10-334A-89DC-35CCB590D9DD.root'
+    '/store/mc/RunIISummer20UL17MiniAOD/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/106X_mc2017_realistic_v6-v2/00000/1DF4761B-CDF0-B646-92FE-2E40D977394D.root'
 ])
 
 # Turn on jet constituent storing for leading three AK4 jets

--- a/scripts/install.csh
+++ b/scripts/install.csh
@@ -20,7 +20,7 @@ else
     echo "Please log into one and run this again"
     exit 1
 endif
-set CMSREL=CMSSW_10_6_8
+set CMSREL=CMSSW_10_6_17
 eval `cmsrel ${CMSREL}`
 cd ${CMSREL}/src
 eval `scramv1 runtime -csh`

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -119,7 +119,7 @@ time git clone https://github.com/UHH2/SFrame.git
 # Get CMSSW
 export SCRAM_ARCH=slc7_amd64_gcc700
 checkArch
-CMSREL=CMSSW_10_6_13
+CMSREL=CMSSW_10_6_17
 eval `cmsrel ${CMSREL}`
 cd ${CMSREL}/src
 eval `scramv1 runtime -sh`


### PR DESCRIPTION
This Pull Request will start automatic compilation, then making + testing of ntuples:

- Don't want to run any of this? (e.g. only XML files) Remove the @: [ci @ skip]

- Only want to compile, but don't make + test ntuples? (e.g. change `CommonModules.cxx`) Remove the @: [only @ compile]

Please include destination branch in title, e.g. `[102X]`, + short meaningful title

Please include an explanation message if it's something more complex than just XML dataset files:

**Updates:**
- Using Puppi v15 in Ntuple generator, following instructions from https://twiki.cern.ch/twiki/bin/viewauth/CMS/PUPPI#Recipe_for_106X
I will attach sanity-check plots in a separate comment to this PR
- This recipe requires CMSSW_10_6_>=17, thus updating the UHH2 install scripts
- This new CMSSW version also requires a further update: ONNXRuntime replaces MXNet (frameworks used for DeepBoosted stuff), see e. g. https://github.com/cms-sw/cmssw/pull/30123 and https://github.com/cms-sw/cmssw/pull/31037
However, this comes with a change of the DeepBoosted outputs, see plot in following comment to this PR (I am not sure why, most likely it is due to a change of the training version)
- Replaced source files for testing of UL17 ntuplewriters (old ones do not exist anymore)