### PR TITLE
[106X] Updating to recommended CMSSW version and adding ParticleNet

### DIFF
--- a/core/include/TopJet.h
+++ b/core/include/TopJet.h
@@ -150,6 +150,49 @@ public:
       m_btag_DeepBoosted_probZqq=-2;
       m_btag_DeepBoosted_probHqqqq=-2;
       m_btag_DeepBoosted_probZbb=-2;
+      
+      m_btag_ParticleNetJetTags_probTbcq=-2;
+      m_btag_ParticleNetJetTags_probTbqq=-2;
+      m_btag_ParticleNetJetTags_probTbc=-2;
+      m_btag_ParticleNetJetTags_probTbq=-2;
+      m_btag_ParticleNetJetTags_probTbel=-2;
+      m_btag_ParticleNetJetTags_probTbmu=-2;
+      m_btag_ParticleNetJetTags_probTbta=-2;
+      m_btag_ParticleNetJetTags_probWcq=-2;
+      m_btag_ParticleNetJetTags_probWqq=-2;
+      m_btag_ParticleNetJetTags_probZbb=-2;
+      m_btag_ParticleNetJetTags_probZcc=-2;
+      m_btag_ParticleNetJetTags_probZqq=-2;
+      m_btag_ParticleNetJetTags_probHbb=-2;
+      m_btag_ParticleNetJetTags_probHcc=-2;
+      m_btag_ParticleNetJetTags_probHqqqq=-2;
+      m_btag_ParticleNetJetTags_probQCDbb=-2;
+      m_btag_ParticleNetJetTags_probQCDcc=-2;
+      m_btag_ParticleNetJetTags_probQCDb=-2;
+      m_btag_ParticleNetJetTags_probQCDc=-2;
+      m_btag_ParticleNetJetTags_probQCDothers=-2;
+
+      m_btag_ParticleNetDiscriminatorsJetTags_TvsQCD=-2;
+      m_btag_ParticleNetDiscriminatorsJetTags_WvsQCD=-2;
+      m_btag_ParticleNetDiscriminatorsJetTags_ZvsQCD=-2;
+      m_btag_ParticleNetDiscriminatorsJetTags_ZbbvsQCD=-2;
+      m_btag_ParticleNetDiscriminatorsJetTags_HbbvsQCD=-2;
+      m_btag_ParticleNetDiscriminatorsJetTags_HccvsQCD=-2;
+      m_btag_ParticleNetDiscriminatorsJetTags_H4qvsQCD=-2;
+
+      m_btag_MassDecorrelatedParticleNetJetTags_probXbb=-2;
+      m_btag_MassDecorrelatedParticleNetJetTags_probXcc=-2;
+      m_btag_MassDecorrelatedParticleNetJetTags_probXqq=-2;
+      m_btag_MassDecorrelatedParticleNetJetTags_probQCDbb=-2;
+      m_btag_MassDecorrelatedParticleNetJetTags_probQCDcc=-2;
+      m_btag_MassDecorrelatedParticleNetJetTags_probQCDb=-2;
+      m_btag_MassDecorrelatedParticleNetJetTags_probQCDc=-2;
+      m_btag_MassDecorrelatedParticleNetJetTags_probQCDothers=-2;
+
+      m_btag_MassDecorrelatedParticleNetDiscriminatorsJetTags_XbbvsQCD=-2;
+      m_btag_MassDecorrelatedParticleNetDiscriminatorsJetTags_XccvsQCD=-2;
+      m_btag_MassDecorrelatedParticleNetDiscriminatorsJetTags_XqqvsQCD=-2;
+
 
   }
 
@@ -275,7 +318,53 @@ public:
   float btag_MassDecorrelatedDeepBoosted_raw_score_h()const{return m_btag_MassDecorrelatedDeepBoosted_probHbb+m_btag_MassDecorrelatedDeepBoosted_probHcc+m_btag_MassDecorrelatedDeepBoosted_probHqqqq;}
 
 
