### PR TITLE
[102X] Additional configurations in CI: test event content excluded by default

### DIFF
--- a/core/python/optionsParse.py
+++ b/core/python/optionsParse.py
@@ -13,12 +13,36 @@ def setup_opts():
                       VarParsing.multiplicity.singleton,
                       VarParsing.varType.int,  # have to use int for a bool (!)
                       "Print module summary (# executions, time per module)")
+    options.register ('eventContent',
+                      'default',
+                      VarParsing.multiplicity.singleton,
+                      VarParsing.varType.string,  # have to use int for a bool (!)
+                      "Control which variables are stored. Possible values: 'default', 'min', max'")
 
     # setup defaults
     options.maxEvents = 500
     options.outputFile = "Ntuple.root"
     
     return options
+
+
+def set_event_content(process, eventContent):
+    """Control event content
+
+    Parameters
+    ----------
+    process : cms.Process
+        Main process object to manipulate
+    eventContent : string
+        Options controlling the event content:
+        if 'min' : minimal event content
+        if 'max' : maximal event content
+        else     : do nothing here, keep content as in process
+    """
+    if eventContent == 'min':
+        process.MyNtuple.doL1seed=cms.bool(False)
+    if eventContent == 'max':
+        process.MyNtuple.doL1seed=cms.bool(True)
 
 
 def parse_apply_opts(process, options):
@@ -41,3 +65,4 @@ def parse_apply_opts(process, options):
     # use this awkward __getattr__ as by default VarParsing changes options.outputFile
     # to xxx_numEventsYYY.root, which we don't necessarily want
     process.MyNtuple.fileName = cms.string(options.__getattr__('outputFile', noTags=True))
+    set_event_content(process,options.eventContent)

--- a/core/python/optionsParse.py
+++ b/core/python/optionsParse.py
@@ -40,9 +40,9 @@ def set_event_content(process, eventContent):
         else     : do nothing here, keep content as in process
     """
     if eventContent == 'min':
-        process.MyNtuple.doL1seed=cms.bool(False)
+        process.MyNtuple.doL1TriggerObjects=cms.bool(False)
     if eventContent == 'max':
-        process.MyNtuple.doL1seed=cms.bool(True)
+        process.MyNtuple.doL1TriggerObjects=cms.bool(True)
 
 
 def parse_apply_opts(process, options):

--- a/core/python/optionsParse.py
+++ b/core/python/optionsParse.py
@@ -16,7 +16,7 @@ def setup_opts():
     options.register ('eventContent',
                       'default',
                       VarParsing.multiplicity.singleton,
-                      VarParsing.varType.string,  # have to use int for a bool (!)
+                      VarParsing.varType.string,
                       "Control which variables are stored. Possible values: 'default', 'min', max'")
 
     # setup defaults


### PR DESCRIPTION
Cherry-pick of #1566 in 106X branch: Add command line option to control event content in ntuple generation. This is meant for the CI automatic tests. Useful in order to test the case where we have additional event content that can be added via switches. We want to test that ntuple generation works with and without the additional content and that no future changes break this.
