### PR TITLE
[106X] Added L1 objects for MC and data

### DIFF
--- a/core/include/Event.h
+++ b/core/include/Event.h
@@ -6,7 +6,7 @@
 namespace uhh2 {
 
 /** \brief The event container.
- * 
+ *
  * Based on the UHHanalysis' BaseCycleContainer. This class allows easy (direct) access to many frequently needed
  * objects, such as jets, electron, muons, etc. To store data beyond those directly declared data
  * members, use the GenericEvent methods, which allows settings and getting arbitrary data via handles.
@@ -14,7 +14,7 @@ namespace uhh2 {
 class Event: public GenericEvent {
 public:
   double weight; // Note: unlike the other members, the weight is not read from the input file and not written to the output file, but calculated on the fly.
-    
+
   int run;
   int luminosityBlock;
   long long event;
@@ -34,8 +34,8 @@ public:
   float beamspot_y0;
   float beamspot_z0;
   std::vector< PrimaryVertex >* pvs;
-  
-  std::vector< Electron >* electrons;  
+
+  std::vector< Electron >* electrons;
   std::vector< Muon >* muons;
   std::vector< Tau >* taus;
   std::vector< Photon >* photons;
@@ -46,6 +46,7 @@ public:
   MET* genmet;
   std::vector< L1EGamma>* L1EG_seeds;
   std::vector< L1Jet>* L1J_seeds;
+  std::vector< L1Muon>* L1M_seeds;
 
   GenInfo* genInfo;
   std::vector< GenTopJet >* gentopjets;
@@ -54,7 +55,7 @@ public:
   std::vector< PFParticle>* pfparticles;
 
   /** \brief Access to trigger results.
-   * 
+   *
    * Access to trigger results is treated differently from the other
    * event content in order to save disk space: In principle, the trigger
    * information saved here can be thought of as a map from string to bool,
@@ -64,7 +65,7 @@ public:
    * of disk space. Therefore, the trigger names are only saved for the first
    * event for each run in that file, and only the vector of booleans of the actual
    * trigger results is saved for each event.
-   * 
+   *
    * Accessing the trigger decision is a two-step process: first get a \c TriggerIndex
    * with \c get_trigger_index. This one \c TriggerIndex can then be used for many events
    * with \c passes_trigger.
@@ -77,7 +78,7 @@ public:
   struct TriggerIndex {
       // invalid triggerindex
       TriggerIndex(): index(-1), runid(0){}
-      
+
   private:
       friend class Event;
       size_t index; // index into trigger results vector<bool>
@@ -86,30 +87,30 @@ public:
       bool is_prefix;
       TriggerIndex(size_t i, int r, std::string tn, bool p): index(i), runid(r), triggername(std::move(tn)), is_prefix(p){}
   };
-  
+
   /** \brief Get a new trigger index based on the name
-   * 
+   *
    * The argument \c triggername can contain a trailing wildcard, i.e., end with '*'
    * to match any characters. (Note that no other matching/wildcard is implemented).
-   * 
+   *
    * The trigger name used here should usually start with 'HLT_' and end with '_v*'.
-   * 
+   *
    * Throws an invalid_argument exception in case triggername is empty or "*". Note
    * that no trigger name lookup is performed at this point, so construction
    * will always succeed, even for triggers not available; use \c lookup_trigger_index
    * to test whether the trigger is actually available.
    */
   TriggerIndex get_trigger_index(const std::string & triggername) const;
-  
+
   /** \brief Test whether the current event passes the trigger represented by the TriggerIndex
-   * 
+   *
    * Throws the same exceptions as \c lookup_trigger_index. In addition, throws a runtime_error
    * if \c lookup_trigger_index returns false.
    */
   bool passes_trigger(TriggerIndex & ti) const;
 
   /** \brief Returns the pre-scale factor of the trigger represented by the TriggerIndex
-   * 
+   *
    * Throws the same exceptions as \c lookup_trigger_index. In addition, throws a runtime_error
    * if \c lookup_trigger_index returns false.
    */
@@ -119,29 +120,29 @@ public:
   //https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2017#Trigger
   int trigger_prescaleL1min(TriggerIndex & ti) const;
   int trigger_prescaleL1max(TriggerIndex & ti) const;
-  
+
   /** \brief Test whether a given trigger is available for the current event
-   * 
+   *
    * Note that this method is only needed to test whether a trigger is available at all;
    * it is not needed to test whether an event passes a trigger as \c passes_trigger
    * calls \c lookup_trigger_index automatically.
-   * 
+   *
    * Throws a runtime_error if the trigger name in \c ti matches multiple triggers.
    */
   bool lookup_trigger_index(TriggerIndex & ti) const;
-  
-  /** \brief Get the names of the triggers for the current event 
+
+  /** \brief Get the names of the triggers for the current event
    */
   const std::vector<std::string> & get_current_triggernames() const {
       return triggerNames_currentrun;
   }
-  
-  
+
+
   // ** Framework methods **
   // Analyses should not use the methods below directly; this is for adapting to the framework(s) only.
   using GenericEvent::RawHandle;
   template<class T> using Handle = GenericEvent::Handle<T>;
-  
+
   std::vector<bool>* & get_triggerResults(){
       return triggerResults;
   }
@@ -157,21 +158,21 @@ public:
     return triggerPrescalesL1max;
   }
 
-  
+
   void set_triggernames(std::vector<std::string> names){ // for the current run(!)
       triggerNames_currentrun = move(names);
       triggerNames_currentrun_runid = run;
   }
-  
+
   // clear all data.
   // Set all members pointer to zero, all floats to NAN, all integers to -1, and clear all vectors.
   void clear();
-  
-  
+
+
   Event(const GenericEventStructure & ges);
-  
+
   ~Event();
-  
+
 private:
     std::vector<bool>* triggerResults;
     std::vector<int>* triggerPrescales;
@@ -183,4 +184,3 @@ private:
 };
 
 }
-

--- a/core/include/Event.h
+++ b/core/include/Event.h
@@ -48,6 +48,7 @@ public:
   std::vector< L1Jet>* L1J_seeds;
   std::vector< L1Muon>* L1M_seeds;
   std::vector< L1EtSum>* L1EtS_seeds;
+  std::vector< L1Tau>* L1T_seeds;
 
   GenInfo* genInfo;
   std::vector< GenTopJet >* gentopjets;

--- a/core/include/Event.h
+++ b/core/include/Event.h
@@ -47,6 +47,7 @@ public:
   std::vector< L1EGamma>* L1EG_seeds;
   std::vector< L1Jet>* L1J_seeds;
   std::vector< L1Muon>* L1M_seeds;
+  std::vector< L1EtSum>* L1EtS_seeds;
 
   GenInfo* genInfo;
   std::vector< GenTopJet >* gentopjets;

