### PR TITLE
[106X] adding ParticleNet mass regression to TopJets

### DIFF
--- a/core/include/TopJet.h
+++ b/core/include/TopJet.h
@@ -193,6 +193,7 @@ public:
       m_btag_MassDecorrelatedParticleNetDiscriminatorsJetTags_XccvsQCD=-2;
       m_btag_MassDecorrelatedParticleNetDiscriminatorsJetTags_XqqvsQCD=-2;
 
+      m_ParticleNetMassRegressionJetTags_mass = -999.;
 
   }
 
@@ -366,7 +367,8 @@ public:
   float btag_MassDecorrelatedParticleNetDiscriminatorsJetTags_XccvsQCD() const{return m_btag_MassDecorrelatedParticleNetDiscriminatorsJetTags_XccvsQCD;}
   float btag_MassDecorrelatedParticleNetDiscriminatorsJetTags_XqqvsQCD() const{return m_btag_MassDecorrelatedParticleNetDiscriminatorsJetTags_XqqvsQCD;}
 
-  
+  //mass from ParticleNet mass regression
+  float ParticleNetMassRegressionJetTags_mass() const{return m_ParticleNetMassRegressionJetTags_mass;}
 
 
   // setters
@@ -508,6 +510,8 @@ public:
   void set_btag_MassDecorrelatedParticleNetDiscriminatorsJetTags_XccvsQCD(float x) { m_btag_MassDecorrelatedParticleNetDiscriminatorsJetTags_XccvsQCD=x;}
   void set_btag_MassDecorrelatedParticleNetDiscriminatorsJetTags_XqqvsQCD(float x) { m_btag_MassDecorrelatedParticleNetDiscriminatorsJetTags_XqqvsQCD=x;}
 
+  void set_ParticleNetMassRegressionJetTags_mass(float x){ m_ParticleNetMassRegressionJetTags_mass=x;}
+  
 private:
   std::vector<Jet> m_subjets;
 
@@ -637,6 +641,8 @@ private:
   float m_btag_MassDecorrelatedParticleNetDiscriminatorsJetTags_XccvsQCD;
   float m_btag_MassDecorrelatedParticleNetDiscriminatorsJetTags_XqqvsQCD;
 
+  float m_ParticleNetMassRegressionJetTags_mass;
+  
   Tags tags;
 };
 

--- a/core/plugins/NtupleWriterJets.cxx
+++ b/core/plugins/NtupleWriterJets.cxx
@@ -501,7 +501,7 @@ void NtupleWriterTopJets::fill_btag_info(uhh2::Event & uevent, const pat::Jet & 
     particlenet_HbbvsQCD=false,particlenet_HccvsQCD=false,particlenet_H4qvsQCD=false,
     decorrmass_particlenet_probXbb=false,decorrmass_particlenet_probXcc=false,decorrmass_particlenet_probXqq=false,decorrmass_particlenet_probQCDbb=false,
     decorrmass_particlenet_probQCDcc=false,decorrmass_particlenet_probQCDb=false,decorrmass_particlenet_probQCDc=false,decorrmass_particlenet_probQCDothers=false,
-    decorrmass_particlenet_XbbvsQCD=false,decorrmass_particlenet_XccvsQCD=false,decorrmass_particlenet_XqqvsQCD=false;
+    decorrmass_particlenet_XbbvsQCD=false,decorrmass_particlenet_XccvsQCD=false,decorrmass_particlenet_XqqvsQCD=false,particlenet_mass=false;
 
 
     for(const auto & name_value : bdisc){
@@ -923,6 +923,10 @@ void NtupleWriterTopJets::fill_btag_info(uhh2::Event & uevent, const pat::Jet & 
         jet.set_btag_MassDecorrelatedParticleNetDiscriminatorsJetTags_XqqvsQCD(value);
         decorrmass_particlenet_XqqvsQCD = true;
       }
+      else if(name == "pfParticleNetMassRegressionJetTags:mass"){
+        jet.set_ParticleNetMassRegressionJetTags_mass(value);
+        particlenet_mass=true;
+      }
 
     }
 
@@ -960,7 +964,7 @@ void NtupleWriterTopJets::fill_btag_info(uhh2::Event & uevent, const pat::Jet & 
        || !particlenet_HbbvsQCD || !particlenet_HccvsQCD || !particlenet_H4qvsQCD
        || !decorrmass_particlenet_probXbb || !decorrmass_particlenet_probXcc || !decorrmass_particlenet_probXqq || !decorrmass_particlenet_probQCDbb
        || !decorrmass_particlenet_probQCDcc || !decorrmass_particlenet_probQCDb || !decorrmass_particlenet_probQCDc || !decorrmass_particlenet_probQCDothers
-       || !decorrmass_particlenet_XbbvsQCD || !decorrmass_particlenet_XccvsQCD || !decorrmass_particlenet_XqqvsQCD){
+       || !decorrmass_particlenet_XbbvsQCD || !decorrmass_particlenet_XccvsQCD || !decorrmass_particlenet_XqqvsQCD || !particlenet_mass){
       if(btag_warning){
         std::string btag_list = "";
         for(const auto & name_value : bdisc){

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -214,7 +214,8 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
     'pfMassDecorrelatedParticleNetJetTags:probQCDothers',
     'pfMassDecorrelatedParticleNetDiscriminatorsJetTags:XbbvsQCD',
     'pfMassDecorrelatedParticleNetDiscriminatorsJetTags:XccvsQCD',
-    'pfMassDecorrelatedParticleNetDiscriminatorsJetTags:XqqvsQCD']
+    'pfMassDecorrelatedParticleNetDiscriminatorsJetTags:XqqvsQCD',
+    'pfParticleNetMassRegressionJetTags:mass']
     ak8btagDiscriminators += pfParticleNetJetTagsAll
 
     bTagInfos = [


### PR DESCRIPTION
This adds the ParticleNet mass regression as another float to the TopJets.
It was introduced in `CMSSW_10_6_25` (see [ReleaseNotes](https://cmssdt.cern.ch/SDT/ReleaseNotes/CMSSW_10/CMSSW_10_6_25.html) and PR cms-sw/cmssw#33588).

