### PR TITLE
[106X] Update MET filters for UL recommendation

### DIFF
--- a/common/include/CommonModules.h
+++ b/common/include/CommonModules.h
@@ -24,7 +24,7 @@
  *  - MCPileupReweight (for MC only)
  *  - JetCorrector using the latest PHYS14 corrections for MC
  *  - JetResolutionSmearer  (for MC only)
- *  - apply MET filters (all filters listed here: https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETOptionalFiltersRun2#MiniAOD_76X_v2),
+ *  - apply MET filters (all filters listed here: https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETOptionalFiltersRun2),
  *      at least one good primary vertex is only required if pvfilter is also active
  *  - Primary vertex cleaner (remove all non-good PVs from the list of primary vertices)
  *  - ElectronCleaner

--- a/common/include/Utils.h
+++ b/common/include/Utils.h
@@ -135,6 +135,8 @@ const std::map<Year, std::string> year_str_map_simple = {
 /* Get Year enum from dataset_version in XML config */
 Year extract_year(const uhh2::Context & ctx);
 
+/* True if is UL year */
+bool is_UL(const Year& year);
 
 /**
  * Run period names for each year

--- a/common/src/CommonModules.cxx
+++ b/common/src/CommonModules.cxx
@@ -156,6 +156,7 @@ void CommonModules::init(Context & ctx, const std::string & SysType_PU){
       // Recommendation for UL still NOT final
       // The following needs to be updated!
       // - UL 2016 MC treatment is still missing recommendation (treat as UL 17/18 for now, but needs update)
+      // - BadPFMuonDzFilter not in Summer19 UL samples, only in Summer20 (?)
       // 
       metfilters_selection->add<TriggerSelection>("goodVertices", "Flag_goodVertices");
       metfilters_selection->add<TriggerSelection>("globalSuperTightHalo2016Filter", "Flag_globalSuperTightHalo2016Filter");
@@ -163,7 +164,7 @@ void CommonModules::init(Context & ctx, const std::string & SysType_PU){
       metfilters_selection->add<TriggerSelection>("HBHENoiseIsoFilter", "Flag_HBHENoiseIsoFilter");
       metfilters_selection->add<TriggerSelection>("EcalDeadCellTriggerPrimitiveFilter", "Flag_EcalDeadCellTriggerPrimitiveFilter");
       metfilters_selection->add<TriggerSelection>("BadPFMuonFilter", "Flag_BadPFMuonFilter");
-      metfilters_selection->add<TriggerSelection>("BadPFMuonDzFilter", "Flag_BadPFMuonDzFilter");
+      //metfilters_selection->add<TriggerSelection>("BadPFMuonDzFilter", "Flag_BadPFMuonDzFilter");
       if (!is_mc) {
 	metfilters_selection->add<TriggerSelection>("eeBadScFilter", "Flag_eeBadScFilter");
       }

--- a/common/src/CommonModules.cxx
+++ b/common/src/CommonModules.cxx
@@ -146,21 +146,47 @@ void CommonModules::init(Context & ctx, const std::string & SysType_PU){
     }
   }
   if(metfilters){
-    // https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETOptionalFiltersRun2
     metfilters_selection.reset(new AndSelection(ctx, "metfilters"));
-    metfilters_selection->add<TriggerSelection>("HBHENoiseFilter", "Flag_HBHENoiseFilter");
-    metfilters_selection->add<TriggerSelection>("HBHENoiseIsoFilter", "Flag_HBHENoiseIsoFilter");
-    metfilters_selection->add<TriggerSelection>("globalSuperTightHalo2016Filter", "Flag_globalSuperTightHalo2016Filter");
-    metfilters_selection->add<TriggerSelection>("EcalDeadCellTriggerPrimitiveFilter", "Flag_EcalDeadCellTriggerPrimitiveFilter");
-    if (!is_mc) metfilters_selection->add<TriggerSelection>("eeBadScFilter", "Flag_eeBadScFilter");
-    // metfilters_selection->add<TriggerSelection>("BadChargedCandidateFilter", "Flag_BadChargedCandidateFilter"); // Not recommended, under review. Separate module in ntuple_generator for 2016v2
-    if (year != Year::is2016v2) {
+
+    // https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETOptionalFiltersRun2
+
+    if( is_UL(year) ) {
+      // recommendation for UL datasets
+      //
+      // Recommendation for UL still NOT final
+      // The following needs to be updated!
+      // - UL 2016 MC treatment is still missing recommendation (treat as UL 17/18 for now, but needs update)
+      // 
+      metfilters_selection->add<TriggerSelection>("goodVertices", "Flag_goodVertices");
+      metfilters_selection->add<TriggerSelection>("globalSuperTightHalo2016Filter", "Flag_globalSuperTightHalo2016Filter");
+      metfilters_selection->add<TriggerSelection>("HBHENoiseFilter", "Flag_HBHENoiseFilter");
+      metfilters_selection->add<TriggerSelection>("HBHENoiseIsoFilter", "Flag_HBHENoiseIsoFilter");
+      metfilters_selection->add<TriggerSelection>("EcalDeadCellTriggerPrimitiveFilter", "Flag_EcalDeadCellTriggerPrimitiveFilter");
       metfilters_selection->add<TriggerSelection>("BadPFMuonFilter", "Flag_BadPFMuonFilter");
+      metfilters_selection->add<TriggerSelection>("BadPFMuonDzFilter", "Flag_BadPFMuonDzFilter");
+      if (!is_mc) {
+	metfilters_selection->add<TriggerSelection>("eeBadScFilter", "Flag_eeBadScFilter");
+      }
+      if ( year==Year::isUL17 || year==Year::isUL18 ) {
+	metfilters_selection->add<TriggerSelection>("Flag_ecalBadCalibFilter", "Flag_ecalBadCalibFilter");
+      }
+
     } else {
-      metfilters_selection->add<TriggerSelection>("BadPFMuonFilter", "Extra_BadPFMuonFilter");
+      // recommendation for EOY datasets
+      metfilters_selection->add<TriggerSelection>("goodVertices", "Flag_goodVertices");
+      metfilters_selection->add<TriggerSelection>("globalSuperTightHalo2016Filter", "Flag_globalSuperTightHalo2016Filter");
+      metfilters_selection->add<TriggerSelection>("HBHENoiseFilter", "Flag_HBHENoiseFilter");
+      metfilters_selection->add<TriggerSelection>("HBHENoiseIsoFilter", "Flag_HBHENoiseIsoFilter");
+      metfilters_selection->add<TriggerSelection>("EcalDeadCellTriggerPrimitiveFilter", "Flag_EcalDeadCellTriggerPrimitiveFilter");
+      if (year == Year::is2016v2) { // filter was run during ntuple production as info not in miniAOD
+	metfilters_selection->add<TriggerSelection>("BadPFMuonFilter", "Extra_BadPFMuonFilter");
+      } else {
+	metfilters_selection->add<TriggerSelection>("BadPFMuonFilter", "Flag_BadPFMuonFilter");
+      }
+      if (!is_mc) metfilters_selection->add<TriggerSelection>("eeBadScFilter", "Flag_eeBadScFilter");
+      metfilters_selection->add<EcalBadCalibSelection>("EcalBadCalibSelection"); // Use this instead of Flag_ecalBadCalibFilter, uses ecalBadCalibReducedMINIAODFilter in ntuple_generator
     }
-    metfilters_selection->add<TriggerSelection>("goodVertices", "Flag_goodVertices");
-    metfilters_selection->add<EcalBadCalibSelection>("EcalBadCalibSelection"); // Use this instead of Flag_ecalBadCalibFilter, uses ecalBadCalibReducedMINIAODFilter in ntuple_generator
+
     if(pvfilter) metfilters_selection->add<NPVSelection>("1 good PV",1,-1,pvid);
   }
   if(eleid) modules.emplace_back(new ElectronCleaner(eleid));

--- a/common/src/Utils.cxx
+++ b/common/src/Utils.cxx
@@ -106,6 +106,10 @@ Year extract_year(const uhh2::Context & ctx) {
     throw std::runtime_error("Cannot figure out year from dataset_version. Should include one of: " + yearStr);
 }
 
+bool is_UL(const Year& year) {
+  return year==Year::isUL16preVFP || year==Year::isUL16postVFP || year==Year::isUL17 || year==Year::isUL18;
+}
+
 const std::vector<std::string> year2runPeriods(const std::string& year) {
   if (year.find("16") != std::string::npos) {
     if (year.find("preVFP") != std::string::npos) return runPeriodsUL16preVFP;

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -2074,7 +2074,6 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
     # Deal with bad ECAL endcap crystals
     # https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETOptionalFiltersRun2#How_to_run_ecal_BadCalibReducedM
     bad_ecal = useData and (year=="2017v1" or year=="2017v2" or year=="2018")
-
     if bad_ecal:
         process.load('RecoMET.METFilters.ecalBadCalibFilter_cfi')
 
@@ -2088,12 +2087,6 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
              872437185,872422564,872421566,872421695,
              872421955,872421567,872437184,872421951,
              872421694,872437056,872437057,872437313
-
-             # Are these supposed to be used as well?
-             # 872438182,872438951,872439990,872439864,
-             # 872439609,872437181,872437182,872437053,
-             # 872436794,872436667,872436536,872421541,
-             # 872421413,872421414,872421031,872423083,872421439
              ])
 
 
@@ -2106,7 +2099,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
         )
         task.add(process.ecalBadCalibReducedMINIAODFilter)
 
-    # Run Bad Charged Hadron and Bad Muon filters for 2016v2, since they were
+    # Run Bad Muon filters for 2016v2, since they were
     # only introduced after samples were produced.
     # Newer samples will already have these.
     do_bad_muon_charged_filters = (year == "2016v2")
@@ -2118,18 +2111,6 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
         process.BadPFMuonFilter.taggingMode = True  # Don't veto, store bit in ntuple
         task.add(process.BadPFMuonFilter)
         extra_trigger_bits.append(process.BadPFMuonFilter.label())
-
-        # DISABLE Bad Charged Hadron Filter for now as some inefficiency for TeV jets
-        # Under review, update when necessary
-        # process.load('RecoMET.METFilters.BadChargedCandidateFilter_cfi')
-        # process.BadChargedCandidateFilter.muons = cms.InputTag("slimmedMuons")
-        # process.BadChargedCandidateFilter.PFCandidates = cms.InputTag("packedPFCandidates")
-        # process.BadChargedCandidateFilter.taggingMode = True
-        # task.add(process.BadChargedCandidateFilter)
-        # extra_trigger_bits.append(process.BadChargedCandidateFilter.label())
-
-    # NtupleWriter
-    #
 
     if useData:
         metfilterpath = "RECO"

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -2073,7 +2073,8 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
     ###############################################
     # Deal with bad ECAL endcap crystals
     # https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETOptionalFiltersRun2#How_to_run_ecal_BadCalibReducedM
-    bad_ecal = useData and ("2017" in year or "2018" in year)
+    bad_ecal = useData and (year=="2017v1" or year=="2017v2" or year=="2018")
+
     if bad_ecal:
         process.load('RecoMET.METFilters.ecalBadCalibFilter_cfi')
 


### PR DESCRIPTION
Updating the MET filters for current status of [UL recommendation](https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETOptionalFiltersRun2#UL_data). This is not yet final and might/will change in the future.

In particular, exclude BadPFMuonDzFilter for now from CommonModules filter sequence as the decision is not stored in the Summer19 UL MiniAOD samples (but should be in the Summer20 versions).