--- a/core/include/EventHelper.h
+++ b/core/include/EventHelper.h
@@ -6,30 +6,30 @@
 #include <vector>
 
 namespace uhh2 {
-    
+
 namespace detail {
 
 /** \brief This is a framework-internal class; do not use it.
- * 
+ *
  * This helper class aids the framework to fill the contents of the Event container
  * correctly: The framework for event input and output is tightly coupled to the GenericEvent,
  * so all data read is read into members of GenericEvent, and the output written is the
  * one in GenericEvent. However, for easier access, the Event class has data members
  * to access the most widely-used event data directly (e.g. Event::run, Event::event, Event::jets, etc.).
  * This helper class provides methods to synchronize these data.
- * 
+ *
  * This helper class contains routines to
  *  - fill the Event class data members from the GenericEvent content; this would be called just
  *    after reading the event from the input file (as the input is read into the GenericEvent members)
  *  - copy the values from the Event class to the GenericEvent; this should be called just before writing the event output;
  *    the output written is the content of the GenericEvent, so to allow modules to change the Event content
  *    by accessing the Event members, this change has to be synchronized back to the GenericEvent.
- * 
+ *
  * The class also deals with the special case of triggerNames:
  *   - when reading events, the framework has to lookup all runs and fill set_triggernames
  *   - this helper class will make sure the right trigger names are set in the event
  *   - when writing, the triggerNames are only non-empty if the event is the first one for the current run
- * 
+ *
  * It is assumed that
  *  - one EventHelper exists per Event; so a separate EventHelper is required for each Event
  *  - only one output file exists per EventHelper (this is important for deciding whether or not to write the trigger).
@@ -40,7 +40,7 @@ public:
     // note: the EventHelper will always set up input AND output.
     // If not output is desired, this has to be dealt within the Context object.
     explicit EventHelper(uhh2::Context & ctx);
-    
+
     // should be called right after construction, before reading the first file.
     // Set the branch names for the direct members of Event. Note
     // that for 'plain' members (run, event, lumi, isRealData, beamspot etc.) the names
@@ -57,7 +57,7 @@ public:
     void setup_toppuppijets(const std::string & bname);
     void setup_met(const std::string & bname);
     void setup_genmet(const std::string & bname);
-    
+
     void setup_genInfo(const std::string & bname);
     void setup_gentopjets(const std::string & bname);
     void setup_genparticles(const std::string & bname);
@@ -66,39 +66,40 @@ public:
 
     void setup_L1EG_seeds(const std::string & bname);
     void setup_L1J_seeds(const std::string & bname);
+    void setup_L1M_seeds(const std::string & bname);
 
     void setup_trigger();
-    
+
     // note: event has to outlive this class. If creating a new event, also create a new EventHelper!
     void set_event(Event * event);
-    
+
     // this is called at the beginning of each input file
     void set_infile_triggernames(std::map<int, std::vector<std::string>> triggernames);
-    
+
     // this is called just after reading an event; it copies the GenericEvent content to the Event
     void event_read();
-    
+
     // this is called just before writing an event; it copies the Event data members to the GenericEvent ones
     void event_write();
-    
+
 private:
-    
+
     uhh2::Context & ctx;
-    
+
     Event * event;
-    
+
     bool pvs, electrons, muons, taus, photons, jets, topjets, toppuppijets, met, genmet;
     bool genInfo, gentopjets, genparticles, genjets;
     bool pfparticles;
     bool trigger;
-    bool L1EG_seeds, L1J_seeds;
+    bool L1EG_seeds, L1J_seeds, L1M_seeds;
     bool first_event_read;
-    
+
     // trigger handling:
     std::map<int, std::vector<std::string>> triggernames;
     std::set<int> triggernames_written;
     int triggernames_last_runid_event;
-    
+
     // handles:
     Event::Handle<int> h_run, h_lumi, h_event;
     Event::Handle<float> h_rho, h_bsx, h_bsy, h_bsz, h_prefire, h_prefireUp, h_prefireDown;
@@ -115,13 +116,13 @@ private:
     Event::Handle<std::vector<TopJet>> h_toppuppijets;
     Event::Handle<MET> h_met;
     Event::Handle<MET> h_genmet;
-    
+
     Event::Handle<GenInfo> h_genInfo;
     Event::Handle<std::vector<GenTopJet>> h_gentopjets;
     Event::Handle<std::vector<GenParticle>> h_genparticles;
     Event::Handle<std::vector<PFParticle>> h_pfparticles;
     Event::Handle<std::vector<GenJet>> h_genjets;
-    
+
     Event::Handle<std::vector<bool>> h_triggerResults;
     Event::Handle<std::vector<int>> h_triggerPrescales;
     Event::Handle<std::vector<int>> h_triggerPrescalesL1min;
@@ -129,10 +130,11 @@ private:
     Event::Handle<std::vector<std::string>> h_triggerNames;
     Event::Handle<std::vector<L1EGamma>> h_L1EG_seeds;
     Event::Handle<std::vector<L1Jet>> h_L1J_seeds;
+    Event::Handle<std::vector<L1Muon>> h_L1M_seeds;
+
 };
 
 
 }
 
 }
-

--- a/core/include/EventHelper.h
+++ b/core/include/EventHelper.h
@@ -68,6 +68,7 @@ public:
     void setup_L1J_seeds(const std::string & bname);
     void setup_L1M_seeds(const std::string & bname);
     void setup_L1EtS_seeds(const std::string & bname);
+    void setup_L1T_seeds(const std::string & bname);
 
     void setup_trigger();
 
@@ -93,7 +94,7 @@ private:
     bool genInfo, gentopjets, genparticles, genjets;
     bool pfparticles;
     bool trigger;
-    bool L1EG_seeds, L1J_seeds, L1M_seeds, L1EtS_seeds;
+    bool L1EG_seeds, L1J_seeds, L1M_seeds, L1EtS_seeds, L1T_seeds;
     bool first_event_read;
 
     // trigger handling:
@@ -133,6 +134,7 @@ private:
     Event::Handle<std::vector<L1Jet>> h_L1J_seeds;
     Event::Handle<std::vector<L1Muon>> h_L1M_seeds;
     Event::Handle<std::vector<L1EtSum>> h_L1EtS_seeds;
+    Event::Handle<std::vector<L1Tau>> h_L1T_seeds;
 
 };
 

--- a/core/include/EventHelper.h
+++ b/core/include/EventHelper.h
@@ -67,6 +67,7 @@ public:
     void setup_L1EG_seeds(const std::string & bname);
     void setup_L1J_seeds(const std::string & bname);
     void setup_L1M_seeds(const std::string & bname);
+    void setup_L1EtS_seeds(const std::string & bname);
 
     void setup_trigger();
 
@@ -92,7 +93,7 @@ private:
     bool genInfo, gentopjets, genparticles, genjets;
     bool pfparticles;
     bool trigger;
-    bool L1EG_seeds, L1J_seeds, L1M_seeds;
+    bool L1EG_seeds, L1J_seeds, L1M_seeds, L1EtS_seeds;
     bool first_event_read;
 
     // trigger handling:
@@ -131,6 +132,7 @@ private:
     Event::Handle<std::vector<L1EGamma>> h_L1EG_seeds;
     Event::Handle<std::vector<L1Jet>> h_L1J_seeds;
     Event::Handle<std::vector<L1Muon>> h_L1M_seeds;
+    Event::Handle<std::vector<L1EtSum>> h_L1EtS_seeds;
 
 };
 

--- a/core/include/L1EtSum.h
+++ b/core/include/L1EtSum.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "Particle.h"
+#include <vector>
+
+// Muon L1 trigger objects
+
+class L1EtSum : public Particle{
+public:
+  enum EtSumType {
+    kTotalEt,
+    kTotalHt,
+    kMissingEt,
+    kMissingHt,
+    kTotalEtx,
+    kTotalEty,
+    kTotalHtx,
+    kTotalHty,
+    kEmpty
+  };
+
+  L1EtSum(){
+    // v4, energy, charge inherited from Particle
+
+    // bunch crossing info
+    m_bx = -100;
+
+    // inherited from L1Candidate.h in CMSSW
+    m_hwPt = 0;
+    m_hwEta = 0;
+    m_hwPhi = 0;
+    m_hwQual = 0;
+    m_hwIso = 0;
+
+    // type info
+    m_type = EtSumType::kEmpty;
+  }
+
+  // getters
+  int bx() const {return m_bx;}
+
+  int hwPt() const {return m_hwPt;}
+  int hwEta() const {return m_hwEta;}
+  int hwPhi() const {return m_hwPhi;}
+  int hwQual() const {return m_hwQual;}
+  int hwIso() const {return m_hwIso;}
+
+  EtSumType type() const {return m_type;}
+
+  // setters
+  void set_bx(int x) {m_bx=x;}
+
+  void set_hwPt(int x) {m_hwPt=x;}
+  void set_hwEta(int x) {m_hwEta=x;}
+  void set_hwPhi(int x) {m_hwPhi=x;}
+  void set_hwQual(int x) {m_hwQual=x;}
+  void set_hwIso(int x) {m_hwIso=x;}
+
+  void set_type(EtSumType x) {m_type=x;}
+
+private:
+  int m_bx, m_hwPt, m_hwEta, m_hwPhi, m_hwQual, m_hwIso;
+  EtSumType m_type;
+};

--- a/core/include/L1Muon.h
+++ b/core/include/L1Muon.h
@@ -1,0 +1,98 @@
+#pragma once
+
+#include "Particle.h"
+#include <vector>
+
+// Muon L1 trigger objects
+
+class L1Muon : public Particle{
+public:
+  L1Muon(){
+    // v4, energy, charge inherited from Particle
+
+    // bunch crossing info
+    m_bx = -100;
+
+    // inherited from L1Candidate.h in CMSSW
+    m_hwPt = 0;
+    m_hwEta = 0;
+    m_hwPhi = 0;
+    m_hwQual = 0;
+    m_hwIso = 0;
+
+    // inherited from Muon.h in CMSSW
+    m_hwCharge = 0;
+    m_hwChargeValid = 0;
+    m_tfMuonIndex = 0;
+    m_hwTag = 0;
+
+    m_hwEtaAtVtx = 0;
+    m_hwPhiAtVtx = 0;
+    m_etaAtVtx = 0.;
+    m_phiAtVtx = 0.;
+
+    m_hwIsoSum = 0;
+    m_hwDPhiExtra = 0;
+    m_hwDEtaExtra = 0;
+    m_hwRank = 0;
+
+    m_debug = false;
+  }
+
+  // getters
+  int bx() const {return m_bx;}
+
+  int hwPt() const {return m_hwPt;}
+  int hwEta() const {return m_hwEta;}
+  int hwPhi() const {return m_hwPhi;}
+  int hwQual() const {return m_hwQual;}
+  int hwIso() const {return m_hwIso;}
+
+  int hwCharge() const { return m_hwCharge; };
+  int hwChargeValid() const { return m_hwChargeValid; };
+  int tfMuonIndex() const { return m_tfMuonIndex; };
+  int hwTag() const { return m_hwTag; };
+
+  int hwEtaAtVtx() const { return m_hwEtaAtVtx; };
+  int hwPhiAtVtx() const { return m_hwPhiAtVtx; };
+  double etaAtVtx() const { return m_etaAtVtx; };
+  double phiAtVtx() const { return m_phiAtVtx; };
+
+  int hwIsoSum() const { return m_hwIsoSum; };
+  int hwDPhiExtra() const { return m_hwDPhiExtra; };
+  int hwDEtaExtra() const { return m_hwDEtaExtra; };
+  int hwRank() const { return m_hwRank; };
+
+  bool debug() const { return m_debug; };
+
+  // setters
+  void set_bx(int x) {m_bx=x;}
+
+  void set_hwPt(int x) {m_hwPt=x;}
+  void set_hwEta(int x) {m_hwEta=x;}
+  void set_hwPhi(int x) {m_hwPhi=x;}
+  void set_hwQual(int x) {m_hwQual=x;}
+  void set_hwIso(int x) {m_hwIso=x;}
+
+  void set_hwCharge(int x) { m_hwCharge = x; };
+  void set_hwChargeValid(int x) { m_hwChargeValid = x; };
+  void set_tfMuonIndex(int x) { m_tfMuonIndex = x; };
+  void set_hwTag(int x) { m_hwTag = x; };
+
+  void set_hwEtaAtVtx(int x) { m_hwEtaAtVtx = x; };
+  void set_hwPhiAtVtx(int x) { m_hwPhiAtVtx = x; };
+  void set_etaAtVtx(double x) { m_etaAtVtx = x; };
+  void set_phiAtVtx(double x) { m_phiAtVtx = x; };
+
+  void set_hwIsoSum(int x) { m_hwIsoSum = x; };
+  void set_hwDPhiExtra(int x) { m_hwDPhiExtra = x; };
+  void set_hwDEtaExtra(int x) { m_hwDEtaExtra = x; };
+  void set_hwRank(int x) { m_hwRank = x; };
+
+  void set_debug(bool x) { m_debug = x; };
+
+private:
+  int m_bx, m_hwPt, m_hwEta, m_hwPhi, m_hwQual, m_hwIso, m_hwCharge, m_hwChargeValid, m_tfMuonIndex, m_hwTag, m_hwEtaAtVtx, m_hwPhiAtVtx, m_hwIsoSum, m_hwDPhiExtra, m_hwDEtaExtra, m_hwRank;
+  double m_etaAtVtx, m_phiAtVtx;
+  bool m_debug;
+};

--- a/core/include/L1Tau.h
+++ b/core/include/L1Tau.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "Particle.h"
+#include <vector>
+
+// Tau L1 trigger objects
+
+class L1Tau : public Particle{
+public:
+  L1Tau(){
+    // v4, energy, charge inherited from Particle
+
+    // bunch crossing info
+    m_bx = -100;
+
+    // inherited from L1Candidate.h in CMSSW
+    m_hwPt = 0;
+    m_hwEta = 0;
+    m_hwPhi = 0;
+    m_hwQual = 0;
+    m_hwIso = 0;
+
+    // inherited from Tau.h in CMSSW
+    m_towerIEta = 0;
+    m_towerIPhi = 0;
+    m_rawEt = 0;
+    m_isoEt = 0;
+    m_nTT = 0;
+    m_hasEM = false;
+    m_isMerged = false;
+  }
+
+  // getters
+  int bx() const {return m_bx;}
+
+  int hwPt() const {return m_hwPt;}
+  int hwEta() const {return m_hwEta;}
+  int hwPhi() const {return m_hwPhi;}
+  int hwQual() const {return m_hwQual;}
+  int hwIso() const {return m_hwIso;}
+
+  int towerIEta() const {return m_towerIEta;}
+  int towerIPhi() const {return m_towerIPhi;}
+  int rawEt() const {return m_rawEt;}
+  int isoEt() const {return m_isoEt;}
+  int nTT() const {return m_nTT;}
+  bool hasEM() const {return m_hasEM;}
+  bool isMerged() const {return m_isMerged;}
+
+  // setters
+  void set_bx(int x) {m_bx=x;}
+
+  void set_hwPt(int x) {m_hwPt=x;}
+  void set_hwEta(int x) {m_hwEta=x;}
+  void set_hwPhi(int x) {m_hwPhi=x;}
+  void set_hwQual(int x) {m_hwQual=x;}
+  void set_hwIso(int x) {m_hwIso=x;}
+
+  void set_towerIEta(int x) {m_towerIEta=x;}
+  void set_towerIPhi(int x) {m_towerIPhi=x;}
+  void set_rawEt(int x) {m_rawEt=x;}
+  void set_isoEt(int x) {m_isoEt=x;}
+  void set_nTT(int x) {m_nTT=x;}
+  void set_hasEM(bool x) {m_hasEM=x;}
+  void set_isMerged(bool x) {m_isMerged=x;}
+
+private:
+  int m_bx, m_hwPt, m_hwEta, m_hwPhi, m_hwQual, m_hwIso, m_towerIEta, m_towerIPhi, m_rawEt, m_isoEt, m_nTT;
+  bool m_hasEM, m_isMerged;
+};

--- a/core/include/NtupleObjects.h
+++ b/core/include/NtupleObjects.h
@@ -17,3 +17,4 @@
 #include "UHH2/core/include/L1Jet.h"
 #include "UHH2/core/include/L1Muon.h"
 #include "UHH2/core/include/L1EtSum.h"
+#include "UHH2/core/include/L1Tau.h"

--- a/core/include/NtupleObjects.h
+++ b/core/include/NtupleObjects.h
@@ -16,3 +16,4 @@
 #include "UHH2/core/include/L1EGamma.h"
 #include "UHH2/core/include/L1Jet.h"
 #include "UHH2/core/include/L1Muon.h"
+#include "UHH2/core/include/L1EtSum.h"

--- a/core/include/NtupleObjects.h
+++ b/core/include/NtupleObjects.h
@@ -15,3 +15,4 @@
 #include "UHH2/core/include/PFParticle.h"
 #include "UHH2/core/include/L1EGamma.h"
 #include "UHH2/core/include/L1Jet.h"
+#include "UHH2/core/include/L1Muon.h"

--- a/core/include/SUHH2core_LinkDef.h
+++ b/core/include/SUHH2core_LinkDef.h
@@ -51,4 +51,6 @@
 #pragma link C++ class std::vector<L1Muon>+;
 #pragma link C++ class L1EtSum+;
 #pragma link C++ class std::vector<L1EtSum>+;
+#pragma link C++ class L1Tau+;
+#pragma link C++ class std::vector<L1Tau>+;
 #endif // __CINT__

--- a/core/include/SUHH2core_LinkDef.h
+++ b/core/include/SUHH2core_LinkDef.h
@@ -47,4 +47,6 @@
 #pragma link C++ class std::vector<L1EGamma>+;
 #pragma link C++ class L1Jet+;
 #pragma link C++ class std::vector<L1Jet>+;
+#pragma link C++ class L1Muon+;
+#pragma link C++ class std::vector<L1Muon>+;
 #endif // __CINT__

--- a/core/include/SUHH2core_LinkDef.h
+++ b/core/include/SUHH2core_LinkDef.h
@@ -49,4 +49,6 @@
 #pragma link C++ class std::vector<L1Jet>+;
 #pragma link C++ class L1Muon+;
 #pragma link C++ class std::vector<L1Muon>+;
+#pragma link C++ class L1EtSum+;
+#pragma link C++ class std::vector<L1EtSum>+;
 #endif // __CINT__

--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -189,12 +189,12 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
   doPFJetConstituentsNjets = iConfig.getParameter<unsigned>("doPFJetConstituentsNjets");
   doPFJetConstituentsMinJetPt = iConfig.getParameter<double>("doPFJetConstituentsMinJetPt");
   doPFJetConstituents = false;
-  if(doPFJetConstituentsNjets>0 || doPFJetConstituentsMinJetPt>0) 
+  if(doPFJetConstituentsNjets>0 || doPFJetConstituentsMinJetPt>0)
     doPFJetConstituents=true;
   doPFTopJetConstituentsNjets = iConfig.getParameter<unsigned>("doPFTopJetConstituentsNjets");
   doPFTopJetConstituentsMinJetPt = iConfig.getParameter<double>("doPFTopJetConstituentsMinJetPt");
   doPFTopJetConstituents = false;
-  if(doPFTopJetConstituentsNjets>0 || doPFTopJetConstituentsMinJetPt>0) 
+  if(doPFTopJetConstituentsNjets>0 || doPFTopJetConstituentsMinJetPt>0)
     doPFTopJetConstituents=true;
 
   doPhotons = iConfig.getParameter<bool>("doPhotons");
@@ -202,7 +202,7 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
   doGenMET = iConfig.getParameter<bool>("doGenMET");
   doGenInfo = iConfig.getParameter<bool>("doGenInfo");
   doStableGenParticles = iConfig.getParameter<bool>("doStableGenParticles");
-  
+
   doAllPFParticles = iConfig.getParameter<bool>("doAllPFParticles");
 
   // topjet configuration:
@@ -218,7 +218,7 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
   doPFxconeJetConstituentsNjets = iConfig.getParameter<unsigned>("doPFxconeJetConstituentsNjets");
   doPFxconeJetConstituentsMinJetPt = iConfig.getParameter<double>("doPFxconeJetConstituentsMinJetPt");
   doPFxconeJetConstituents = false;
-  if((doPFxconeJetConstituentsNjets>0 || doPFxconeJetConstituentsMinJetPt>0) && doXCone) 
+  if((doPFxconeJetConstituentsNjets>0 || doPFxconeJetConstituentsMinJetPt>0) && doXCone)
     doPFxconeJetConstituents=true;
   if(doPFxconeJetConstituentsMinJetPt<1e-6) doPFxconeJetConstituentsMinJetPt=2e6;
 
@@ -226,7 +226,7 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
   doPFhotvrJetConstituentsNjets = iConfig.getParameter<unsigned>("doPFhotvrJetConstituentsNjets");
   doPFhotvrJetConstituentsMinJetPt = iConfig.getParameter<double>("doPFhotvrJetConstituentsMinJetPt");
   doPFhotvrJetConstituents = false;
-  if((doPFhotvrJetConstituentsNjets>0 || doPFhotvrJetConstituentsMinJetPt>0) && doHOTVR) 
+  if((doPFhotvrJetConstituentsNjets>0 || doPFhotvrJetConstituentsMinJetPt>0) && doHOTVR)
     doPFhotvrJetConstituents=true;
   if(doPFhotvrJetConstituentsMinJetPt<1e-6) doPFhotvrJetConstituentsMinJetPt=2e6;
 
@@ -245,7 +245,7 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
   doPFxconeDijetJetConstituentsNjets = iConfig.getParameter<unsigned>("doPFxconeDijetJetConstituentsNjets");
   doPFxconeDijetJetConstituentsMinJetPt = iConfig.getParameter<double>("doPFxconeDijetJetConstituentsMinJetPt");
   doPFxconeDijetJetConstituents = false;
-  if((doPFxconeDijetJetConstituentsNjets>0 || doPFxconeDijetJetConstituentsMinJetPt>0) && doXCone_dijet) 
+  if((doPFxconeDijetJetConstituentsNjets>0 || doPFxconeDijetJetConstituentsMinJetPt>0) && doXCone_dijet)
     doPFxconeDijetJetConstituents=true;
   if(doPFxconeDijetJetConstituentsMinJetPt<1e-6) doPFxconeDijetJetConstituentsMinJetPt=2e6;
 
@@ -526,7 +526,7 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
     }
     genjetflavor_token = consumes<reco::JetFlavourInfoMatchingCollection > ( edm::InputTag("slimmedGenJetsFlavourInfos"));
   }
-  
+
   if(doMET){
      auto met_sources = iConfig.getParameter<std::vector<std::string> >("met_sources");
      met.resize(met_sources.size());
@@ -634,9 +634,11 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
     l1GtToken_ = consumes<BXVector<GlobalAlgBlk>>(iConfig.getParameter<edm::InputTag>("l1GtSrc"));
     l1EGToken_ = consumes<BXVector<l1t::EGamma>>(iConfig.getParameter<edm::InputTag>("l1EGSrc"));
     l1JetToken_ = consumes<BXVector<l1t::Jet>>(iConfig.getParameter<edm::InputTag>("l1JetSrc"));
+    l1MuonToken_ = consumes<BXVector<l1t::Muon>>(iConfig.getParameter<edm::InputTag>("l1MuonSrc"));
 
     branch(tr,"L1EGamma_seeds","std::vector<L1EGamma>",&L1EG_seeds);
     branch(tr,"L1Jet_seeds","std::vector<L1Jet>",&L1Jet_seeds);
+    branch(tr,"L1Muon_seeds","std::vector<L1Muon>",&L1Muon_seeds);
   }
 
   if(doAllPFParticles){
@@ -1018,7 +1020,7 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
    } // end if doGenJets
    print_times(timer, "genjets");
 
-  
+
    for(auto & m : writer_modules){
        m->process(iEvent, *event, iSetup);
    }
@@ -1233,82 +1235,137 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
    print_times(timer, "trigger+prefire");
 
 
-   if(doL1seed && iEvent.isRealData()){
-     auto & triggerResults = *event->get_triggerResults();   
-     auto & triggerPrescales = *event->get_triggerPrescales();
-     auto & triggerPrescalesL1min = *event->get_triggerPrescalesL1min();
-     auto & triggerPrescalesL1max = *event->get_triggerPrescalesL1max();
-     
-     //muGT 
-     edm::Handle<BXVector<GlobalAlgBlk>> l1GtHandle;
-     iEvent.getByToken(l1GtToken_, l1GtHandle);
-     bool prefire = l1GtHandle->begin(-1)->getFinalOR();
-     triggerNames_outbranch.push_back("muGT_BX_minus_1__prefire");
-     triggerResults.push_back(prefire);
-     triggerPrescales.push_back(1);
-     triggerPrescalesL1min.push_back(1);
-     triggerPrescalesL1max.push_back(1);
-     
-     bool postfire = l1GtHandle->begin(1)->getFinalOR();
-     triggerNames_outbranch.push_back("muGT_BX_plus_1");
-     triggerResults.push_back(postfire);
-     triggerPrescales.push_back(1);
-     triggerPrescalesL1min.push_back(1);
-     triggerPrescalesL1max.push_back(1);
-     
-     bool fire = l1GtHandle->begin(0)->getFinalOR();
-     triggerNames_outbranch.push_back("muGT_BX_plus_0");
-     triggerResults.push_back(fire);
-     triggerPrescales.push_back(1);
-     triggerPrescalesL1min.push_back(1);
-     triggerPrescalesL1max.push_back(1);
+   if(doL1seed){
+     if(iEvent.isRealData()) {
+       auto & triggerResults = *event->get_triggerResults();
+       auto & triggerPrescales = *event->get_triggerPrescales();
+       auto & triggerPrescalesL1min = *event->get_triggerPrescalesL1min();
+       auto & triggerPrescalesL1max = *event->get_triggerPrescalesL1max();
+
+       //muGT
+       edm::Handle<BXVector<GlobalAlgBlk>> l1GtHandle;
+       iEvent.getByToken(l1GtToken_, l1GtHandle);
+       bool prefire = l1GtHandle->begin(-1)->getFinalOR();
+       triggerNames_outbranch.push_back("muGT_BX_minus_1__prefire");
+       triggerResults.push_back(prefire);
+       triggerPrescales.push_back(1);
+       triggerPrescalesL1min.push_back(1);
+       triggerPrescalesL1max.push_back(1);
+
+       bool postfire = l1GtHandle->begin(1)->getFinalOR();
+       triggerNames_outbranch.push_back("muGT_BX_plus_1");
+       triggerResults.push_back(postfire);
+       triggerPrescales.push_back(1);
+       triggerPrescalesL1min.push_back(1);
+       triggerPrescalesL1max.push_back(1);
+
+       bool fire = l1GtHandle->begin(0)->getFinalOR();
+       triggerNames_outbranch.push_back("muGT_BX_plus_0");
+       triggerResults.push_back(fire);
+       triggerPrescales.push_back(1);
+       triggerPrescalesL1min.push_back(1);
+       triggerPrescalesL1max.push_back(1);
+     }
+
      //L1EG
-     
      edm::Handle<BXVector<l1t::EGamma>> l1EGHandle;
      iEvent.getByToken(l1EGToken_, l1EGHandle);
      L1EG_seeds.clear();
      auto readBx = [&] (const BXVector<l1t::EGamma>& egVect, int bx) {
        for (auto itL1=l1EGHandle->begin(bx); itL1!=l1EGHandle->end(bx); ++itL1) {
-	 L1EGamma l1eg;
-	 l1eg.set_bx(bx);
-	 l1eg.set_pt(itL1->p4().Pt());
-	 l1eg.set_eta(itL1->p4().Eta());
-	 l1eg.set_phi(itL1->p4().Phi());
-	 l1eg.set_energy(itL1->p4().energy());
-	 l1eg.set_Shape(itL1->shape());
-	 l1eg.set_iso(itL1->hwIso());
-	 L1EG_seeds.push_back(l1eg);
+      	 L1EGamma l1eg;
+      	 l1eg.set_bx(bx);
+      	 l1eg.set_pt(itL1->p4().Pt());
+      	 l1eg.set_eta(itL1->p4().Eta());
+      	 l1eg.set_phi(itL1->p4().Phi());
+      	 l1eg.set_energy(itL1->p4().energy());
+      	 l1eg.set_Shape(itL1->shape());
+      	 l1eg.set_iso(itL1->hwIso());
+      	 L1EG_seeds.push_back(l1eg);
        }
      };
-     readBx(*l1EGHandle, -2);
-     readBx(*l1EGHandle, -1);
      readBx(*l1EGHandle, 0);
-     readBx(*l1EGHandle, +1);
-     readBx(*l1EGHandle, +2);
-     
+     if(iEvent.isRealData()) {
+       readBx(*l1EGHandle, -2);
+       readBx(*l1EGHandle, -1);
+       readBx(*l1EGHandle, +1);
+       readBx(*l1EGHandle, +2);
+     }
+
      //L1Jet
      edm::Handle<BXVector<l1t::Jet>> l1JetHandle;
      iEvent.getByToken(l1JetToken_, l1JetHandle);
      L1Jet_seeds.clear();
      auto readBxjet = [&] (const BXVector<l1t::Jet>& egVect, int bx) {
        for (auto itL1=l1JetHandle->begin(bx); itL1!=l1JetHandle->end(bx); ++itL1) {
-	 L1Jet l1jet;
-	 l1jet.set_bx(bx);
-	 l1jet.set_pt(itL1->p4().Pt());
-	 l1jet.set_eta(itL1->p4().Eta());
-	 l1jet.set_phi(itL1->p4().Phi());
-	 l1jet.set_energy(itL1->p4().energy());
-	 l1jet.set_puEt(itL1->puEt());
-	 l1jet.set_seedEt(itL1->seedEt());
-	 l1jet.set_rawEt(itL1->rawEt());
-	 L1Jet_seeds.push_back(l1jet);
+      	 L1Jet l1jet;
+      	 l1jet.set_bx(bx);
+      	 l1jet.set_pt(itL1->p4().Pt());
+      	 l1jet.set_eta(itL1->p4().Eta());
+      	 l1jet.set_phi(itL1->p4().Phi());
+      	 l1jet.set_energy(itL1->p4().energy());
+      	 l1jet.set_puEt(itL1->puEt());
+      	 l1jet.set_seedEt(itL1->seedEt());
+      	 l1jet.set_rawEt(itL1->rawEt());
+      	 L1Jet_seeds.push_back(l1jet);
        }
      };
-     readBxjet(*l1JetHandle, -2);
-     readBxjet(*l1JetHandle, -1);
      readBxjet(*l1JetHandle, 0);
-     readBxjet(*l1JetHandle, +1);
-     readBxjet(*l1JetHandle, +2);
+     if(iEvent.isRealData()) {
+       readBxjet(*l1JetHandle, -2);
+       readBxjet(*l1JetHandle, -1);
+       readBxjet(*l1JetHandle, +1);
+       readBxjet(*l1JetHandle, +2);
+     }
+
+     //L1Muon
+     edm::Handle<BXVector<l1t::Muon>> l1MuonHandle;
+     iEvent.getByToken(l1MuonToken_, l1MuonHandle);
+     L1Muon_seeds.clear();
+     auto readBxmuon = [&] (const BXVector<l1t::Muon>& egVect, int bx) {
+       for (auto itL1=l1MuonHandle->begin(bx); itL1!=l1MuonHandle->end(bx); ++itL1) {
+      	 L1Muon l1muon;
+      	 l1muon.set_pt(itL1->p4().Pt());
+      	 l1muon.set_eta(itL1->p4().Eta());
+      	 l1muon.set_phi(itL1->p4().Phi());
+      	 l1muon.set_energy(itL1->p4().energy());
+         l1muon.set_charge(itL1->charge());
+
+         l1muon.set_bx(bx);
+
+         l1muon.set_hwPt(itL1->hwPt());
+         l1muon.set_hwEta(itL1->hwEta());
+         l1muon.set_hwPhi(itL1->hwPhi());
+         l1muon.set_hwQual(itL1->hwQual());
+         l1muon.set_hwIso(itL1->hwIso());
+
+         l1muon.set_hwCharge(itL1->hwCharge());
+         l1muon.set_hwChargeValid(itL1->hwChargeValid());
+         l1muon.set_tfMuonIndex(itL1->tfMuonIndex());
+         l1muon.set_hwTag(itL1->hwTag());
+
+         l1muon.set_hwEtaAtVtx(itL1->hwEtaAtVtx());
+         l1muon.set_hwPhiAtVtx(itL1->hwPhiAtVtx());
+         l1muon.set_etaAtVtx(itL1->etaAtVtx());
+         l1muon.set_phiAtVtx(itL1->phiAtVtx());
+
+         l1muon.set_hwIsoSum(itL1->hwIsoSum());
+         l1muon.set_hwDPhiExtra(itL1->hwDPhiExtra());
+         l1muon.set_hwDEtaExtra(itL1->hwDEtaExtra());
+         l1muon.set_hwRank(itL1->hwRank());
+
+         l1muon.set_debug(itL1->debug());
+
+         L1Muon_seeds.push_back(l1muon);
+       }
+     };
+     readBxmuon(*l1MuonHandle, 0);
+     if(iEvent.isRealData()) {
+       readBxmuon(*l1MuonHandle, -2);
+       readBxmuon(*l1MuonHandle, -1);
+       readBxmuon(*l1MuonHandle, +1);
+       readBxmuon(*l1MuonHandle, +2);
+     }
    }
 
 

--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -636,11 +636,13 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
     l1JetToken_ = consumes<BXVector<l1t::Jet>>(iConfig.getParameter<edm::InputTag>("l1JetSrc"));
     l1MuonToken_ = consumes<BXVector<l1t::Muon>>(iConfig.getParameter<edm::InputTag>("l1MuonSrc"));
     l1EtSumToken_ = consumes<BXVector<l1t::EtSum>>(iConfig.getParameter<edm::InputTag>("l1EtSumSrc"));
+    l1TauToken_ = consumes<BXVector<l1t::Tau>>(iConfig.getParameter<edm::InputTag>("l1TauSrc"));
 
     branch(tr,"L1EGamma_seeds","std::vector<L1EGamma>",&L1EG_seeds);
     branch(tr,"L1Jet_seeds","std::vector<L1Jet>",&L1Jet_seeds);
     branch(tr,"L1Muon_seeds","std::vector<L1Muon>",&L1Muon_seeds);
     branch(tr,"L1EtSum_seeds","std::vector<L1EtSum>",&L1EtSum_seeds);
+    branch(tr,"L1Tau_seeds","std::vector<L1Tau>",&L1Tau_seeds);
   }
 
   if(doAllPFParticles){
@@ -1428,6 +1430,48 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
        readBxetsum(*l1EtSumHandle, +1);
        readBxetsum(*l1EtSumHandle, +2);
      }
+
+
+     //L1Tau
+     edm::Handle<BXVector<l1t::Tau>> l1TauHandle;
+     iEvent.getByToken(l1TauToken_, l1TauHandle);
+     L1Tau_seeds.clear();
+     auto readBxtau = [&] (const BXVector<l1t::Tau>& egVect, int bx) {
+       for (auto itL1=l1TauHandle->begin(bx); itL1!=l1TauHandle->end(bx); ++itL1) {
+         L1Tau l1tau;
+         l1tau.set_pt(itL1->p4().Pt());
+         l1tau.set_eta(itL1->p4().Eta());
+         l1tau.set_phi(itL1->p4().Phi());
+         l1tau.set_energy(itL1->p4().energy());
+         l1tau.set_charge(itL1->charge());
+
+         l1tau.set_bx(bx);
+
+         l1tau.set_hwPt(itL1->hwPt());
+         l1tau.set_hwEta(itL1->hwEta());
+         l1tau.set_hwPhi(itL1->hwPhi());
+         l1tau.set_hwQual(itL1->hwQual());
+         l1tau.set_hwIso(itL1->hwIso());
+
+         l1tau.set_towerIEta(itL1->towerIEta());
+         l1tau.set_towerIPhi(itL1->towerIPhi());
+         l1tau.set_rawEt(itL1->rawEt());
+         l1tau.set_isoEt(itL1->isoEt());
+         l1tau.set_nTT(itL1->nTT());
+         l1tau.set_hasEM(itL1->hasEM());
+         l1tau.set_isMerged(itL1->isMerged());
+
+         L1Tau_seeds.push_back(l1tau);
+       }
+     };
+     readBxtau(*l1TauHandle, 0);
+     if(iEvent.isRealData()) {
+       readBxtau(*l1TauHandle, -2);
+       readBxtau(*l1TauHandle, -1);
+       readBxtau(*l1TauHandle, +1);
+       readBxtau(*l1TauHandle, +2);
+     }
+
    }
 
 

--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -635,10 +635,12 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
     l1EGToken_ = consumes<BXVector<l1t::EGamma>>(iConfig.getParameter<edm::InputTag>("l1EGSrc"));
     l1JetToken_ = consumes<BXVector<l1t::Jet>>(iConfig.getParameter<edm::InputTag>("l1JetSrc"));
     l1MuonToken_ = consumes<BXVector<l1t::Muon>>(iConfig.getParameter<edm::InputTag>("l1MuonSrc"));
+    l1EtSumToken_ = consumes<BXVector<l1t::EtSum>>(iConfig.getParameter<edm::InputTag>("l1EtSumSrc"));
 
     branch(tr,"L1EGamma_seeds","std::vector<L1EGamma>",&L1EG_seeds);
     branch(tr,"L1Jet_seeds","std::vector<L1Jet>",&L1Jet_seeds);
     branch(tr,"L1Muon_seeds","std::vector<L1Muon>",&L1Muon_seeds);
+    branch(tr,"L1EtSum_seeds","std::vector<L1EtSum>",&L1EtSum_seeds);
   }
 
   if(doAllPFParticles){
@@ -1365,6 +1367,66 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
        readBxmuon(*l1MuonHandle, -1);
        readBxmuon(*l1MuonHandle, +1);
        readBxmuon(*l1MuonHandle, +2);
+     }
+
+     //l1EtSum
+     edm::Handle<BXVector<l1t::EtSum>> l1EtSumHandle;
+     iEvent.getByToken(l1EtSumToken_, l1EtSumHandle);
+     L1EtSum_seeds.clear();
+     auto readBxetsum = [&] (const BXVector<l1t::EtSum>& egVect, int bx) {
+       for (auto itL1=l1EtSumHandle->begin(bx); itL1!=l1EtSumHandle->end(bx); ++itL1) {
+         L1EtSum l1EtSum;
+
+         // checking and setting type
+         if(itL1->getType() == l1t::EtSum::EtSumType::kTotalEt) {
+           l1EtSum.set_type(L1EtSum::EtSumType::kTotalEt);
+         }
+         else if(itL1->getType() == l1t::EtSum::EtSumType::kTotalHt) {
+           l1EtSum.set_type(L1EtSum::EtSumType::kTotalHt);
+         }
+         else if(itL1->getType() == l1t::EtSum::EtSumType::kMissingEt) {
+           l1EtSum.set_type(L1EtSum::EtSumType::kMissingEt);
+         }
+         else if(itL1->getType() == l1t::EtSum::EtSumType::kMissingHt) {
+           l1EtSum.set_type(L1EtSum::EtSumType::kMissingHt);
+         }
+         else if(itL1->getType() == l1t::EtSum::EtSumType::kTotalEtx) {
+           l1EtSum.set_type(L1EtSum::EtSumType::kTotalEtx);
+         }
+         else if(itL1->getType() == l1t::EtSum::EtSumType::kTotalEty) {
+           l1EtSum.set_type(L1EtSum::EtSumType::kTotalEty);
+         }
+         else if(itL1->getType() == l1t::EtSum::EtSumType::kTotalHtx) {
+           l1EtSum.set_type(L1EtSum::EtSumType::kTotalEtx);
+         }
+         else if(itL1->getType() == l1t::EtSum::EtSumType::kTotalHty) {
+           l1EtSum.set_type(L1EtSum::EtSumType::kTotalEty);
+         }
+         else continue; // only keeping a selection of types for the moment
+
+      	 l1EtSum.set_pt(itL1->p4().Pt());
+      	 l1EtSum.set_eta(itL1->p4().Eta());
+      	 l1EtSum.set_phi(itL1->p4().Phi());
+      	 l1EtSum.set_energy(itL1->p4().energy());
+         l1EtSum.set_charge(itL1->charge());
+
+         l1EtSum.set_bx(bx);
+
+         l1EtSum.set_hwPt(itL1->hwPt());
+         l1EtSum.set_hwEta(itL1->hwEta());
+         l1EtSum.set_hwPhi(itL1->hwPhi());
+         l1EtSum.set_hwQual(itL1->hwQual());
+         l1EtSum.set_hwIso(itL1->hwIso());
+
+         L1EtSum_seeds.push_back(l1EtSum);
+       }
+     };
+     readBxetsum(*l1EtSumHandle, 0);
+     if(iEvent.isRealData()) {
+       readBxetsum(*l1EtSumHandle, -2);
+       readBxetsum(*l1EtSumHandle, -1);
+       readBxetsum(*l1EtSumHandle, +1);
+       readBxetsum(*l1EtSumHandle, +2);
      }
    }
 

--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -630,8 +630,8 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
     prefweightup_token = consumes<double>(edm::InputTag(prefire_source, "nonPrefiringProbUp"));
     prefweightdown_token = consumes<double>(edm::InputTag(prefire_source, "nonPrefiringProbDown"));
   }
+  l1GtToken_ = consumes<BXVector<GlobalAlgBlk>>(iConfig.getParameter<edm::InputTag>("l1GtSrc"));
   if(doL1TriggerObjects){
-    l1GtToken_ = consumes<BXVector<GlobalAlgBlk>>(iConfig.getParameter<edm::InputTag>("l1GtSrc"));
     l1EGToken_ = consumes<BXVector<l1t::EGamma>>(iConfig.getParameter<edm::InputTag>("l1EGSrc"));
     l1JetToken_ = consumes<BXVector<l1t::Jet>>(iConfig.getParameter<edm::InputTag>("l1JetSrc"));
     l1MuonToken_ = consumes<BXVector<l1t::Muon>>(iConfig.getParameter<edm::InputTag>("l1MuonSrc"));

--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -209,7 +209,7 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
   bool doTopJets = iConfig.getParameter<bool>("doTopJets");
 
   doTrigger = iConfig.getParameter<bool>("doTrigger");
-  doL1seed = iConfig.getParameter<bool>("doL1seed");
+  doL1TriggerObjects = iConfig.getParameter<bool>("doL1TriggerObjects");
   doEcalBadCalib = iConfig.getParameter<bool>("doEcalBadCalib");
   doPrefire = iConfig.getParameter<bool>("doPrefire");
 
@@ -630,7 +630,7 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
     prefweightup_token = consumes<double>(edm::InputTag(prefire_source, "nonPrefiringProbUp"));
     prefweightdown_token = consumes<double>(edm::InputTag(prefire_source, "nonPrefiringProbDown"));
   }
-  if(doL1seed){
+  if(doL1TriggerObjects){
     l1GtToken_ = consumes<BXVector<GlobalAlgBlk>>(iConfig.getParameter<edm::InputTag>("l1GtSrc"));
     l1EGToken_ = consumes<BXVector<l1t::EGamma>>(iConfig.getParameter<edm::InputTag>("l1EGSrc"));
     l1JetToken_ = consumes<BXVector<l1t::Jet>>(iConfig.getParameter<edm::InputTag>("l1JetSrc"));
@@ -1238,39 +1238,39 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
    print_times(timer, "trigger+prefire");
 
+   if(iEvent.isRealData()) {
+    auto & triggerResults = *event->get_triggerResults();
+    auto & triggerPrescales = *event->get_triggerPrescales();
+    auto & triggerPrescalesL1min = *event->get_triggerPrescalesL1min();
+    auto & triggerPrescalesL1max = *event->get_triggerPrescalesL1max();
 
-   if(doL1seed){
-     if(iEvent.isRealData()) {
-       auto & triggerResults = *event->get_triggerResults();
-       auto & triggerPrescales = *event->get_triggerPrescales();
-       auto & triggerPrescalesL1min = *event->get_triggerPrescalesL1min();
-       auto & triggerPrescalesL1max = *event->get_triggerPrescalesL1max();
+    //muGT
+    edm::Handle<BXVector<GlobalAlgBlk>> l1GtHandle;
+    iEvent.getByToken(l1GtToken_, l1GtHandle);
+    bool prefire = l1GtHandle->begin(-1)->getFinalOR();
+    triggerNames_outbranch.push_back("muGT_BX_minus_1__prefire");
+    triggerResults.push_back(prefire);
+    triggerPrescales.push_back(1);
+    triggerPrescalesL1min.push_back(1);
+    triggerPrescalesL1max.push_back(1);
 
-       //muGT
-       edm::Handle<BXVector<GlobalAlgBlk>> l1GtHandle;
-       iEvent.getByToken(l1GtToken_, l1GtHandle);
-       bool prefire = l1GtHandle->begin(-1)->getFinalOR();
-       triggerNames_outbranch.push_back("muGT_BX_minus_1__prefire");
-       triggerResults.push_back(prefire);
-       triggerPrescales.push_back(1);
-       triggerPrescalesL1min.push_back(1);
-       triggerPrescalesL1max.push_back(1);
+    bool postfire = l1GtHandle->begin(1)->getFinalOR();
+    triggerNames_outbranch.push_back("muGT_BX_plus_1");
+    triggerResults.push_back(postfire);
+    triggerPrescales.push_back(1);
+    triggerPrescalesL1min.push_back(1);
+    triggerPrescalesL1max.push_back(1);
 
-       bool postfire = l1GtHandle->begin(1)->getFinalOR();
-       triggerNames_outbranch.push_back("muGT_BX_plus_1");
-       triggerResults.push_back(postfire);
-       triggerPrescales.push_back(1);
-       triggerPrescalesL1min.push_back(1);
-       triggerPrescalesL1max.push_back(1);
+    bool fire = l1GtHandle->begin(0)->getFinalOR();
+    triggerNames_outbranch.push_back("muGT_BX_plus_0");
+    triggerResults.push_back(fire);
+    triggerPrescales.push_back(1);
+    triggerPrescalesL1min.push_back(1);
+    triggerPrescalesL1max.push_back(1);
+  }
 
-       bool fire = l1GtHandle->begin(0)->getFinalOR();
-       triggerNames_outbranch.push_back("muGT_BX_plus_0");
-       triggerResults.push_back(fire);
-       triggerPrescales.push_back(1);
-       triggerPrescalesL1min.push_back(1);
-       triggerPrescalesL1max.push_back(1);
-     }
 
+  if(doL1TriggerObjects){
      //L1EG
      edm::Handle<BXVector<l1t::EGamma>> l1EGHandle;
      iEvent.getByToken(l1EGToken_, l1EGHandle);

--- a/core/plugins/NtupleWriter.h
+++ b/core/plugins/NtupleWriter.h
@@ -21,6 +21,7 @@
 #include "DataFormats/L1Trigger/interface/Jet.h"
 #include "DataFormats/L1Trigger/interface/Muon.h"
 #include "DataFormats/L1Trigger/interface/EtSum.h"
+#include "DataFormats/L1Trigger/interface/Tau.h"
 
 #include "UHH2/core/include/Event.h"
 #include "UHH2/core/include/AnalysisModule.h"
@@ -201,11 +202,13 @@ class NtupleWriter : public edm::EDFilter {
       edm::EDGetTokenT<BXVector<l1t::Jet>> l1JetToken_;
       edm::EDGetTokenT<BXVector<l1t::Muon>> l1MuonToken_;
       edm::EDGetTokenT<BXVector<l1t::EtSum>> l1EtSumToken_;
+      edm::EDGetTokenT<BXVector<l1t::Tau>> l1TauToken_;
 
       std::vector<L1EGamma>  L1EG_seeds;
       std::vector<L1Jet> L1Jet_seeds;
       std::vector<L1Muon> L1Muon_seeds;
       std::vector<L1EtSum> L1EtSum_seeds;
+      std::vector<L1Tau> L1Tau_seeds;
 
 
 };

--- a/core/plugins/NtupleWriter.h
+++ b/core/plugins/NtupleWriter.h
@@ -20,6 +20,7 @@
 #include "DataFormats/L1Trigger/interface/EGamma.h"
 #include "DataFormats/L1Trigger/interface/Jet.h"
 #include "DataFormats/L1Trigger/interface/Muon.h"
+#include "DataFormats/L1Trigger/interface/EtSum.h"
 
 #include "UHH2/core/include/Event.h"
 #include "UHH2/core/include/AnalysisModule.h"
@@ -199,10 +200,12 @@ class NtupleWriter : public edm::EDFilter {
       edm::EDGetTokenT<BXVector<l1t::EGamma>> l1EGToken_;
       edm::EDGetTokenT<BXVector<l1t::Jet>> l1JetToken_;
       edm::EDGetTokenT<BXVector<l1t::Muon>> l1MuonToken_;
+      edm::EDGetTokenT<BXVector<l1t::EtSum>> l1EtSumToken_;
 
       std::vector<L1EGamma>  L1EG_seeds;
       std::vector<L1Jet> L1Jet_seeds;
       std::vector<L1Muon> L1Muon_seeds;
+      std::vector<L1EtSum> L1EtSum_seeds;
 
 
 };

--- a/core/plugins/NtupleWriter.h
+++ b/core/plugins/NtupleWriter.h
@@ -19,6 +19,7 @@
 #include "DataFormats/L1TGlobal/interface/GlobalAlgBlk.h"
 #include "DataFormats/L1Trigger/interface/EGamma.h"
 #include "DataFormats/L1Trigger/interface/Jet.h"
+#include "DataFormats/L1Trigger/interface/Muon.h"
 
 #include "UHH2/core/include/Event.h"
 #include "UHH2/core/include/AnalysisModule.h"
@@ -45,7 +46,7 @@ class NtupleWriter : public edm::EDFilter {
       virtual void endJob() override;
 
       virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
-      
+
       // fill gen particles and other info from a reco::jet
       void fill_geninfo_recojet(const reco::Jet& reco_genjet, GenJet& genjet, bool &add);
 
@@ -144,14 +145,14 @@ class NtupleWriter : public edm::EDFilter {
       std::vector<MET> met;
 
       std::vector<edm::EDGetToken> genmet_tokens;
-      std::vector<MET> genmet; 
+      std::vector<MET> genmet;
 
       std::vector<edm::EDGetToken> pv_tokens;
       std::vector<std::vector<PrimaryVertex>> pvs;
 
       edm::EDGetToken genparticle_token;
-      edm::EDGetToken stablegenparticle_token;   
-      
+      edm::EDGetToken stablegenparticle_token;
+
       std::vector<std::string> trigger_prefixes;
       std::vector<std::string> triggerNames_outbranch;
 
@@ -197,9 +198,12 @@ class NtupleWriter : public edm::EDFilter {
       edm::EDGetTokenT<BXVector<GlobalAlgBlk>> l1GtToken_;
       edm::EDGetTokenT<BXVector<l1t::EGamma>> l1EGToken_;
       edm::EDGetTokenT<BXVector<l1t::Jet>> l1JetToken_;
+      edm::EDGetTokenT<BXVector<l1t::Muon>> l1MuonToken_;
 
       std::vector<L1EGamma>  L1EG_seeds;
       std::vector<L1Jet> L1Jet_seeds;
+      std::vector<L1Muon> L1Muon_seeds;
+
 
 };
 

--- a/core/plugins/NtupleWriter.h
+++ b/core/plugins/NtupleWriter.h
@@ -100,7 +100,7 @@ class NtupleWriter : public edm::EDFilter {
 
       bool doPV;
       bool doTrigger;
-      bool doL1seed;
+      bool doL1TriggerObjects;
       bool doEcalBadCalib;
       bool doPrefire;
       bool runOnMiniAOD;

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -2382,7 +2382,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                     extra_trigger_bits=extra_trigger_bits,
 
                                     #For 2017 data with prefiring issue it might be usefull to store L1 seeds
-                                    doL1seed=cms.bool(True),
+                                    doL1TriggerObjects=cms.bool(True),
                                     l1GtSrc = cms.InputTag("gtStage2Digis"),
                                     l1EGSrc = cms.InputTag("caloStage2Digis:EGamma"),
                                     l1JetSrc = cms.InputTag("caloStage2Digis:Jet"),

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -2387,6 +2387,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                     l1EGSrc = cms.InputTag("caloStage2Digis:EGamma"),
                                     l1JetSrc = cms.InputTag("caloStage2Digis:Jet"),
                                     l1MuonSrc = cms.InputTag("gmtStage2Digis:Muon"),
+                                    l1EtSumSrc = cms.InputTag("caloStage2Digis:EtSum"),
 
                                     doEcalBadCalib=cms.bool(bad_ecal),
                                     ecalBadCalib_source=cms.InputTag("ecalBadCalibReducedMINIAODFilter"),

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -2388,6 +2388,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                     l1JetSrc = cms.InputTag("caloStage2Digis:Jet"),
                                     l1MuonSrc = cms.InputTag("gmtStage2Digis:Muon"),
                                     l1EtSumSrc = cms.InputTag("caloStage2Digis:EtSum"),
+                                    l1TauSrc = cms.InputTag("caloStage2Digis:Tau"),
 
                                     doEcalBadCalib=cms.bool(bad_ecal),
                                     ecalBadCalib_source=cms.InputTag("ecalBadCalibReducedMINIAODFilter"),

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -2382,7 +2382,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                     extra_trigger_bits=extra_trigger_bits,
 
                                     #For 2017 data with prefiring issue it might be usefull to store L1 seeds
-                                    doL1TriggerObjects=cms.bool(True),
+                                    doL1TriggerObjects=cms.bool(False),
                                     l1GtSrc = cms.InputTag("gtStage2Digis"),
                                     l1EGSrc = cms.InputTag("caloStage2Digis:EGamma"),
                                     l1JetSrc = cms.InputTag("caloStage2Digis:Jet"),

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -2386,6 +2386,7 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
                                     l1GtSrc = cms.InputTag("gtStage2Digis"),
                                     l1EGSrc = cms.InputTag("caloStage2Digis:EGamma"),
                                     l1JetSrc = cms.InputTag("caloStage2Digis:Jet"),
+                                    l1MuonSrc = cms.InputTag("gmtStage2Digis:Muon"),
 
                                     doEcalBadCalib=cms.bool(bad_ecal),
                                     ecalBadCalib_source=cms.InputTag("ecalBadCalibReducedMINIAODFilter"),

--- a/core/python/optionsParse.py
+++ b/core/python/optionsParse.py
@@ -22,7 +22,7 @@ def setup_opts():
     # setup defaults
     options.maxEvents = 500
     options.outputFile = "Ntuple.root"
-    
+
     return options
 
 
@@ -40,14 +40,14 @@ def set_event_content(process, eventContent):
         else     : do nothing here, keep content as in process
     """
     if eventContent == 'min':
-        process.MyNtuple.doL1seed=cms.bool(False)
+        process.MyNtuple.doL1TriggerObjects=cms.bool(False)
     if eventContent == 'max':
-        process.MyNtuple.doL1seed=cms.bool(True)
+        process.MyNtuple.doL1TriggerObjects=cms.bool(True)
 
 
 def parse_apply_opts(process, options):
     """Handle command-line args, and apply to the cms.Process object
-    
+
     Parameters
     ----------
     process : cms.Process

--- a/core/src/AnalysisModuleRunner.cxx
+++ b/core/src/AnalysisModuleRunner.cxx
@@ -605,7 +605,9 @@ void AnalysisModuleRunner::AnalysisModuleRunnerImpl::begin_input_data(AnalysisMo
         eh->setup_met(context->get("METName", ""));
         eh->setup_pfparticles(context->get("PFParticleCollection", ""));
         eh->setup_L1EG_seeds(context->get("L1EGseedsCollection", ""));
-	eh->setup_L1J_seeds(context->get("L1JseedsCollection", ""));
+	      eh->setup_L1J_seeds(context->get("L1JseedsCollection", ""));
+        eh->setup_L1M_seeds(context->get("L1MseedsCollection", ""));
+        eh->setup_L1EtS_seeds(context->get("L1EtSseedsCollection", ""));
 
         bool is_mc = context->get("dataset_type") == "MC";
         if (is_mc) {

--- a/core/src/AnalysisModuleRunner.cxx
+++ b/core/src/AnalysisModuleRunner.cxx
@@ -608,6 +608,7 @@ void AnalysisModuleRunner::AnalysisModuleRunnerImpl::begin_input_data(AnalysisMo
 	      eh->setup_L1J_seeds(context->get("L1JseedsCollection", ""));
         eh->setup_L1M_seeds(context->get("L1MseedsCollection", ""));
         eh->setup_L1EtS_seeds(context->get("L1EtSseedsCollection", ""));
+        eh->setup_L1T_seeds(context->get("L1TseedsCollection", ""));
 
         bool is_mc = context->get("dataset_type") == "MC";
         if (is_mc) {

--- a/core/src/EventHelper.cxx
+++ b/core/src/EventHelper.cxx
@@ -20,7 +20,7 @@ Event::Handle<T> declare_in_out(const std::string & branch_name, const std::stri
 
 EventHelper::EventHelper(uhh2::Context & ctx_): ctx(ctx_), event(0), pvs(false), electrons(false), muons(false), taus(false), photons(false), jets(false),
 						topjets(false), toppuppijets(false), met(false),  genmet(false), genInfo(false), gentopjets(false),
-						genparticles(false), genjets(false), pfparticles(false), trigger(false),  L1EG_seeds(false), L1J_seeds(false), L1M_seeds(false), L1EtS_seeds(false), first_event_read(true){
+						genparticles(false), genjets(false), pfparticles(false), trigger(false),  L1EG_seeds(false), L1J_seeds(false), L1M_seeds(false), L1EtS_seeds(false), L1T_seeds(false), first_event_read(true){
     h_run = declare_in_out<int>("run", "run", ctx);
     h_lumi = declare_in_out<int>("luminosityBlock", "luminosityBlock", ctx);
     h_event = declare_in_out<int>("event", "event", ctx);
@@ -65,6 +65,8 @@ IMPL_SETUP(L1EG_seeds, vector<L1EGamma>)
 IMPL_SETUP(L1J_seeds, vector<L1Jet>)
 IMPL_SETUP(L1M_seeds, vector<L1Muon>)
 IMPL_SETUP(L1EtS_seeds, vector<L1EtSum>)
+IMPL_SETUP(L1T_seeds, vector<L1Tau>)
+
 
 
 
@@ -173,6 +175,9 @@ void EventHelper::event_read(){
 	}
   if(L1EtS_seeds){
 	  event->L1EtS_seeds =  &event->get(h_L1EtS_seeds);
+	}
+  if(L1T_seeds){
+	  event->L1T_seeds =  &event->get(h_L1T_seeds);
 	}
     }
 }

--- a/core/src/EventHelper.cxx
+++ b/core/src/EventHelper.cxx
@@ -20,7 +20,7 @@ Event::Handle<T> declare_in_out(const std::string & branch_name, const std::stri
 
 EventHelper::EventHelper(uhh2::Context & ctx_): ctx(ctx_), event(0), pvs(false), electrons(false), muons(false), taus(false), photons(false), jets(false),
 						topjets(false), toppuppijets(false), met(false),  genmet(false), genInfo(false), gentopjets(false),
-						genparticles(false), genjets(false), pfparticles(false), trigger(false),  L1EG_seeds(false), L1J_seeds(false), L1M_seeds(false), first_event_read(true){
+						genparticles(false), genjets(false), pfparticles(false), trigger(false),  L1EG_seeds(false), L1J_seeds(false), L1M_seeds(false), L1EtS_seeds(false), first_event_read(true){
     h_run = declare_in_out<int>("run", "run", ctx);
     h_lumi = declare_in_out<int>("luminosityBlock", "luminosityBlock", ctx);
     h_event = declare_in_out<int>("event", "event", ctx);
@@ -64,6 +64,7 @@ IMPL_SETUP(genmet, MET)
 IMPL_SETUP(L1EG_seeds, vector<L1EGamma>)
 IMPL_SETUP(L1J_seeds, vector<L1Jet>)
 IMPL_SETUP(L1M_seeds, vector<L1Muon>)
+IMPL_SETUP(L1EtS_seeds, vector<L1EtSum>)
 
 
 
@@ -169,6 +170,9 @@ void EventHelper::event_read(){
 	}
   if(L1M_seeds){
 	  event->L1M_seeds =  &event->get(h_L1M_seeds);
+	}
+  if(L1EtS_seeds){
+	  event->L1EtS_seeds =  &event->get(h_L1EtS_seeds);
 	}
     }
 }

--- a/core/src/EventHelper.cxx
+++ b/core/src/EventHelper.cxx
@@ -8,7 +8,7 @@ using namespace std;
 
 
 namespace {
-    
+
 template<typename T>
 Event::Handle<T> declare_in_out(const std::string & branch_name, const std::string & event_name, Context & ctx){
     auto result = ctx.declare_event_input<T>(branch_name, event_name);
@@ -19,8 +19,8 @@ Event::Handle<T> declare_in_out(const std::string & branch_name, const std::stri
 }
 
 EventHelper::EventHelper(uhh2::Context & ctx_): ctx(ctx_), event(0), pvs(false), electrons(false), muons(false), taus(false), photons(false), jets(false),
-						topjets(false), toppuppijets(false), met(false),  genmet(false), genInfo(false), gentopjets(false), 
-						genparticles(false), genjets(false), pfparticles(false), trigger(false),  L1EG_seeds(false), L1J_seeds(false), first_event_read(true){
+						topjets(false), toppuppijets(false), met(false),  genmet(false), genInfo(false), gentopjets(false),
+						genparticles(false), genjets(false), pfparticles(false), trigger(false),  L1EG_seeds(false), L1J_seeds(false), L1M_seeds(false), first_event_read(true){
     h_run = declare_in_out<int>("run", "run", ctx);
     h_lumi = declare_in_out<int>("luminosityBlock", "luminosityBlock", ctx);
     h_event = declare_in_out<int>("event", "event", ctx);
@@ -63,6 +63,7 @@ IMPL_SETUP(genjets, vector<GenJet>)
 IMPL_SETUP(genmet, MET)
 IMPL_SETUP(L1EG_seeds, vector<L1EGamma>)
 IMPL_SETUP(L1J_seeds, vector<L1Jet>)
+IMPL_SETUP(L1M_seeds, vector<L1Muon>)
 
 
 
@@ -114,7 +115,7 @@ void EventHelper::event_read(){
         }
         triggernames_last_runid_event = event->run;
     }
-    
+
     // note: pointers only need to be set once
     if(first_event_read){
         first_event_read = false;
@@ -153,7 +154,7 @@ void EventHelper::event_read(){
 	catch(const std::runtime_error& error){
 	  std::cout<<"Problem with genjets in EventHelper.cxx"<<std::endl;
 	  std::cout<<error.what();
-	}	
+	}
         if(trigger){
             event->get_triggerResults() = &event->get(h_triggerResults);
 	    event->get_triggerPrescales() = &event->get(h_triggerPrescales);
@@ -165,6 +166,9 @@ void EventHelper::event_read(){
 	}
 	if(L1J_seeds){
 	  event->L1J_seeds =  &event->get(h_L1J_seeds);
+	}
+  if(L1M_seeds){
+	  event->L1M_seeds =  &event->get(h_L1M_seeds);
 	}
     }
 }
@@ -183,7 +187,7 @@ void EventHelper::event_write(){
     event->set(h_prefire, event->prefiringWeight);
     event->set(h_prefireUp, event->prefiringWeightUp);
     event->set(h_prefireDown, event->prefiringWeightDown);
-    
+
     // special case: trigger is saved only once per runid:
     if(trigger){
         if(triggernames_written.find(event->run) == triggernames_written.end()){
@@ -198,7 +202,6 @@ void EventHelper::event_write(){
             event->set(h_triggerNames, vector<string>());
         }
     }
-    
+
     // TODO: can check here whether someone changes the pointers of Event although they shouldn't.
 }
-

--- a/core/src/classes.h
+++ b/core/src/classes.h
@@ -17,6 +17,7 @@
 #include "UHH2/core/include/source_candidate.h"
 #include "UHH2/core/include/L1EGamma.h"
 #include "UHH2/core/include/L1Jet.h"
+#include "UHH2/core/include/L1Muon.h"
 
 #include <vector>
 #include <map>
@@ -39,17 +40,17 @@ namespace {
     std::vector<GenJet> genjets;
     GenTopJet gentopjet;
     std::vector<GenTopJet> gentopjets;
-    Electron ele; 
-    std::vector<Electron> eles; 
-    Muon mu; 
-    std::vector<Muon> mus; 
+    Electron ele;
+    std::vector<Electron> eles;
+    Muon mu;
+    std::vector<Muon> mus;
     Tau tau;
-    std::vector<Tau> taus; 
-    Photon ph; 
-    std::vector<Photon> phs; 
+    std::vector<Tau> taus;
+    Photon ph;
+    std::vector<Photon> phs;
     MET met;
     PrimaryVertex pv;
-    std::vector<PrimaryVertex> pvs; 
+    std::vector<PrimaryVertex> pvs;
     GenInfo genInfo;
     GenParticle genp;
     std::vector<GenParticle> genps;
@@ -61,5 +62,7 @@ namespace {
     std::vector<L1EGamma> L1EG_seeds;
     L1Jet L1Jet_seed;
     std::vector<L1Jet> L1J_seeds;
+    L1Muon L1Muon_seed;
+    std::vector<L1Muon> L1M_seeds;
   }
 }

--- a/core/src/classes.h
+++ b/core/src/classes.h
@@ -18,6 +18,8 @@
 #include "UHH2/core/include/L1EGamma.h"
 #include "UHH2/core/include/L1Jet.h"
 #include "UHH2/core/include/L1Muon.h"
+#include "UHH2/core/include/L1EtSum.h"
+
 
 #include <vector>
 #include <map>
@@ -64,5 +66,7 @@ namespace {
     std::vector<L1Jet> L1J_seeds;
     L1Muon L1Muon_seed;
     std::vector<L1Muon> L1M_seeds;
+    L1EtSum L1EtSum_seed;
+    std::vector<L1EtSum> L1EtS_seeds;
   }
 }

--- a/core/src/classes.h
+++ b/core/src/classes.h
@@ -19,6 +19,7 @@
 #include "UHH2/core/include/L1Jet.h"
 #include "UHH2/core/include/L1Muon.h"
 #include "UHH2/core/include/L1EtSum.h"
+#include "UHH2/core/include/L1Tau.h"
 
 
 #include <vector>
@@ -68,5 +69,7 @@ namespace {
     std::vector<L1Muon> L1M_seeds;
     L1EtSum L1EtSum_seed;
     std::vector<L1EtSum> L1EtS_seeds;
+    L1EtSum L1Tau_seed;
+    std::vector<L1EtSum> L1T_seeds;
   }
 }

--- a/core/src/classes_def.xml
+++ b/core/src/classes_def.xml
@@ -37,4 +37,6 @@
 <class name="std::vector<L1EGamma>"/>
 <class name="L1Jet"/>
 <class name="std::vector<L1Jet>"/>
+<class name="L1Muon"/>
+<class name="std::vector<L1Muon>"/>
 </lcgdict>

--- a/core/src/classes_def.xml
+++ b/core/src/classes_def.xml
@@ -39,4 +39,6 @@
 <class name="std::vector<L1Jet>"/>
 <class name="L1Muon"/>
 <class name="std::vector<L1Muon>"/>
+<class name="L1EtSum"/>
+<class name="std::vector<L1EtSum>"/>
 </lcgdict>

--- a/core/src/classes_def.xml
+++ b/core/src/classes_def.xml
@@ -41,4 +41,6 @@
 <class name="std::vector<L1Muon>"/>
 <class name="L1EtSum"/>
 <class name="std::vector<L1EtSum>"/>
+<class name="L1Tau"/>
+<class name="std::vector<L1Tau>"/>
 </lcgdict>


### PR DESCRIPTION
This is the same content as in #1564, now cherry-picked to 106X as the other things are done. The default behavior does not include include the L1 objects. Should we do another test with those included after the "regular" case went through?