+  //raw scores of ParticleNet tagger
+  float btag_ParticleNetJetTags_probTbcq() const{return m_btag_ParticleNetJetTags_probTbcq;}
+  float btag_ParticleNetJetTags_probTbqq() const{return m_btag_ParticleNetJetTags_probTbqq;}
+  float btag_ParticleNetJetTags_probTbc() const{return m_btag_ParticleNetJetTags_probTbc;}
+  float btag_ParticleNetJetTags_probTbq() const{return m_btag_ParticleNetJetTags_probTbq;}
+  float btag_ParticleNetJetTags_probTbel() const{return m_btag_ParticleNetJetTags_probTbel;}
+  float btag_ParticleNetJetTags_probTbmu() const{return m_btag_ParticleNetJetTags_probTbmu;}
+  float btag_ParticleNetJetTags_probTbta() const{return m_btag_ParticleNetJetTags_probTbta;}
+  float btag_ParticleNetJetTags_probWcq() const{return m_btag_ParticleNetJetTags_probWcq;}
+  float btag_ParticleNetJetTags_probWqq() const{return m_btag_ParticleNetJetTags_probWqq;}
+  float btag_ParticleNetJetTags_probZbb() const{return m_btag_ParticleNetJetTags_probZbb;}
+  float btag_ParticleNetJetTags_probZcc() const{return m_btag_ParticleNetJetTags_probZcc;}
+  float btag_ParticleNetJetTags_probZqq() const{return m_btag_ParticleNetJetTags_probZqq;}
+  float btag_ParticleNetJetTags_probHbb() const{return m_btag_ParticleNetJetTags_probHbb;}
+  float btag_ParticleNetJetTags_probHcc() const{return m_btag_ParticleNetJetTags_probHcc;}
+  float btag_ParticleNetJetTags_probHqqqq() const{return m_btag_ParticleNetJetTags_probHqqqq;}
+  float btag_ParticleNetJetTags_probQCDbb() const{return m_btag_ParticleNetJetTags_probQCDbb;}
+  float btag_ParticleNetJetTags_probQCDcc() const{return m_btag_ParticleNetJetTags_probQCDcc;}
+  float btag_ParticleNetJetTags_probQCDb() const{return m_btag_ParticleNetJetTags_probQCDb;}
+  float btag_ParticleNetJetTags_probQCDc() const{return m_btag_ParticleNetJetTags_probQCDc;}
+  float btag_ParticleNetJetTags_probQCDothers() const{return m_btag_ParticleNetJetTags_probQCDothers;}
+  float btag_ParticleNetJetTags_probQCD() const{return m_btag_ParticleNetJetTags_probQCDbb+m_btag_ParticleNetJetTags_probQCDcc+m_btag_ParticleNetJetTags_probQCDb+m_btag_ParticleNetJetTags_probQCDc+m_btag_ParticleNetJetTags_probQCDothers;}
 
+  //binary scores of ParticleNet, see https://github.com/cms-sw/cmssw/blob/master/RecoBTag/ONNXRuntime/python/pfParticleNetDiscriminatorsJetTags_cfi.py
+  float btag_ParticleNetDiscriminatorsJetTags_TvsQCD() const{return m_btag_ParticleNetDiscriminatorsJetTags_TvsQCD;}
+  float btag_ParticleNetDiscriminatorsJetTags_WvsQCD() const{return m_btag_ParticleNetDiscriminatorsJetTags_WvsQCD;}
+  float btag_ParticleNetDiscriminatorsJetTags_ZvsQCD() const{return m_btag_ParticleNetDiscriminatorsJetTags_ZvsQCD;}
+  float btag_ParticleNetDiscriminatorsJetTags_ZbbvsQCD() const{return m_btag_ParticleNetDiscriminatorsJetTags_ZbbvsQCD;}
+  float btag_ParticleNetDiscriminatorsJetTags_HbbvsQCD() const{return m_btag_ParticleNetDiscriminatorsJetTags_HbbvsQCD;}
+  float btag_ParticleNetDiscriminatorsJetTags_HccvsQCD() const{return m_btag_ParticleNetDiscriminatorsJetTags_HccvsQCD;}
+  float btag_ParticleNetDiscriminatorsJetTags_H4qvsQCD() const{return m_btag_ParticleNetDiscriminatorsJetTags_H4qvsQCD;}
+
+  //raw scores of mass decorrelated ParticleNet tagger
+  float btag_MassDecorrelatedParticleNetJetTags_probXbb() const{return m_btag_MassDecorrelatedParticleNetJetTags_probXbb;}
+  float btag_MassDecorrelatedParticleNetJetTags_probXcc() const{return m_btag_MassDecorrelatedParticleNetJetTags_probXcc;}
+  float btag_MassDecorrelatedParticleNetJetTags_probXqq() const{return m_btag_MassDecorrelatedParticleNetJetTags_probXqq;}
+  float btag_MassDecorrelatedParticleNetJetTags_probQCDbb() const{return m_btag_MassDecorrelatedParticleNetJetTags_probQCDbb;}
+  float btag_MassDecorrelatedParticleNetJetTags_probQCDcc() const{return m_btag_MassDecorrelatedParticleNetJetTags_probQCDcc;}
+  float btag_MassDecorrelatedParticleNetJetTags_probQCDb() const{return m_btag_MassDecorrelatedParticleNetJetTags_probQCDb;}
+  float btag_MassDecorrelatedParticleNetJetTags_probQCDc() const{return m_btag_MassDecorrelatedParticleNetJetTags_probQCDc;}
+  float btag_MassDecorrelatedParticleNetJetTags_probQCDothers() const{return m_btag_MassDecorrelatedParticleNetJetTags_probQCDothers;}
+  float btag_MassDecorrelatedParticleNetJetTags_probQCD() const{return m_btag_MassDecorrelatedParticleNetJetTags_probQCDbb+m_btag_MassDecorrelatedParticleNetJetTags_probQCDcc+m_btag_MassDecorrelatedParticleNetJetTags_probQCDb+m_btag_MassDecorrelatedParticleNetJetTags_probQCDc+m_btag_MassDecorrelatedParticleNetJetTags_probQCDothers;}
+
+  //binary scores of mass decorrelated ParticleNet tagger, see https://github.com/cms-sw/cmssw/blob/master/RecoBTag/ONNXRuntime/python/pfMassDecorrelatedParticleNetDiscriminatorsJetTags_cfi.py
+  float btag_MassDecorrelatedParticleNetDiscriminatorsJetTags_XbbvsQCD() const{return m_btag_MassDecorrelatedParticleNetDiscriminatorsJetTags_XbbvsQCD;}
+  float btag_MassDecorrelatedParticleNetDiscriminatorsJetTags_XccvsQCD() const{return m_btag_MassDecorrelatedParticleNetDiscriminatorsJetTags_XccvsQCD;}
+  float btag_MassDecorrelatedParticleNetDiscriminatorsJetTags_XqqvsQCD() const{return m_btag_MassDecorrelatedParticleNetDiscriminatorsJetTags_XqqvsQCD;}
 
   
 
