### PR TITLE
[106X] prefiring weights for UL17 in ntuple generator

### DIFF
--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -2051,6 +2051,9 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
         '2016v3': '2016BtoH',
         '2017v1': '2017BtoF',
         '2017v2': '2017BtoF',
+        'UL17': 'UL2017BtoF',
+        #'UL16preVFP': '', # FIXME/TODO
+        #'UL16postVFP': '', # FIXME/TODO
     }
     prefire_era = None if useData else prefire_era_dict.get(year, None)
     do_prefire = prefire_era is not None

--- a/scripts/install.csh
+++ b/scripts/install.csh
@@ -101,6 +101,13 @@ scram setup fastjet
 scram setup fastjet-contrib
 scram setup fastjet-contrib-archive
 
+# Get L1PrefiringMaps.root (not in CMSSW_10_6_X yet), according to recipe described at https://twiki.cern.ch/twiki/bin/viewauth/CMS/L1ECALPrefiringWeightRecipe#Accessing_the_UL2017_maps
+# Remove these lines again once these maps are included in CMSSW. FIXME/TODO: For UL16, no prefiring maps available yet. Needs to be addressed before UL16 ntuple production starts
+time git cms-addpkg PhysicsTools/PatUtils
+cd PhysicsTools/PatUtils/data/
+wget --no-check-certificate https://github.com/cms-data/PhysicsTools-PatUtils/raw/master/L1PrefiringMaps.root
+cd ../../../
+
 scram b clean
 time scram b $MAKEFLAGS
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -160,6 +160,13 @@ scram setup fastjet
 scram setup fastjet-contrib
 scram setup fastjet-contrib-archive
 
+# Get L1PrefiringMaps.root (not in CMSSW_10_6_X yet), according to recipe described at https://twiki.cern.ch/twiki/bin/viewauth/CMS/L1ECALPrefiringWeightRecipe#Accessing_the_UL2017_maps
+# Remove these lines again once these maps are included in CMSSW. FIXME/TODO: For UL16, no prefiring maps available yet. Needs to be addressed before UL16 ntuple production starts
+time git cms-addpkg PhysicsTools/PatUtils
+cd PhysicsTools/PatUtils/data/
+wget --no-check-certificate https://github.com/cms-data/PhysicsTools-PatUtils/raw/master/L1PrefiringMaps.root
+cd ../../../
+
 scram b clean
 time scram b $MAKEFLAGS
 


### PR DESCRIPTION
Followed the recipe at: https://twiki.cern.ch/twiki/bin/viewauth/CMS/L1ECALPrefiringWeightRecipe#Accessing_the_UL2017_maps
No UL16 maps available yet. Needs to be addressed before UL16 ntuple production.
The above recipe requires to pull the new `L1PrefiringMaps.root` file containing the UL17 maps. This file is not yet part of CMSSW und thus needs to be downloaded manually. I implemented this in the install scripts. If you already installed the framework before this commit, do this:

`cd <your/path/to>/CMSSW_10_6_20/src/`
`git-cms-addpkg PhysicsTools/PatUtils`
`cd PhysicsTools/PatUtils/data/`
`wget --no-check-certificate https://github.com/cms-data/PhysicsTools-PatUtils/raw/master/L1PrefiringMaps.root`
`cd ../../../`
`scram b`