### PR TITLE
[102X] Fixed string interpolation compilation error in TF2 deployment script

### DIFF
--- a/common/python/prepare_for_deployment_TF2.py
+++ b/common/python/prepare_for_deployment_TF2.py
@@ -46,7 +46,7 @@ print(frozen_func.outputs)
 # writing graph (the .pb file)
 tf.io.write_graph(graph_or_graph_def=frozen_func.graph,
                   logdir=frozen_out_path,
-                  name=f"{frozen_graph_filename}.pb",
+                  name=frozen_graph_filename+".pb",
                   as_text=False)
 
 # writing the .config.pbtxt file


### PR DESCRIPTION
[only compile]

I did not know that python files are compiled in UHH2. When I compiled UHH2 offline, i noticed an error in "prepare_for_deployment_TF2.py", which uses string interpolation that is not available in the used python version.

To avoid anyone stumbling over this compilation error, this PR fixes it (and now uses "only compile" to check whether compilation works).