@@ -377,6 +466,48 @@ public:
   void set_btag_DeepBoosted_probHqqqq(float x) { m_btag_DeepBoosted_probHqqqq=x;}
   void set_btag_DeepBoosted_probZbb(float x) { m_btag_DeepBoosted_probZbb=x;}
 
+  void set_btag_ParticleNetJetTags_probTbcq(float x) { m_btag_ParticleNetJetTags_probTbcq=x;}
+  void set_btag_ParticleNetJetTags_probTbqq(float x) { m_btag_ParticleNetJetTags_probTbqq=x;}
+  void set_btag_ParticleNetJetTags_probTbc(float x) { m_btag_ParticleNetJetTags_probTbc=x;}
+  void set_btag_ParticleNetJetTags_probTbq(float x) { m_btag_ParticleNetJetTags_probTbq=x;}
+  void set_btag_ParticleNetJetTags_probTbel(float x) { m_btag_ParticleNetJetTags_probTbel=x;}
+  void set_btag_ParticleNetJetTags_probTbmu(float x) { m_btag_ParticleNetJetTags_probTbmu=x;}
+  void set_btag_ParticleNetJetTags_probTbta(float x) { m_btag_ParticleNetJetTags_probTbta=x;}
+  void set_btag_ParticleNetJetTags_probWcq(float x) { m_btag_ParticleNetJetTags_probWcq=x;}
+  void set_btag_ParticleNetJetTags_probWqq(float x) { m_btag_ParticleNetJetTags_probWqq=x;}
+  void set_btag_ParticleNetJetTags_probZbb(float x) { m_btag_ParticleNetJetTags_probZbb=x;}
+  void set_btag_ParticleNetJetTags_probZcc(float x) { m_btag_ParticleNetJetTags_probZcc=x;}
+  void set_btag_ParticleNetJetTags_probZqq(float x) { m_btag_ParticleNetJetTags_probZqq=x;}
+  void set_btag_ParticleNetJetTags_probHbb(float x) { m_btag_ParticleNetJetTags_probHbb=x;}
+  void set_btag_ParticleNetJetTags_probHcc(float x) { m_btag_ParticleNetJetTags_probHcc=x;}
+  void set_btag_ParticleNetJetTags_probHqqqq(float x) { m_btag_ParticleNetJetTags_probHqqqq=x;}
+  void set_btag_ParticleNetJetTags_probQCDbb(float x) { m_btag_ParticleNetJetTags_probQCDbb=x;}
+  void set_btag_ParticleNetJetTags_probQCDcc(float x) { m_btag_ParticleNetJetTags_probQCDcc=x;}
+  void set_btag_ParticleNetJetTags_probQCDb(float x) { m_btag_ParticleNetJetTags_probQCDb=x;}
+  void set_btag_ParticleNetJetTags_probQCDc(float x) { m_btag_ParticleNetJetTags_probQCDc=x;}
+  void set_btag_ParticleNetJetTags_probQCDothers(float x) { m_btag_ParticleNetJetTags_probQCDothers=x;}
+
+  void set_btag_ParticleNetDiscriminatorsJetTags_TvsQCD(float x) { m_btag_ParticleNetDiscriminatorsJetTags_TvsQCD=x;}
+  void set_btag_ParticleNetDiscriminatorsJetTags_WvsQCD(float x) { m_btag_ParticleNetDiscriminatorsJetTags_WvsQCD=x;}
+  void set_btag_ParticleNetDiscriminatorsJetTags_ZvsQCD(float x) { m_btag_ParticleNetDiscriminatorsJetTags_ZvsQCD=x;}
+  void set_btag_ParticleNetDiscriminatorsJetTags_ZbbvsQCD(float x) { m_btag_ParticleNetDiscriminatorsJetTags_ZbbvsQCD=x;}
+  void set_btag_ParticleNetDiscriminatorsJetTags_HbbvsQCD(float x) { m_btag_ParticleNetDiscriminatorsJetTags_HbbvsQCD=x;}
+  void set_btag_ParticleNetDiscriminatorsJetTags_HccvsQCD(float x) { m_btag_ParticleNetDiscriminatorsJetTags_HccvsQCD=x;}
+  void set_btag_ParticleNetDiscriminatorsJetTags_H4qvsQCD(float x) { m_btag_ParticleNetDiscriminatorsJetTags_H4qvsQCD=x;}
+
+  void set_btag_MassDecorrelatedParticleNetJetTags_probXbb(float x) { m_btag_MassDecorrelatedParticleNetJetTags_probXbb=x;}
+  void set_btag_MassDecorrelatedParticleNetJetTags_probXcc(float x) { m_btag_MassDecorrelatedParticleNetJetTags_probXcc=x;}
+  void set_btag_MassDecorrelatedParticleNetJetTags_probXqq(float x) { m_btag_MassDecorrelatedParticleNetJetTags_probXqq=x;}
+  void set_btag_MassDecorrelatedParticleNetJetTags_probQCDbb(float x) { m_btag_MassDecorrelatedParticleNetJetTags_probQCDbb=x;}
+  void set_btag_MassDecorrelatedParticleNetJetTags_probQCDcc(float x) { m_btag_MassDecorrelatedParticleNetJetTags_probQCDcc=x;}
+  void set_btag_MassDecorrelatedParticleNetJetTags_probQCDb(float x) { m_btag_MassDecorrelatedParticleNetJetTags_probQCDb=x;}
+  void set_btag_MassDecorrelatedParticleNetJetTags_probQCDc(float x) { m_btag_MassDecorrelatedParticleNetJetTags_probQCDc=x;}
+  void set_btag_MassDecorrelatedParticleNetJetTags_probQCDothers(float x) { m_btag_MassDecorrelatedParticleNetJetTags_probQCDothers=x;}
+
+  void set_btag_MassDecorrelatedParticleNetDiscriminatorsJetTags_XbbvsQCD(float x) { m_btag_MassDecorrelatedParticleNetDiscriminatorsJetTags_XbbvsQCD=x;}
+  void set_btag_MassDecorrelatedParticleNetDiscriminatorsJetTags_XccvsQCD(float x) { m_btag_MassDecorrelatedParticleNetDiscriminatorsJetTags_XccvsQCD=x;}
+  void set_btag_MassDecorrelatedParticleNetDiscriminatorsJetTags_XqqvsQCD(float x) { m_btag_MassDecorrelatedParticleNetDiscriminatorsJetTags_XqqvsQCD=x;}
+
 private:
   std::vector<Jet> m_subjets;
 
