### PR TITLE
[106X] Update to CMSSW_10_6_26

### DIFF
--- a/scripts/install.csh
+++ b/scripts/install.csh
@@ -20,7 +20,7 @@ else
     echo "Please log into one and run this again"
     exit 1
 endif
-set CMSREL=CMSSW_10_6_20
+set CMSREL=CMSSW_10_6_26
 eval `cmsrel ${CMSREL}`
 cd ${CMSREL}/src
 eval `scramv1 runtime -csh`

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -119,7 +119,7 @@ time git clone https://github.com/UHH2/SFrame.git
 # Get CMSSW
 export SCRAM_ARCH=slc7_amd64_gcc700
 checkArch
-CMSREL=CMSSW_10_6_20
+CMSREL=CMSSW_10_6_26
 eval `cmsrel ${CMSREL}`
 cd ${CMSREL}/src
 eval `scramv1 runtime -sh`


### PR DESCRIPTION
Switching to new CMSSW version, needed for egamma postrecotools. It compiled for me locally, and a few exemplary ntuplewriters worked, lets see what the full tests say.