@@ -463,6 +594,48 @@ private:
   float m_btag_DeepBoosted_probZqq;
   float m_btag_DeepBoosted_probHqqqq;
   float m_btag_DeepBoosted_probZbb;
+
+  float m_btag_ParticleNetJetTags_probTbcq;
+  float m_btag_ParticleNetJetTags_probTbqq;
+  float m_btag_ParticleNetJetTags_probTbc;
+  float m_btag_ParticleNetJetTags_probTbq;
+  float m_btag_ParticleNetJetTags_probTbel;
+  float m_btag_ParticleNetJetTags_probTbmu;
+  float m_btag_ParticleNetJetTags_probTbta;
+  float m_btag_ParticleNetJetTags_probWcq;
+  float m_btag_ParticleNetJetTags_probWqq;
+  float m_btag_ParticleNetJetTags_probZbb;
+  float m_btag_ParticleNetJetTags_probZcc;
+  float m_btag_ParticleNetJetTags_probZqq;
+  float m_btag_ParticleNetJetTags_probHbb;
+  float m_btag_ParticleNetJetTags_probHcc;
+  float m_btag_ParticleNetJetTags_probHqqqq;
+  float m_btag_ParticleNetJetTags_probQCDbb;
+  float m_btag_ParticleNetJetTags_probQCDcc;
+  float m_btag_ParticleNetJetTags_probQCDb;
+  float m_btag_ParticleNetJetTags_probQCDc;
+  float m_btag_ParticleNetJetTags_probQCDothers;
+
+  float m_btag_ParticleNetDiscriminatorsJetTags_TvsQCD;
+  float m_btag_ParticleNetDiscriminatorsJetTags_WvsQCD;
+  float m_btag_ParticleNetDiscriminatorsJetTags_ZvsQCD;
+  float m_btag_ParticleNetDiscriminatorsJetTags_ZbbvsQCD;
+  float m_btag_ParticleNetDiscriminatorsJetTags_HbbvsQCD;
+  float m_btag_ParticleNetDiscriminatorsJetTags_HccvsQCD;
+  float m_btag_ParticleNetDiscriminatorsJetTags_H4qvsQCD;
+
+  float m_btag_MassDecorrelatedParticleNetJetTags_probXbb;
+  float m_btag_MassDecorrelatedParticleNetJetTags_probXcc;
+  float m_btag_MassDecorrelatedParticleNetJetTags_probXqq;
+  float m_btag_MassDecorrelatedParticleNetJetTags_probQCDbb;
+  float m_btag_MassDecorrelatedParticleNetJetTags_probQCDcc;
+  float m_btag_MassDecorrelatedParticleNetJetTags_probQCDb;
+  float m_btag_MassDecorrelatedParticleNetJetTags_probQCDc;
+  float m_btag_MassDecorrelatedParticleNetJetTags_probQCDothers;
+
+  float m_btag_MassDecorrelatedParticleNetDiscriminatorsJetTags_XbbvsQCD;
+  float m_btag_MassDecorrelatedParticleNetDiscriminatorsJetTags_XccvsQCD;
+  float m_btag_MassDecorrelatedParticleNetDiscriminatorsJetTags_XqqvsQCD;
 
   Tags tags;
 };

--- a/core/plugins/NtupleWriterJets.cxx
+++ b/core/plugins/NtupleWriterJets.cxx
@@ -491,7 +491,17 @@ void NtupleWriterTopJets::fill_btag_info(uhh2::Event & uevent, const pat::Jet & 
     decorrmass_deepboosted_probQCDothers=false,decorrmass_deepboosted_probQCDb=false,decorrmass_deepboosted_probTbc=false,
     decorrmass_deepboosted_probWqq=false,decorrmass_deepboosted_probQCDcc=false,decorrmass_deepboosted_probHcc=false,
     decorrmass_deepboosted_probWcq=false,decorrmass_deepboosted_probZcc=false,decorrmass_deepboosted_probZqq=false,
-    decorrmass_deepboosted_probHqqqq=false,decorrmass_deepboosted_probZbb=false;
+    decorrmass_deepboosted_probHqqqq=false,decorrmass_deepboosted_probZbb=false,
+    particlenet_probTbcq=false,particlenet_probTbqq=false,particlenet_probTbc=false,particlenet_probTbq=false,
+    particlenet_probTbel=false,particlenet_probTbmu=false,particlenet_probTbta=false,particlenet_probWcq=false,
+    particlenet_probWqq=false,particlenet_probZbb=false,particlenet_probZcc=false,particlenet_probZqq=false,
+    particlenet_probHbb=false,particlenet_probHcc=false,particlenet_probHqqqq=false,particlenet_probQCDbb=false,
+    particlenet_probQCDcc=false,particlenet_probQCDb=false,particlenet_probQCDc=false,particlenet_probQCDothers=false,
+    particlenet_TvsQCD=false,particlenet_WvsQCD=false,particlenet_ZvsQCD=false,particlenet_ZbbvsQCD=false,
+    particlenet_HbbvsQCD=false,particlenet_HccvsQCD=false,particlenet_H4qvsQCD=false,
+    decorrmass_particlenet_probXbb=false,decorrmass_particlenet_probXcc=false,decorrmass_particlenet_probXqq=false,decorrmass_particlenet_probQCDbb=false,
+    decorrmass_particlenet_probQCDcc=false,decorrmass_particlenet_probQCDb=false,decorrmass_particlenet_probQCDc=false,decorrmass_particlenet_probQCDothers=false,
+    decorrmass_particlenet_XbbvsQCD=false,decorrmass_particlenet_XccvsQCD=false,decorrmass_particlenet_XqqvsQCD=false;
 
 
     for(const auto & name_value : bdisc){
@@ -761,6 +771,158 @@ void NtupleWriterTopJets::fill_btag_info(uhh2::Event & uevent, const pat::Jet & 
         jet.set_btag_DeepBoosted_probZbb(value);
         deepboosted_probZbb=true;
       }
+      else if(name == "pfParticleNetJetTags:probTbcq"){
+        jet.set_btag_ParticleNetJetTags_probTbcq(value);
+        particlenet_probTbcq = true;
+      }
+      else if(name == "pfParticleNetJetTags:probTbqq"){
+        jet.set_btag_ParticleNetJetTags_probTbqq(value);
+        particlenet_probTbqq = true;
+      }
+      else if(name == "pfParticleNetJetTags:probTbc"){
+        jet.set_btag_ParticleNetJetTags_probTbc(value);
+        particlenet_probTbc = true;
+      }
+      else if(name == "pfParticleNetJetTags:probTbq"){
+        jet.set_btag_ParticleNetJetTags_probTbq(value);
+        particlenet_probTbq = true;
+      }
+      else if(name == "pfParticleNetJetTags:probTbel"){
+        jet.set_btag_ParticleNetJetTags_probTbel(value);
+        particlenet_probTbel = true;
+      }
+      else if(name == "pfParticleNetJetTags:probTbmu"){
+        jet.set_btag_ParticleNetJetTags_probTbmu(value);
+        particlenet_probTbmu = true;
+      }
+      else if(name == "pfParticleNetJetTags:probTbta"){
+        jet.set_btag_ParticleNetJetTags_probTbta(value);
+        particlenet_probTbta = true;
+      }
+      else if(name == "pfParticleNetJetTags:probWcq"){
+        jet.set_btag_ParticleNetJetTags_probWcq(value);
+        particlenet_probWcq = true;
+      }
+      else if(name == "pfParticleNetJetTags:probWqq"){
+        jet.set_btag_ParticleNetJetTags_probWqq(value);
+        particlenet_probWqq = true;
+      }
+      else if(name == "pfParticleNetJetTags:probZbb"){
+        jet.set_btag_ParticleNetJetTags_probZbb(value);
+        particlenet_probZbb = true;
+      }
+      else if(name == "pfParticleNetJetTags:probZcc"){
+        jet.set_btag_ParticleNetJetTags_probZcc(value);
+        particlenet_probZcc = true;
+      }
+      else if(name == "pfParticleNetJetTags:probZqq"){
+        jet.set_btag_ParticleNetJetTags_probZqq(value);
+        particlenet_probZqq = true;
+      }
+      else if(name == "pfParticleNetJetTags:probHbb"){
+        jet.set_btag_ParticleNetJetTags_probHbb(value);
+        particlenet_probHbb = true;
+      }
+      else if(name == "pfParticleNetJetTags:probHcc"){
+        jet.set_btag_ParticleNetJetTags_probHcc(value);
+        particlenet_probHcc = true;
+      }
+      else if(name == "pfParticleNetJetTags:probHqqqq"){
+        jet.set_btag_ParticleNetJetTags_probHqqqq(value);
+        particlenet_probHqqqq = true;
+      }
+      else if(name == "pfParticleNetJetTags:probQCDbb"){
+        jet.set_btag_ParticleNetJetTags_probQCDbb(value);
+        particlenet_probQCDbb = true;
+      }
+      else if(name == "pfParticleNetJetTags:probQCDcc"){
+        jet.set_btag_ParticleNetJetTags_probQCDcc(value);
+        particlenet_probQCDcc = true;
+      }
+      else if(name == "pfParticleNetJetTags:probQCDb"){
+        jet.set_btag_ParticleNetJetTags_probQCDb(value);
+        particlenet_probQCDb = true;
+      }
+      else if(name == "pfParticleNetJetTags:probQCDc"){
+        jet.set_btag_ParticleNetJetTags_probQCDc(value);
+        particlenet_probQCDc = true;
+      }
+      else if(name == "pfParticleNetJetTags:probQCDothers"){
+        jet.set_btag_ParticleNetJetTags_probQCDothers(value);
+        particlenet_probQCDothers = true;
+      }
+      else if(name == "pfParticleNetDiscriminatorsJetTags:TvsQCD"){
+        jet.set_btag_ParticleNetDiscriminatorsJetTags_TvsQCD(value);
+        particlenet_TvsQCD = true;
+      }
+      else if(name == "pfParticleNetDiscriminatorsJetTags:WvsQCD"){
+        jet.set_btag_ParticleNetDiscriminatorsJetTags_WvsQCD(value);
+        particlenet_WvsQCD = true;
+      }
+      else if(name == "pfParticleNetDiscriminatorsJetTags:ZvsQCD"){
+        jet.set_btag_ParticleNetDiscriminatorsJetTags_ZvsQCD(value);
+        particlenet_ZvsQCD = true;
+      }
+      else if(name == "pfParticleNetDiscriminatorsJetTags:ZbbvsQCD"){
+        jet.set_btag_ParticleNetDiscriminatorsJetTags_ZbbvsQCD(value);
+        particlenet_ZbbvsQCD = true;
+      }
+      else if(name == "pfParticleNetDiscriminatorsJetTags:HbbvsQCD"){
+        jet.set_btag_ParticleNetDiscriminatorsJetTags_HbbvsQCD(value);
+        particlenet_HbbvsQCD = true;
+      }
+      else if(name == "pfParticleNetDiscriminatorsJetTags:HccvsQCD"){
+        jet.set_btag_ParticleNetDiscriminatorsJetTags_HccvsQCD(value);
+        particlenet_HccvsQCD = true;
+      }
+      else if(name == "pfParticleNetDiscriminatorsJetTags:H4qvsQCD"){
+        jet.set_btag_ParticleNetDiscriminatorsJetTags_H4qvsQCD(value);
+        particlenet_H4qvsQCD = true;
+      }
+      else if(name == "pfMassDecorrelatedParticleNetJetTags:probXbb"){
+        jet.set_btag_MassDecorrelatedParticleNetJetTags_probXbb(value);
+        decorrmass_particlenet_probXbb = true;
+      }
+      else if(name == "pfMassDecorrelatedParticleNetJetTags:probXcc"){
+        jet.set_btag_MassDecorrelatedParticleNetJetTags_probXcc(value);
+        decorrmass_particlenet_probXcc = true;
+      }
+      else if(name == "pfMassDecorrelatedParticleNetJetTags:probXqq"){
+        jet.set_btag_MassDecorrelatedParticleNetJetTags_probXqq(value);
+        decorrmass_particlenet_probXqq = true;
+      }
+      else if(name == "pfMassDecorrelatedParticleNetJetTags:probQCDbb"){
+        jet.set_btag_MassDecorrelatedParticleNetJetTags_probQCDbb(value);
+        decorrmass_particlenet_probQCDbb = true;
+      }
+      else if(name == "pfMassDecorrelatedParticleNetJetTags:probQCDcc"){
+        jet.set_btag_MassDecorrelatedParticleNetJetTags_probQCDcc(value);
+        decorrmass_particlenet_probQCDcc = true;
+      }
+      else if(name == "pfMassDecorrelatedParticleNetJetTags:probQCDb"){
+        jet.set_btag_MassDecorrelatedParticleNetJetTags_probQCDb(value);
+        decorrmass_particlenet_probQCDb = true;
+      }
+      else if(name == "pfMassDecorrelatedParticleNetJetTags:probQCDc"){
+        jet.set_btag_MassDecorrelatedParticleNetJetTags_probQCDc(value);
+        decorrmass_particlenet_probQCDc = true;
+      }
+      else if(name == "pfMassDecorrelatedParticleNetJetTags:probQCDothers"){
+        jet.set_btag_MassDecorrelatedParticleNetJetTags_probQCDothers(value);
+        decorrmass_particlenet_probQCDothers = true;
+      }
+      else if(name == "pfMassDecorrelatedParticleNetDiscriminatorsJetTags:XbbvsQCD"){
+        jet.set_btag_MassDecorrelatedParticleNetDiscriminatorsJetTags_XbbvsQCD(value);
+        decorrmass_particlenet_XbbvsQCD = true;
+      }
+      else if(name == "pfMassDecorrelatedParticleNetDiscriminatorsJetTags:XccvsQCD"){
+        jet.set_btag_MassDecorrelatedParticleNetDiscriminatorsJetTags_XccvsQCD(value);
+        decorrmass_particlenet_XccvsQCD = true;
+      }
+      else if(name == "pfMassDecorrelatedParticleNetDiscriminatorsJetTags:XqqvsQCD"){
+        jet.set_btag_MassDecorrelatedParticleNetDiscriminatorsJetTags_XqqvsQCD(value);
+        decorrmass_particlenet_XqqvsQCD = true;
+      }
 
     }
 
@@ -788,7 +950,17 @@ void NtupleWriterTopJets::fill_btag_info(uhh2::Event & uevent, const pat::Jet & 
        || !decorrmass_deepboosted_probQCDcc || !decorrmass_deepboosted_probHcc
        || !decorrmass_deepboosted_probWcq || !decorrmass_deepboosted_probZcc
        || !decorrmass_deepboosted_probZqq || !decorrmass_deepboosted_probHqqqq
-       || !decorrmass_deepboosted_probZbb){
+       || !decorrmass_deepboosted_probZbb
+       || !particlenet_probTbcq || !particlenet_probTbqq || !particlenet_probTbc || !particlenet_probTbq
+       || !particlenet_probTbel || !particlenet_probTbmu || !particlenet_probTbta || !particlenet_probWcq
+       || !particlenet_probWqq || !particlenet_probZbb || !particlenet_probZcc || !particlenet_probZqq
+       || !particlenet_probHbb || !particlenet_probHcc || !particlenet_probHqqqq || !particlenet_probQCDbb
+       || !particlenet_probQCDcc || !particlenet_probQCDb || !particlenet_probQCDc || !particlenet_probQCDothers
+       || !particlenet_TvsQCD || !particlenet_WvsQCD || !particlenet_ZvsQCD || !particlenet_ZbbvsQCD
+       || !particlenet_HbbvsQCD || !particlenet_HccvsQCD || !particlenet_H4qvsQCD
+       || !decorrmass_particlenet_probXbb || !decorrmass_particlenet_probXcc || !decorrmass_particlenet_probXqq || !decorrmass_particlenet_probQCDbb
+       || !decorrmass_particlenet_probQCDcc || !decorrmass_particlenet_probQCDb || !decorrmass_particlenet_probQCDc || !decorrmass_particlenet_probQCDothers
+       || !decorrmass_particlenet_XbbvsQCD || !decorrmass_particlenet_XccvsQCD || !decorrmass_particlenet_XqqvsQCD){
       if(btag_warning){
         std::string btag_list = "";
         for(const auto & name_value : bdisc){

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -175,6 +175,47 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
         'pfDeepBoostedJetTags:probZbb'
     ]
 
+    # from RecoBTag.ONNXRuntime.pfParticleNet_cff import _pfParticleNetJetTagsAll as pfParticleNetJetTagsAll
+    pfParticleNetJetTagsAll = [
+    'pfParticleNetJetTags:probTbcq',
+    'pfParticleNetJetTags:probTbqq',
+    'pfParticleNetJetTags:probTbc',
+    'pfParticleNetJetTags:probTbq',
+    'pfParticleNetJetTags:probTbel',
+    'pfParticleNetJetTags:probTbmu',
+    'pfParticleNetJetTags:probTbta',
+    'pfParticleNetJetTags:probWcq',
+    'pfParticleNetJetTags:probWqq',
+    'pfParticleNetJetTags:probZbb',
+    'pfParticleNetJetTags:probZcc',
+    'pfParticleNetJetTags:probZqq',
+    'pfParticleNetJetTags:probHbb',
+    'pfParticleNetJetTags:probHcc',
+    'pfParticleNetJetTags:probHqqqq',
+    'pfParticleNetJetTags:probQCDbb',
+    'pfParticleNetJetTags:probQCDcc',
+    'pfParticleNetJetTags:probQCDb',
+    'pfParticleNetJetTags:probQCDc',
+    'pfParticleNetJetTags:probQCDothers',
+    'pfParticleNetDiscriminatorsJetTags:TvsQCD',
+    'pfParticleNetDiscriminatorsJetTags:WvsQCD',
+    'pfParticleNetDiscriminatorsJetTags:ZvsQCD',
+    'pfParticleNetDiscriminatorsJetTags:ZbbvsQCD',
+    'pfParticleNetDiscriminatorsJetTags:HbbvsQCD',
+    'pfParticleNetDiscriminatorsJetTags:HccvsQCD',
+    'pfParticleNetDiscriminatorsJetTags:H4qvsQCD',
+    'pfMassDecorrelatedParticleNetJetTags:probXbb',
+    'pfMassDecorrelatedParticleNetJetTags:probXcc',
+    'pfMassDecorrelatedParticleNetJetTags:probXqq',
+    'pfMassDecorrelatedParticleNetJetTags:probQCDbb',
+    'pfMassDecorrelatedParticleNetJetTags:probQCDcc',
+    'pfMassDecorrelatedParticleNetJetTags:probQCDb',
+    'pfMassDecorrelatedParticleNetJetTags:probQCDc',
+    'pfMassDecorrelatedParticleNetJetTags:probQCDothers',
+    'pfMassDecorrelatedParticleNetDiscriminatorsJetTags:XbbvsQCD',
+    'pfMassDecorrelatedParticleNetDiscriminatorsJetTags:XccvsQCD',
+    'pfMassDecorrelatedParticleNetDiscriminatorsJetTags:XqqvsQCD']
+    ak8btagDiscriminators += pfParticleNetJetTagsAll
 
     bTagInfos = [
         'pfImpactParameterTagInfos', 'pfSecondaryVertexTagInfos', 'pfInclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos'

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -1187,23 +1187,21 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
     )
     task.add(process.rekeyPackedPatJetsAk8PuppiJets)
 
-    #### update PUPPI to v14
-    from CommonTools.PileupAlgos.customizePuppiTune_cff import UpdatePuppiTuneV14
-    UpdatePuppiTuneV14(process, not useData)
+    #### update PUPPI to v15
+    from CommonTools.PileupAlgos.customizePuppiTune_cff import UpdatePuppiTuneV15
+    UpdatePuppiTuneV15(process, not useData)
 
     # Update DeepBoosted training to V2 for everything but 2016v2
     # Check https://twiki.cern.ch/twiki/bin/view/CMS/DeepAKXTagging for latest recommendations
     # e.g. 2018 specific training
     if (year != "2016v2"):
-        from RecoBTag.MXNet.pfDeepBoostedJet_cff import pfDeepBoostedJetTags, pfMassDecorrelatedDeepBoostedJetTags
-        from RecoBTag.MXNet.Parameters.V02.pfDeepBoostedJetPreprocessParams_cfi import pfDeepBoostedJetPreprocessParams as pfDeepBoostedJetPreprocessParamsV02
-        from RecoBTag.MXNet.Parameters.V02.pfMassDecorrelatedDeepBoostedJetPreprocessParams_cfi import pfMassDecorrelatedDeepBoostedJetPreprocessParams as pfMassDecorrelatedDeepBoostedJetPreprocessParamsV02
+        from RecoBTag.ONNXRuntime.pfDeepBoostedJet_cff import pfDeepBoostedJetTags, pfMassDecorrelatedDeepBoostedJetTags
+        from RecoBTag.ONNXRuntime.Parameters.DeepBoostedJet.V02.pfDeepBoostedJetPreprocessParams_cfi import pfDeepBoostedJetPreprocessParams as pfDeepBoostedJetPreprocessParamsV02
+        from RecoBTag.ONNXRuntime.Parameters.DeepBoostedJet.V02.pfMassDecorrelatedDeepBoostedJetPreprocessParams_cfi import pfMassDecorrelatedDeepBoostedJetPreprocessParams as pfMassDecorrelatedDeepBoostedJetPreprocessParamsV02
         pfDeepBoostedJetTags.preprocessParams = pfDeepBoostedJetPreprocessParamsV02
-        pfDeepBoostedJetTags.model_path = 'RecoBTag/Combined/data/DeepBoostedJet/V02/full/resnet-symbol.json'
-        pfDeepBoostedJetTags.param_path = 'RecoBTag/Combined/data/DeepBoostedJet/V02/full/resnet-0000.params'
+        pfDeepBoostedJetTags.model_path = 'RecoBTag/Combined/data/DeepBoostedJet/V02/full/resnet.onnx'
         pfMassDecorrelatedDeepBoostedJetTags.preprocessParams = pfMassDecorrelatedDeepBoostedJetPreprocessParamsV02
-        pfMassDecorrelatedDeepBoostedJetTags.model_path = 'RecoBTag/Combined/data/DeepBoostedJet/V02/decorrelated/resnet-symbol.json'
-        pfMassDecorrelatedDeepBoostedJetTags.param_path = 'RecoBTag/Combined/data/DeepBoostedJet/V02/decorrelated/resnet-0000.params'
+        pfMassDecorrelatedDeepBoostedJetTags.model_path = 'RecoBTag/Combined/data/DeepBoostedJet/V02/decorrelated/resnet.onnx'
 
     ###############################################
     # Do deep flavours & deep tagging

--- a/scripts/install.csh
+++ b/scripts/install.csh
@@ -20,7 +20,7 @@ else
     echo "Please log into one and run this again"
     exit 1
 endif
-set CMSREL=CMSSW_10_6_13
+set CMSREL=CMSSW_10_6_20
 eval `cmsrel ${CMSREL}`
 cd ${CMSREL}/src
 eval `scramv1 runtime -csh`

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -119,7 +119,7 @@ time git clone https://github.com/UHH2/SFrame.git
 # Get CMSSW
 export SCRAM_ARCH=slc7_amd64_gcc700
 checkArch
-CMSREL=CMSSW_10_6_13
+CMSREL=CMSSW_10_6_20
 eval `cmsrel ${CMSREL}`
 cd ${CMSREL}/src
 eval `scramv1 runtime -sh`


### PR DESCRIPTION
This PR:
 - updates the CMSSW version to `10_6_20`, which is the one recommended by PdmV (for all legacy analyses - see [PdmV Twiki](https://twiki.cern.ch/twiki/bin/view/CMS/PdmVRun2LegacyAnalysis))
    - for this I also cherry-picked #1550 partially (for Puppiv15 and DeepAK8-binding fix)
 - adds ParticleNet scores to `TopJet.h` and the necessary implementation in `ntuple_generator.py` and `NtupleWriterJets.cxx` in order to fill those.
 

