### PR TITLE
[106X] add L1/reco matching for leptons

### DIFF
--- a/core/include/Electron.h
+++ b/core/include/Electron.h
@@ -99,7 +99,7 @@ class Electron : public RecParticle {
     m_pfMINIIso_NH_pfwgt = 0;
     m_pfMINIIso_Ph_pfwgt = 0;
 
-    m_minDeltaRToL1Electron = 10.;
+    m_minDeltaRToL1EGamma = 10.;
 
     m_source_candidates.clear();
 
@@ -154,7 +154,7 @@ class Electron : public RecParticle {
   float pfMINIIso_NH_pfwgt() const { return m_pfMINIIso_NH_pfwgt; }
   float pfMINIIso_Ph_pfwgt() const { return m_pfMINIIso_Ph_pfwgt; }
 
-  double minDeltaRToL1Electron() const{return m_minDeltaRToL1Electron;}
+  double minDeltaRToL1EGamma() const{return m_minDeltaRToL1EGamma;}
 
   const std::vector<source_candidate>& source_candidates() const { return m_source_candidates; }
 
@@ -198,7 +198,7 @@ class Electron : public RecParticle {
   void set_pfMINIIso_NH_pfwgt(float x){ m_pfMINIIso_NH_pfwgt = x; }
   void set_pfMINIIso_Ph_pfwgt(float x){ m_pfMINIIso_Ph_pfwgt = x; }
 
-  void set_minDeltaRToL1Electron(double x){m_minDeltaRToL1Electron = x;}
+  void set_minDeltaRToL1EGamma(double x){m_minDeltaRToL1EGamma = x;}
 
   void set_source_candidates(const std::vector<source_candidate>& vsc){ m_source_candidates = vsc; }
   void add_source_candidate (const source_candidate& sc){ m_source_candidates.push_back(sc); }
@@ -299,7 +299,7 @@ class Electron : public RecParticle {
   float m_pfMINIIso_NH_pfwgt;
   float m_pfMINIIso_Ph_pfwgt;
 
-  double m_minDeltaRToL1Electron;
+  double m_minDeltaRToL1EGamma;
 
   std::vector<source_candidate> m_source_candidates;
 

--- a/core/include/Electron.h
+++ b/core/include/Electron.h
@@ -99,6 +99,8 @@ class Electron : public RecParticle {
     m_pfMINIIso_NH_pfwgt = 0;
     m_pfMINIIso_Ph_pfwgt = 0;
 
+    m_minDeltaRToL1Electron = 10.;
+
     m_source_candidates.clear();
 
     m_Nclusters = 0;
@@ -152,6 +154,8 @@ class Electron : public RecParticle {
   float pfMINIIso_NH_pfwgt() const { return m_pfMINIIso_NH_pfwgt; }
   float pfMINIIso_Ph_pfwgt() const { return m_pfMINIIso_Ph_pfwgt; }
 
+  double minDeltaRToL1Electron() const{return m_minDeltaRToL1Electron;}
+
   const std::vector<source_candidate>& source_candidates() const { return m_source_candidates; }
 
   void set_supercluster_eta(float x){m_supercluster_eta=x;}
@@ -193,6 +197,8 @@ class Electron : public RecParticle {
   void set_pfMINIIso_PU      (float x){ m_pfMINIIso_PU       = x; }
   void set_pfMINIIso_NH_pfwgt(float x){ m_pfMINIIso_NH_pfwgt = x; }
   void set_pfMINIIso_Ph_pfwgt(float x){ m_pfMINIIso_Ph_pfwgt = x; }
+
+  void set_minDeltaRToL1Electron(double x){m_minDeltaRToL1Electron = x;}
 
   void set_source_candidates(const std::vector<source_candidate>& vsc){ m_source_candidates = vsc; }
   void add_source_candidate (const source_candidate& sc){ m_source_candidates.push_back(sc); }
@@ -292,6 +298,8 @@ class Electron : public RecParticle {
   float m_pfMINIIso_PU;
   float m_pfMINIIso_NH_pfwgt;
   float m_pfMINIIso_Ph_pfwgt;
+
+  double m_minDeltaRToL1Electron;
 
   std::vector<source_candidate> m_source_candidates;
 

--- a/core/include/Jet.h
+++ b/core/include/Jet.h
@@ -55,18 +55,20 @@ class Jet : public FlavorParticle {
     m_btag_DeepFlavour_probc=-2;
     m_btag_DeepFlavour_probuds=-2;
     m_btag_DeepFlavour_probg=-2;
-   
+
     m_JEC_factor_raw = 0;
     m_JEC_L1factor_raw = 0;
     m_genjet_index = -1; // not default of 0, as 0 is a valid index
     m_pileupID = -2;
+
+    m_minDeltaRToL1Jet = 10.;
 
     m_lepton_keys.clear();
     m_pfcand_indexs.clear();
   }
 
   float jetArea() const{return m_jetArea;}
-  int numberOfDaughters() const{return m_numberOfDaughters;} 
+  int numberOfDaughters() const{return m_numberOfDaughters;}
   float neutralEmEnergyFraction() const{return m_neutralEmEnergyFraction;}
   float neutralHadronEnergyFraction() const{return m_neutralHadronEnergyFraction;}
   float chargedEmEnergyFraction() const{return m_chargedEmEnergyFraction;}
@@ -75,7 +77,7 @@ class Jet : public FlavorParticle {
   float photonEnergyFraction() const{return m_photonEnergyFraction;}
   int chargedMultiplicity() const{return m_chargedMultiplicity;}
   int neutralMultiplicity() const{return m_neutralMultiplicity;}
-  int muonMultiplicity() const{return m_muonMultiplicity;} 
+  int muonMultiplicity() const{return m_muonMultiplicity;}
   int electronMultiplicity() const{return m_electronMultiplicity;}
   int photonMultiplicity() const{return m_photonMultiplicity;}
   float puppiMultiplicity() const{return m_puppiMultiplicity;}
@@ -94,7 +96,6 @@ class Jet : public FlavorParticle {
   float btag_DeepFlavour_g() const{return m_btag_DeepFlavour_probg;}
   float btag_DeepFlavour_c() const{return m_btag_DeepFlavour_probc;}
   float btag_DeepJet() const{return m_btag_DeepFlavour_probbb+m_btag_DeepFlavour_probb+m_btag_DeepFlavour_problepb;}
- 
 
   float JEC_factor_raw() const{return m_JEC_factor_raw;} // This takes you from corrected -> uncorrected
   float JEC_L1factor_raw() const{return m_JEC_L1factor_raw;} // This takes you from uncorrected -> L1 corrected
@@ -103,11 +104,13 @@ class Jet : public FlavorParticle {
   float has_tag(tag t) const { return tags.has_tag(static_cast<int>(t)); }
   float pileupID() const {return m_pileupID;}
 
+  double minDeltaRToL1Jet() const{return m_minDeltaRToL1Jet;}
+
   const std::vector<long int>& lepton_keys() const { return m_lepton_keys; }
   const std::vector<long int>& pfcand_indexs() const { return m_pfcand_indexs; }
 
   void set_jetArea(float x){m_jetArea=x;}
-  void set_numberOfDaughters(int x){m_numberOfDaughters=x;} 
+  void set_numberOfDaughters(int x){m_numberOfDaughters=x;}
   void set_neutralEmEnergyFraction(float x){m_neutralEmEnergyFraction=x;}
   void set_neutralHadronEnergyFraction(float x){m_neutralHadronEnergyFraction=x;}
   void set_chargedEmEnergyFraction(float x){m_chargedEmEnergyFraction=x;}
@@ -116,7 +119,7 @@ class Jet : public FlavorParticle {
   void set_photonEnergyFraction(float x){m_photonEnergyFraction=x;}
   void set_chargedMultiplicity(int x){m_chargedMultiplicity=x;}
   void set_neutralMultiplicity(int x){m_neutralMultiplicity=x;}
-  void set_muonMultiplicity(int x){m_muonMultiplicity=x;} 
+  void set_muonMultiplicity(int x){m_muonMultiplicity=x;}
   void set_electronMultiplicity(int x){m_electronMultiplicity=x;}
   void set_photonMultiplicity(int x){m_photonMultiplicity=x;}
   void set_puppiMultiplicity(float x){m_puppiMultiplicity=x;}
@@ -142,6 +145,8 @@ class Jet : public FlavorParticle {
   void set_tag(tag t, float value) { return tags.set_tag(static_cast<int>(t), value); }
 
   void set_pileupID(float x){m_pileupID = x;}
+
+  void set_minDeltaRToL1Jet(double x){m_minDeltaRToL1Jet = x;}
 
   void set_lepton_keys(const std::vector<long int>& vlk){ m_lepton_keys = vlk; }
   void add_lepton_key (const long int k){ m_lepton_keys.push_back(k); }
@@ -180,12 +185,14 @@ class Jet : public FlavorParticle {
   float m_btag_DeepFlavour_probuds;
   float m_btag_DeepFlavour_probc;
   float m_btag_DeepFlavour_probg;
-  
+
   float m_JEC_factor_raw;
   float m_JEC_L1factor_raw;
   int m_genjet_index;
 
   float m_pileupID;
+
+  double m_minDeltaRToL1Jet;
 
   std::vector<long int> m_lepton_keys;
   std::vector<long int> m_pfcand_indexs;

--- a/core/include/MET.h
+++ b/core/include/MET.h
@@ -2,240 +2,174 @@
 
 class MET{
 public:
-    
+
   MET(){
-      m_pt = 0;
-      m_phi = 0;
-      m_sumEt = 0;
-      m_mEtSignificance = 0;
-      m_uncorr_pt = 0;
-      m_uncorr_phi = 0;
-      m_shiftedPx_JetEnUp = 0;
-      m_shiftedPx_JetEnDown = 0;
-      m_shiftedPx_JetResUp = 0;
-      m_shiftedPx_JetResDown = 0;
-      m_shiftedPx_UnclusteredEnDown = 0;
-      m_shiftedPx_UnclusteredEnUp = 0;
-      m_shiftedPx_ElectronEnUp = 0;
-      m_shiftedPx_ElectronEnDown = 0;
-      m_shiftedPx_TauEnUp = 0;
-      m_shiftedPx_TauEnDown = 0;
-      m_shiftedPx_MuonEnDown = 0;
-      m_shiftedPx_MuonEnUp = 0;
-      m_shiftedPy_JetEnUp = 0;
-      m_shiftedPy_JetEnDown = 0;
-      m_shiftedPy_JetResUp = 0;
-      m_shiftedPy_JetResDown = 0;
-      m_shiftedPy_UnclusteredEnDown = 0;
-      m_shiftedPy_UnclusteredEnUp = 0;
-      m_shiftedPy_ElectronEnUp = 0;
-      m_shiftedPy_ElectronEnDown = 0;
-      m_shiftedPy_TauEnUp = 0;
-      m_shiftedPy_TauEnDown = 0;
-      m_shiftedPy_MuonEnDown = 0;
-      m_shiftedPy_MuonEnUp = 0;
-      m_rawCHS_px = 0;
-      m_rawCHS_py = 0;
-      /* m_corr_x = 0; */
-      /* m_corr_y = 0; */
-      /* //  m_corr_SumEt = 0; */
+    m_pt = 0;
+    m_phi = 0;
+    m_sumEt = 0;
+    m_mEtSignificance = 0;
+    m_uncorr_pt = 0;
+    m_uncorr_phi = 0;
+    m_shiftedPx_JetEnUp = 0;
+    m_shiftedPx_JetEnDown = 0;
+    m_shiftedPx_JetResUp = 0;
+    m_shiftedPx_JetResDown = 0;
+    m_shiftedPx_UnclusteredEnDown = 0;
+    m_shiftedPx_UnclusteredEnUp = 0;
+    m_shiftedPx_ElectronEnUp = 0;
+    m_shiftedPx_ElectronEnDown = 0;
+    m_shiftedPx_TauEnUp = 0;
+    m_shiftedPx_TauEnDown = 0;
+    m_shiftedPx_MuonEnDown = 0;
+    m_shiftedPx_MuonEnUp = 0;
+    m_shiftedPy_JetEnUp = 0;
+    m_shiftedPy_JetEnDown = 0;
+    m_shiftedPy_JetResUp = 0;
+    m_shiftedPy_JetResDown = 0;
+    m_shiftedPy_UnclusteredEnDown = 0;
+    m_shiftedPy_UnclusteredEnUp = 0;
+    m_shiftedPy_ElectronEnUp = 0;
+    m_shiftedPy_ElectronEnDown = 0;
+    m_shiftedPy_TauEnUp = 0;
+    m_shiftedPy_TauEnDown = 0;
+    m_shiftedPy_MuonEnDown = 0;
+    m_shiftedPy_MuonEnUp = 0;
+    m_rawCHS_px = 0;
+    m_rawCHS_py = 0;
+    /* m_corr_x = 0; */
+    /* m_corr_y = 0; */
+    /* //  m_corr_SumEt = 0; */
+    m_minDeltaRToL1MET = 10.;
   }
 
-  /// transverse momentum
-   float pt() const{return m_pt;}
-   /// phi
-   float phi() const{return m_phi;}
-   /// sum of ET in the event
-   float sumEt() const{return m_sumEt;}
-   /// transverse momentum significance from covariance matrix
-   float mEtSignificance() const{return m_mEtSignificance;}
-
-   /// uncorrected transverse momentum
-   float uncorr_pt() const{return m_uncorr_pt;}
-   /// uncorrected phi
-   float uncorr_phi() const{return m_uncorr_phi;}
-   /* /// corr in Px */
-   /* float corr_x() const{return m_corr_x;} */
-   /* /// corr in Py */
-   /* float corr_y() const{return m_corr_y;} */
-   /// corr in SumEt
-   //   float corr_SumEt() const{return m_corr_SumEt;}
-   
-   float shiftedPx_JetEnUp() const{return m_shiftedPx_JetEnUp;}
-   
-   float shiftedPx_JetEnDown() const{return m_shiftedPx_JetEnDown;} 
-
-   float shiftedPx_JetResUp() const{return m_shiftedPx_JetResUp;}
-   
-   float shiftedPx_JetResDown() const{return m_shiftedPx_JetResDown;}
-
-   float shiftedPx_UnclusteredEnDown() const{return m_shiftedPx_UnclusteredEnDown;}
-
-   float shiftedPx_MuonEnDown() const{return m_shiftedPx_MuonEnDown;}
-
-   float shiftedPx_UnclusteredEnUp() const{return m_shiftedPx_UnclusteredEnUp;}
-
-   float shiftedPx_ElectronEnUp() const{return m_shiftedPx_ElectronEnUp;}
-
-   float shiftedPx_ElectronEnDown() const{return m_shiftedPx_ElectronEnDown;}
-
-   float shiftedPx_TauEnUp() const{return m_shiftedPx_TauEnUp;}
-
-   float shiftedPx_TauEnDown() const{return m_shiftedPx_TauEnDown;}
-   
-   float shiftedPx_MuonEnUp() const{return m_shiftedPx_MuonEnUp;}
-   
-   float shiftedPy_JetEnUp() const{return m_shiftedPy_JetEnUp;}
-   
-   float shiftedPy_JetEnDown() const{return m_shiftedPy_JetEnDown;} 
-
-   float shiftedPy_JetResUp() const{return m_shiftedPy_JetResUp;}
-   
-   float shiftedPy_JetResDown() const{return m_shiftedPy_JetResDown;}
-
-   float shiftedPy_UnclusteredEnDown() const{return m_shiftedPy_UnclusteredEnDown;}
-
-   float shiftedPy_UnclusteredEnUp() const{return m_shiftedPy_UnclusteredEnUp;}
-
-   float shiftedPy_ElectronEnUp() const{return m_shiftedPy_ElectronEnUp;}
-
-   float shiftedPy_ElectronEnDown() const{return m_shiftedPy_ElectronEnDown;}
-
-   float shiftedPy_TauEnUp() const{return m_shiftedPy_TauEnUp;}
-
-   float shiftedPy_TauEnDown() const{return m_shiftedPy_TauEnDown;}
-   
-   float shiftedPy_MuonEnDown() const{return m_shiftedPy_MuonEnDown;}
-
-   float shiftedPy_MuonEnUp() const{return m_shiftedPy_MuonEnUp;}
-   
-   // For 2016v2, rawCHS does not exist, so it just returns the normal MET px & py
-   float rawCHS_px() const{return m_rawCHS_px;}
-
-   float rawCHS_py() const{return m_rawCHS_py;}
+  float pt() const{return m_pt;}
+  float phi() const{return m_phi;}
+  float sumEt() const{return m_sumEt;}
+  float mEtSignificance() const{return m_mEtSignificance;}
+  float uncorr_pt() const{return m_uncorr_pt;}
+  float uncorr_phi() const{return m_uncorr_phi;}
+  // float corr_x() const{return m_corr_x;}
+  // float corr_y() const{return m_corr_y;}
+  // float corr_SumEt() const{return m_corr_SumEt;}
+  float shiftedPx_JetEnUp() const{return m_shiftedPx_JetEnUp;}
+  float shiftedPx_JetEnDown() const{return m_shiftedPx_JetEnDown;}
+  float shiftedPx_JetResUp() const{return m_shiftedPx_JetResUp;}
+  float shiftedPx_JetResDown() const{return m_shiftedPx_JetResDown;}
+  float shiftedPx_UnclusteredEnDown() const{return m_shiftedPx_UnclusteredEnDown;}
+  float shiftedPx_MuonEnDown() const{return m_shiftedPx_MuonEnDown;}
+  float shiftedPx_UnclusteredEnUp() const{return m_shiftedPx_UnclusteredEnUp;}
+  float shiftedPx_ElectronEnUp() const{return m_shiftedPx_ElectronEnUp;}
+  float shiftedPx_ElectronEnDown() const{return m_shiftedPx_ElectronEnDown;}
+  float shiftedPx_TauEnUp() const{return m_shiftedPx_TauEnUp;}
+  float shiftedPx_TauEnDown() const{return m_shiftedPx_TauEnDown;}
+  float shiftedPx_MuonEnUp() const{return m_shiftedPx_MuonEnUp;}
+  float shiftedPy_JetEnUp() const{return m_shiftedPy_JetEnUp;}
+  float shiftedPy_JetEnDown() const{return m_shiftedPy_JetEnDown;}
+  float shiftedPy_JetResUp() const{return m_shiftedPy_JetResUp;}
+  float shiftedPy_JetResDown() const{return m_shiftedPy_JetResDown;}
+  float shiftedPy_UnclusteredEnDown() const{return m_shiftedPy_UnclusteredEnDown;}
+  float shiftedPy_UnclusteredEnUp() const{return m_shiftedPy_UnclusteredEnUp;}
+  float shiftedPy_ElectronEnUp() const{return m_shiftedPy_ElectronEnUp;}
+  float shiftedPy_ElectronEnDown() const{return m_shiftedPy_ElectronEnDown;}
+  float shiftedPy_TauEnUp() const{return m_shiftedPy_TauEnUp;}
+  float shiftedPy_TauEnDown() const{return m_shiftedPy_TauEnDown;}
+  float shiftedPy_MuonEnDown() const{return m_shiftedPy_MuonEnDown;}
+  float shiftedPy_MuonEnUp() const{return m_shiftedPy_MuonEnUp;}
+  // For 2016v2, rawCHS does not exist, so it just returns the normal MET px & py
+  float rawCHS_px() const{return m_rawCHS_px;}
+  float rawCHS_py() const{return m_rawCHS_py;}
+  double minDeltaRToL1MET() const{return m_minDeltaRToL1MET;}
 
 
-   /// set transverse momentum
-   void set_pt(float pt){m_pt=pt;}  
-   /// set phi
-   void set_phi(float phi){m_phi=phi;}
-   /// set sum Et
-   void set_sumEt(float sumEt){m_sumEt=sumEt;}
-   /// set transverse momentum significance (should be from covariance matrix)
-   void set_mEtSignificance(float mEtSignificance){m_mEtSignificance=mEtSignificance;}
+  void set_pt(float pt){m_pt=pt;}
+  void set_phi(float phi){m_phi=phi;}
+  void set_sumEt(float sumEt){m_sumEt=sumEt;}
+  void set_mEtSignificance(float mEtSignificance){m_mEtSignificance=mEtSignificance;}
+  void set_uncorr_pt(float pt){m_uncorr_pt=pt;}
+  void set_uncorr_phi(float phi){m_uncorr_phi=phi;}
+  // void set_corr_x(float x){m_corr_x=x;}
+  // void set_corr_y(float x){m_corr_y=x;}
+  // void set_corr_SumEt(float x)(m_corr_SumEt=x;}
+  void set_shiftedPx_JetEnUp(float shiftedPx_JetEnUp) {m_shiftedPx_JetEnUp = shiftedPx_JetEnUp;}
+  void set_shiftedPx_JetEnDown(float shiftedPx_JetEnDown) {m_shiftedPx_JetEnDown = shiftedPx_JetEnDown;}
+  void set_shiftedPx_JetResUp(float shiftedPx_JetResUp) {m_shiftedPx_JetResUp = shiftedPx_JetResUp;}
+  void set_shiftedPx_JetResDown(float shiftedPx_JetResDown) {m_shiftedPx_JetResDown = shiftedPx_JetResDown;}
+  void set_shiftedPx_UnclusteredEnDown(float shiftedPx_UnclusteredEnDown) {m_shiftedPx_UnclusteredEnDown = shiftedPx_UnclusteredEnDown;}
+  void set_shiftedPx_UnclusteredEnUp(float shiftedPx_UnclusteredEnUp) {m_shiftedPx_UnclusteredEnUp = shiftedPx_UnclusteredEnUp;}
+  void set_shiftedPx_ElectronEnUp(float shiftedPx_ElectronEnUp) {m_shiftedPx_ElectronEnUp = shiftedPx_ElectronEnUp;}
+  void set_shiftedPx_ElectronEnDown(float shiftedPx_ElectronEnDown) {m_shiftedPx_ElectronEnDown = shiftedPx_ElectronEnDown;}
+  void set_shiftedPx_TauEnUp(float shiftedPx_TauEnUp) {m_shiftedPx_TauEnUp = shiftedPx_TauEnUp;}
+  void set_shiftedPx_TauEnDown(float shiftedPx_TauEnDown) {m_shiftedPx_TauEnDown = shiftedPx_TauEnDown;}
+  void set_shiftedPx_MuonEnDown(float shiftedPx_MuonEnDown) {m_shiftedPx_MuonEnDown = shiftedPx_MuonEnDown;}
+  void set_shiftedPx_MuonEnUp(float shiftedPx_MuonEnUp) {m_shiftedPx_MuonEnUp = shiftedPx_MuonEnUp;}
+  void set_shiftedPy_JetEnUp(float shiftedPy_JetEnUp) {m_shiftedPy_JetEnUp = shiftedPy_JetEnUp;}
+  void set_shiftedPy_JetEnDown(float shiftedPy_JetEnDown) {m_shiftedPy_JetEnDown = shiftedPy_JetEnDown;}
+  void set_shiftedPy_JetResUp(float shiftedPy_JetResUp) {m_shiftedPy_JetResUp = shiftedPy_JetResUp;}
+  void set_shiftedPy_JetResDown(float shiftedPy_JetResDown) {m_shiftedPy_JetResDown = shiftedPy_JetResDown;}
+  void set_shiftedPy_UnclusteredEnDown(float shiftedPy_UnclusteredEnDown) {m_shiftedPy_UnclusteredEnDown = shiftedPy_UnclusteredEnDown;}
+  void set_shiftedPy_UnclusteredEnUp(float shiftedPy_UnclusteredEnUp) {m_shiftedPy_UnclusteredEnUp = shiftedPy_UnclusteredEnUp;}
+  void set_shiftedPy_ElectronEnUp(float shiftedPy_ElectronEnUp) {m_shiftedPy_ElectronEnUp = shiftedPy_ElectronEnUp;}
+  void set_shiftedPy_ElectronEnDown(float shiftedPy_ElectronEnDown) {m_shiftedPy_ElectronEnDown = shiftedPy_ElectronEnDown;}
+  void set_shiftedPy_TauEnUp(float shiftedPy_TauEnUp) {m_shiftedPy_TauEnUp = shiftedPy_TauEnUp;}
+  void set_shiftedPy_TauEnDown(float shiftedPy_TauEnDown) {m_shiftedPy_TauEnDown = shiftedPy_TauEnDown;}
+  void set_shiftedPy_MuonEnDown(float shiftedPy_MuonEnDown) {m_shiftedPy_MuonEnDown = shiftedPy_MuonEnDown;}
+  void set_shiftedPy_MuonEnUp(float shiftedPy_MuonEnUp) {m_shiftedPy_MuonEnUp = shiftedPy_MuonEnUp;}
+  void set_rawCHS_px(float CHS_px){m_rawCHS_px = CHS_px;}
+  void set_rawCHS_py(float CHS_py){m_rawCHS_py = CHS_py;}
+  void set_minDeltaRToL1MET(double x){m_minDeltaRToL1MET = x;}
 
-   /// set uncorrected transverse momentum
-   void set_uncorr_pt(float pt){m_uncorr_pt=pt;}  
-   /// set uncorrected phi
-   void set_uncorr_phi(float phi){m_uncorr_phi=phi;}
 
-   /* /// set corr in Px, Py, SumEt */
-   /* void set_corr_x(float x){m_corr_x=x;} */
-   /* void set_corr_y(float x){m_corr_y=x;} */
-   /* //   void set_corr_SumEt(float x)(m_corr_SumEt=x;} */
+  /// convert missing transverse energy into 4-vector
+  LorentzVector v4(){
+    LorentzVector met(0,0,0,0);
+    met.SetPt(m_pt);
+    met.SetPhi(m_phi);
+    return met;
+  }
 
-   void set_shiftedPx_JetEnUp(float shiftedPx_JetEnUp) {m_shiftedPx_JetEnUp = shiftedPx_JetEnUp;}
-   
-   void set_shiftedPx_JetEnDown(float shiftedPx_JetEnDown) {m_shiftedPx_JetEnDown = shiftedPx_JetEnDown;}
-   
-   void set_shiftedPx_JetResUp(float shiftedPx_JetResUp) {m_shiftedPx_JetResUp = shiftedPx_JetResUp;}
+  /// convert missing transverse energy into 4-vector
+  LorentzVector uncorr_v4(){
+    LorentzVector met(0,0,0,0);
+    met.SetPt(m_uncorr_pt);
+    met.SetPhi(m_uncorr_phi);
+    return met;
+  }
 
-   void set_shiftedPx_JetResDown(float shiftedPx_JetResDown) {m_shiftedPx_JetResDown = shiftedPx_JetResDown;}
-
-   void set_shiftedPx_UnclusteredEnDown(float shiftedPx_UnclusteredEnDown) {m_shiftedPx_UnclusteredEnDown = shiftedPx_UnclusteredEnDown;}
-
-   void set_shiftedPx_UnclusteredEnUp(float shiftedPx_UnclusteredEnUp) {m_shiftedPx_UnclusteredEnUp = shiftedPx_UnclusteredEnUp;}
-
-   void set_shiftedPx_ElectronEnUp(float shiftedPx_ElectronEnUp) {m_shiftedPx_ElectronEnUp = shiftedPx_ElectronEnUp;}
-
-   void set_shiftedPx_ElectronEnDown(float shiftedPx_ElectronEnDown) {m_shiftedPx_ElectronEnDown = shiftedPx_ElectronEnDown;}
-
-   void set_shiftedPx_TauEnUp(float shiftedPx_TauEnUp) {m_shiftedPx_TauEnUp = shiftedPx_TauEnUp;}
-
-   void set_shiftedPx_TauEnDown(float shiftedPx_TauEnDown) {m_shiftedPx_TauEnDown = shiftedPx_TauEnDown;}
-
-   void set_shiftedPx_MuonEnDown(float shiftedPx_MuonEnDown) {m_shiftedPx_MuonEnDown = shiftedPx_MuonEnDown;}
-
-   void set_shiftedPx_MuonEnUp(float shiftedPx_MuonEnUp) {m_shiftedPx_MuonEnUp = shiftedPx_MuonEnUp;}
-
-   void set_shiftedPy_JetEnUp(float shiftedPy_JetEnUp) {m_shiftedPy_JetEnUp = shiftedPy_JetEnUp;}
-   
-   void set_shiftedPy_JetEnDown(float shiftedPy_JetEnDown) {m_shiftedPy_JetEnDown = shiftedPy_JetEnDown;}
-   
-   void set_shiftedPy_JetResUp(float shiftedPy_JetResUp) {m_shiftedPy_JetResUp = shiftedPy_JetResUp;}
-
-   void set_shiftedPy_JetResDown(float shiftedPy_JetResDown) {m_shiftedPy_JetResDown = shiftedPy_JetResDown;}
-
-   void set_shiftedPy_UnclusteredEnDown(float shiftedPy_UnclusteredEnDown) {m_shiftedPy_UnclusteredEnDown = shiftedPy_UnclusteredEnDown;}
-
-   void set_shiftedPy_UnclusteredEnUp(float shiftedPy_UnclusteredEnUp) {m_shiftedPy_UnclusteredEnUp = shiftedPy_UnclusteredEnUp;}
-
-   void set_shiftedPy_ElectronEnUp(float shiftedPy_ElectronEnUp) {m_shiftedPy_ElectronEnUp = shiftedPy_ElectronEnUp;}
-
-   void set_shiftedPy_ElectronEnDown(float shiftedPy_ElectronEnDown) {m_shiftedPy_ElectronEnDown = shiftedPy_ElectronEnDown;}
-
-   void set_shiftedPy_TauEnUp(float shiftedPy_TauEnUp) {m_shiftedPy_TauEnUp = shiftedPy_TauEnUp;}
-
-   void set_shiftedPy_TauEnDown(float shiftedPy_TauEnDown) {m_shiftedPy_TauEnDown = shiftedPy_TauEnDown;}
-
-   void set_shiftedPy_MuonEnDown(float shiftedPy_MuonEnDown) {m_shiftedPy_MuonEnDown = shiftedPy_MuonEnDown;}
-
-   void set_shiftedPy_MuonEnUp(float shiftedPy_MuonEnUp) {m_shiftedPy_MuonEnUp = shiftedPy_MuonEnUp;}
-
-   void set_rawCHS_px(float CHS_px){m_rawCHS_px = CHS_px;}
-
-   void set_rawCHS_py(float CHS_py){m_rawCHS_py = CHS_py;}
-
-   /// convert missing transverse energy into 4-vector
-   LorentzVector v4(){
-      LorentzVector met(0,0,0,0);
-      met.SetPt(m_pt);
-      met.SetPhi(m_phi);
-      return met;
-   }
-
-   /// convert missing transverse energy into 4-vector
-   LorentzVector uncorr_v4(){
-      LorentzVector met(0,0,0,0);
-      met.SetPt(m_uncorr_pt);
-      met.SetPhi(m_uncorr_phi);
-      return met;
-   }
-   
 private:
-   float m_pt;
-   float m_phi;
-   float m_sumEt;
-   float m_mEtSignificance;
-   float m_shiftedPx_JetEnUp;
-   float m_shiftedPx_JetEnDown;
-   float m_shiftedPx_JetResUp; 
-   float m_shiftedPx_JetResDown; 
-   float m_shiftedPx_UnclusteredEnUp;
-   float m_shiftedPx_UnclusteredEnDown;
-   float m_shiftedPx_ElectronEnUp;
-   float m_shiftedPx_ElectronEnDown;
-   float m_shiftedPx_TauEnUp;
-   float m_shiftedPx_TauEnDown;
-   float m_shiftedPx_MuonEnDown;
-   float m_shiftedPx_MuonEnUp;
-   float m_shiftedPy_JetEnUp;
-   float m_shiftedPy_JetEnDown;
-   float m_shiftedPy_JetResUp; 
-   float m_shiftedPy_JetResDown; 
-   float m_shiftedPy_UnclusteredEnUp;
-   float m_shiftedPy_UnclusteredEnDown;
-   float m_shiftedPy_ElectronEnUp;
-   float m_shiftedPy_ElectronEnDown;
-   float m_shiftedPy_TauEnUp;
-   float m_shiftedPy_TauEnDown;
-   float m_shiftedPy_MuonEnDown;
-   float m_shiftedPy_MuonEnUp;
-   float m_rawCHS_px;
-   float m_rawCHS_py;
-   float m_uncorr_pt;
-   float m_uncorr_phi;
-   /* float m_corr_x; */
-   /* float m_corr_y; */
-   //   float m_corr_SumEt;
+  float m_pt;
+  float m_phi;
+  float m_sumEt;
+  float m_mEtSignificance;
+  float m_shiftedPx_JetEnUp;
+  float m_shiftedPx_JetEnDown;
+  float m_shiftedPx_JetResUp;
+  float m_shiftedPx_JetResDown;
+  float m_shiftedPx_UnclusteredEnUp;
+  float m_shiftedPx_UnclusteredEnDown;
+  float m_shiftedPx_ElectronEnUp;
+  float m_shiftedPx_ElectronEnDown;
+  float m_shiftedPx_TauEnUp;
+  float m_shiftedPx_TauEnDown;
+  float m_shiftedPx_MuonEnDown;
+  float m_shiftedPx_MuonEnUp;
+  float m_shiftedPy_JetEnUp;
+  float m_shiftedPy_JetEnDown;
+  float m_shiftedPy_JetResUp;
+  float m_shiftedPy_JetResDown;
+  float m_shiftedPy_UnclusteredEnUp;
+  float m_shiftedPy_UnclusteredEnDown;
+  float m_shiftedPy_ElectronEnUp;
+  float m_shiftedPy_ElectronEnDown;
+  float m_shiftedPy_TauEnUp;
+  float m_shiftedPy_TauEnDown;
+  float m_shiftedPy_MuonEnDown;
+  float m_shiftedPy_MuonEnUp;
+  float m_rawCHS_px;
+  float m_rawCHS_py;
+  float m_uncorr_pt;
+  float m_uncorr_phi;
+  // float m_corr_x;
+  // float m_corr_y;
+  // float m_corr_SumEt;
+  double m_minDeltaRToL1MET;
 };

--- a/core/include/Muon.h
+++ b/core/include/Muon.h
@@ -23,15 +23,15 @@ class Muon : public Particle {
     Highpt,
     // 2016v3 & 2017 onwards selectors:
     CutBasedIdLoose,
-    CutBasedIdMedium, 
-    CutBasedIdMediumPrompt, 
-    CutBasedIdTight, 
-    CutBasedIdGlobalHighPt, 
-    CutBasedIdTrkHighPt, 
-    SoftCutBasedId, 
-    SoftMvaId, 
-    MvaLoose, 
-    MvaMedium, 
+    CutBasedIdMedium,
+    CutBasedIdMediumPrompt,
+    CutBasedIdTight,
+    CutBasedIdGlobalHighPt,
+    CutBasedIdTrkHighPt,
+    SoftCutBasedId,
+    SoftMvaId,
+    MvaLoose,
+    MvaMedium,
     MvaTight,
     PFIsoVeryLoose,
     PFIsoLoose,
@@ -40,9 +40,9 @@ class Muon : public Particle {
     PFIsoVeryTight,
     TkIsoLoose,
     TkIsoTight,
-    MiniIsoLoose,           
-    MiniIsoMedium,          
-    MiniIsoTight,           
+    MiniIsoLoose,
+    MiniIsoMedium,
+    MiniIsoTight,
     MiniIsoVeryTight
   };
 
@@ -60,8 +60,8 @@ class Muon : public Particle {
 
   Note that this is only available for 2017 datasets and later
   */
-  enum SimType{ 
-    Unknown                     = 999, 
+  enum SimType{
+    Unknown                     = 999,
     NotMatched                  = 0,
     MatchedPunchthrough         = 1,
     MatchedElectron             = 11,
@@ -75,7 +75,7 @@ class Muon : public Particle {
     GhostPrimaryMuon            = -13,
     GhostHeavyQuark             = -3,
     GhostLightQuark             = -2
-    
+
   };
 
   enum MuonTrackType{
@@ -135,12 +135,14 @@ class Muon : public Particle {
     m_simFlavor = 0;
     m_simPdgId = 0;
     m_simMotherPdgId = 0;
-    m_simHeaviestMotherFlavor = 0; 
+    m_simHeaviestMotherFlavor = 0;
 
     m_tunePTrackPt = 0;
     m_tunePTrackEta = -999;
     m_tunePTrackPhi = -999;
     m_tunePTrackType = InnerTk;
+
+    m_minDeltaRToL1Muon = 10.;
 
     m_source_candidates.clear();
   }
@@ -160,8 +162,8 @@ class Muon : public Particle {
   float combinedQuality_trkKink()                 const { return m_combinedQuality_trkKink; }
   float segmentCompatibility()                    const { return m_segmentCompatibility; }
 
-  float sumChargedHadronPt() const{ return m_sumChargedHadronPt; } 
-  float sumNeutralHadronEt() const{ return m_sumNeutralHadronEt; } 
+  float sumChargedHadronPt() const{ return m_sumChargedHadronPt; }
+  float sumNeutralHadronEt() const{ return m_sumNeutralHadronEt; }
   float sumPhotonEt()        const{ return m_sumPhotonEt; }
   float sumPUPt()            const{ return m_sumPUPt; }
 
@@ -176,19 +178,21 @@ class Muon : public Particle {
   int simFlavor()               const {return m_simFlavor;}
   int simPdgId()                const {return m_simPdgId;}
   int simMotherPdgId()          const {return m_simMotherPdgId;}
-  int simHeaviestMotherFlavor() const {return m_simHeaviestMotherFlavor;} 
+  int simHeaviestMotherFlavor() const {return m_simHeaviestMotherFlavor;}
 
   float tunePTrackPt()           const {return m_tunePTrackPt;}
   float tunePTrackEta()          const {return m_tunePTrackEta;}
   float tunePTrackPhi()          const {return m_tunePTrackPhi;}
   MuonTrackType tunePTrackType() const {return m_tunePTrackType;}
 
+  double minDeltaRToL1Muon() const{return m_minDeltaRToL1Muon;}
+
   const std::vector<source_candidate>& source_candidates() const { return m_source_candidates; }
 
   void set_dxy(float x){m_dxy=x;}
   void set_dxy_error(float x){m_dxy_error=x;}
-  void set_dz(float x){m_dz=x;} 
-  void set_dz_error(float x){m_dz_error=x;} 
+  void set_dz(float x){m_dz=x;}
+  void set_dz_error(float x){m_dz_error=x;}
 
   void set_globalTrack_normalizedChi2             (float x){ m_globalTrack_normalizedChi2 = x; }
   void set_globalTrack_numberOfValidMuonHits      (int   x){ m_globalTrack_numberOfValidMuonHits = x; }
@@ -200,8 +204,8 @@ class Muon : public Particle {
   void set_combinedQuality_trkKink                (float x){ m_combinedQuality_trkKink = x; }
   void set_segmentCompatibility                   (float x){ m_segmentCompatibility = x; }
 
-  void set_sumChargedHadronPt(float x){m_sumChargedHadronPt=x;} 
-  void set_sumNeutralHadronEt(float x){m_sumNeutralHadronEt=x;} 
+  void set_sumChargedHadronPt(float x){m_sumChargedHadronPt=x;}
+  void set_sumNeutralHadronEt(float x){m_sumNeutralHadronEt=x;}
   void set_sumPhotonEt       (float x){m_sumPhotonEt=x;}
   void set_sumPUPt           (float x){m_sumPUPt=x;}
 
@@ -216,12 +220,14 @@ class Muon : public Particle {
   void set_simFlavor              (int x){m_simFlavor = x;}
   void set_simPdgId               (int x){m_simPdgId = x;}
   void set_simMotherPdgId         (int x){m_simMotherPdgId = x;}
-  void set_simHeaviestMotherFlavor(int x){m_simHeaviestMotherFlavor = x;} 
+  void set_simHeaviestMotherFlavor(int x){m_simHeaviestMotherFlavor = x;}
 
   void set_tunePTrackPt  (float x){ m_tunePTrackPt = x; }
   void set_tunePTrackEta (float x){ m_tunePTrackEta = x; }
   void set_tunePTrackPhi (float x){ m_tunePTrackPhi = x; }
   void set_tunePTrackType(MuonTrackType x){ m_tunePTrackType = x; }
+
+  void set_minDeltaRToL1Muon(double x){m_minDeltaRToL1Muon = x;}
 
   void set_source_candidates(const std::vector<source_candidate>& vsc){ m_source_candidates = vsc; }
   void add_source_candidate (const source_candidate& sc){ m_source_candidates.push_back(sc); }
@@ -287,6 +293,8 @@ class Muon : public Particle {
   float m_tunePTrackEta;
   float m_tunePTrackPhi;
   MuonTrackType m_tunePTrackType;
+
+  double m_minDeltaRToL1Muon;
 
   std::vector<source_candidate> m_source_candidates;
 

--- a/core/include/Photon.h
+++ b/core/include/Photon.h
@@ -59,6 +59,8 @@ public:
     m_photonIso =-1;
     m_puChargedHadronIso =-1;
 
+    m_minDeltaRToL1EGamma = 10.;
+
     m_source_candidates.clear();
   }
 
@@ -82,6 +84,7 @@ public:
   float photonIso() const{return m_photonIso;}
   float puChargedHadronIso() const{return m_puChargedHadronIso;}
 
+  double minDeltaRToL1EGamma() const{return m_minDeltaRToL1EGamma;}
 
   //  float get_tag(tag t) const{ return tags.get_tag(static_cast<int>(t));}
 
@@ -106,6 +109,8 @@ public:
   void set_puChargedHadronIso(float x){m_puChargedHadronIso =x;}
 
   //  void set_tag(tag t, float value){tags.set_tag(static_cast<int>(t), value);}
+
+  void set_minDeltaRToL1EGamma(double x){m_minDeltaRToL1EGamma = x;}
 
   void set_source_candidates(const std::vector<source_candidate>& vsc){ m_source_candidates = vsc; }
   void add_source_candidate (const source_candidate& sc){ m_source_candidates.push_back(sc); }
@@ -135,6 +140,8 @@ private:
   float m_neutralHadronIso;
   float m_photonIso;
   float m_puChargedHadronIso;
+
+  double m_minDeltaRToL1EGamma;
 
   std::vector<source_candidate> m_source_candidates;
 

--- a/core/include/Tau.h
+++ b/core/include/Tau.h
@@ -8,46 +8,45 @@
 
 class Tau: public Particle{
 public:
-    
+
   enum tag { /* for future use (more b-taggers, etc.) */ };
-  
-  
+
+
   // see https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuidePFTauID
   // "Tau ID 2014 (Preparation for Run II)"
   // for those which are "binary" for most variables below. The names correspond to the strings used in PAT, not necessarily to
   // the names used in the twiki page above (e.g. 'by...Rejection' has the name 'against...' here). See at the end of this file for a list
   // of variable names in miniAOD.
   enum bool_id {
-      againstElectronVLooseMVA6, againstElectronLooseMVA6, againstElectronMediumMVA6, againstElectronTightMVA6, againstElectronVTightMVA6, 
-      againstMuonLoose3, againstMuonTight3,
-      decayModeFinding, decayModeFindingNewDMs,
-      byLooseCombinedIsolationDeltaBetaCorr3Hits, byMediumCombinedIsolationDeltaBetaCorr3Hits, byTightCombinedIsolationDeltaBetaCorr3Hits,
-      byVLooseIsolationMVA3newDMwoLT, byLooseIsolationMVA3newDMwoLT, byMediumIsolationMVA3newDMwoLT, byTightIsolationMVA3newDMwoLT, byVTightIsolationMVA3newDMwoLT, byVVTightIsolationMVA3newDMwoLT,
-      byVLooseIsolationMVArun2v1DBnewDMwLT, byLooseIsolationMVArun2v1DBnewDMwLT, byMediumIsolationMVArun2v1DBnewDMwLT, byTightIsolationMVArun2v1DBnewDMwLT, byVTightIsolationMVArun2v1DBnewDMwLT, byVVTightIsolationMVArun2v1DBnewDMwLT
+    againstElectronVLooseMVA6, againstElectronLooseMVA6, againstElectronMediumMVA6, againstElectronTightMVA6, againstElectronVTightMVA6,
+    againstMuonLoose3, againstMuonTight3,
+    decayModeFinding, decayModeFindingNewDMs,
+    byLooseCombinedIsolationDeltaBetaCorr3Hits, byMediumCombinedIsolationDeltaBetaCorr3Hits, byTightCombinedIsolationDeltaBetaCorr3Hits,
+    byVLooseIsolationMVA3newDMwoLT, byLooseIsolationMVA3newDMwoLT, byMediumIsolationMVA3newDMwoLT, byTightIsolationMVA3newDMwoLT, byVTightIsolationMVA3newDMwoLT, byVVTightIsolationMVA3newDMwoLT,
+    byVLooseIsolationMVArun2v1DBnewDMwLT, byLooseIsolationMVArun2v1DBnewDMwLT, byMediumIsolationMVArun2v1DBnewDMwLT, byTightIsolationMVArun2v1DBnewDMwLT, byVTightIsolationMVArun2v1DBnewDMwLT, byVVTightIsolationMVArun2v1DBnewDMwLT
   };
-  
+
   bool get_bool(bool_id i) const {
-      return (id_bits & (uint64_t(1) << static_cast<uint64_t>(i)));
+    return (id_bits & (uint64_t(1) << static_cast<uint64_t>(i)));
   }
-  
+
   void set_bool(bool_id i, bool value) {
-      if(value){
-          id_bits |= uint64_t(1) << static_cast<uint64_t>(i);
-      }
-      else{
-          id_bits &= ~(uint64_t(1) << static_cast<uint64_t>(i));
-      }
+    if(value){
+      id_bits |= uint64_t(1) << static_cast<uint64_t>(i);
+    }
+    else{
+      id_bits &= ~(uint64_t(1) << static_cast<uint64_t>(i));
+    }
   }
-  
+
   // some non-bool values ('raw'):
   float byCombinedIsolationDeltaBetaCorrRaw3Hits() const { return m_byCombinedIsolationDeltaBetaCorrRaw3Hits; }
   float byIsolationMVArun2v1DBnewDMwLTraw() const { return m_byIsolationMVArun2v1DBnewDMwLTraw; }
   float byIsolationMVA3newDMwoLTraw() const { return m_byIsolationMVA3newDMwoLTraw; }
-  
+
   float chargedIsoPtSum() const { return m_chargedIsoPtSum; }
   float neutralIsoPtSum() const { return m_neutralIsoPtSum; }
   float puCorrPtSum() const { return m_puCorrPtSum; }
-  
 
   /* float byLoosePileupWeightedIsolation3Hits() const { return m_byLoosePileupWeightedIsolation3Hits; }  */
   /* float byMediumPileupWeightedIsolation3Hits() const { return m_byMediumPileupWeightedIsolation3Hits; }  */
@@ -56,12 +55,12 @@ public:
   float neutralIsoPtSumWeight() const { return m_neutralIsoPtSumWeight; }
   float footprintCorrection() const { return m_footprintCorrection; }
   float photonPtSumOutsideSignalCone() const { return m_photonPtSumOutsideSignalCone; }
-  
-
- 
 
   int decayMode() const { return m_decayMode; }
-  
+
+  double minDeltaRToL1Tau() const{return m_minDeltaRToL1Tau;}
+
+
   void set_byCombinedIsolationDeltaBetaCorrRaw3Hits(float value){ m_byCombinedIsolationDeltaBetaCorrRaw3Hits = value; }
   void set_byIsolationMVA3newDMwoLTraw(float value) { m_byIsolationMVA3newDMwoLTraw = value; }
   void set_byIsolationMVArun2v1DBnewDMwLTraw(float value) { m_byIsolationMVArun2v1DBnewDMwLTraw = value; }
@@ -69,10 +68,11 @@ public:
   void set_chargedIsoPtSum(float value) { m_chargedIsoPtSum = value; }
   void set_neutralIsoPtSum(float value) { m_neutralIsoPtSum = value; }
   void set_puCorrPtSum(float value) { m_puCorrPtSum = value; }
-  
+
   void set_decayMode(int value){ m_decayMode = value; }
 
-  
+  void set_minDeltaRToL1Tau(double x){m_minDeltaRToL1Tau = x;}
+
   /* void set_byLoosePileupWeightedIsolation3Hits(float value) { m_byLoosePileupWeightedIsolation3Hits = value;}  */
   /* void set_byMediumPileupWeightedIsolation3Hits(float value) { m_byMediumPileupWeightedIsolation3Hits = value; }  */
   /* void set_byTightPileupWeightedIsolation3Hits(float value){ m_byTightPileupWeightedIsolation3Hits = value; }  */
@@ -81,56 +81,57 @@ public:
   void set_neutralIsoPtSumWeight(float value) { m_neutralIsoPtSumWeight = value;}
   void set_footprintCorrection(float value) { m_footprintCorrection = value;}
   void set_photonPtSumOutsideSignalCone(float value) { m_photonPtSumOutsideSignalCone = value;}
-  
-
 
   float get_tag(tag t) const { return tags.get_tag(static_cast<int>(t)); }
   void set_tag(tag t, float value) { return tags.set_tag(static_cast<int>(t), value); }
-  
-  
+
+
   Tau(){
-      id_bits = 0;
-      m_byCombinedIsolationDeltaBetaCorrRaw3Hits = 0;
-      m_byIsolationMVA3newDMwoLTraw = 0;
-      m_byIsolationMVArun2v1DBnewDMwLTraw = 0;
-      m_chargedIsoPtSum = 0;
-      m_neutralIsoPtSum = 0;
-      m_puCorrPtSum = 0;
-      m_neutralIsoPtSumWeight = 0;
-      m_footprintCorrection = 0;
-      m_photonPtSumOutsideSignalCone = 0;
-      /* m_byPileupWeightedIsolationRaw3Hits = 0; */
-      m_decayMode = 0;
+    id_bits = 0;
+    m_byCombinedIsolationDeltaBetaCorrRaw3Hits = 0;
+    m_byIsolationMVA3newDMwoLTraw = 0;
+    m_byIsolationMVArun2v1DBnewDMwLTraw = 0;
+    m_chargedIsoPtSum = 0;
+    m_neutralIsoPtSum = 0;
+    m_puCorrPtSum = 0;
+    m_neutralIsoPtSumWeight = 0;
+    m_footprintCorrection = 0;
+    m_photonPtSumOutsideSignalCone = 0;
+    /* m_byPileupWeightedIsolationRaw3Hits = 0; */
+    m_decayMode = 0;
+
+    m_minDeltaRToL1Tau = 10.;
   }
 
 private:
-    // save the bool-like id variables in an uint64_t as single bits;
-    // the bit positions correspond to the int-converted values of the enum bool_id.
-    uint64_t id_bits;
-    
-    float m_byCombinedIsolationDeltaBetaCorrRaw3Hits;
-    float m_byIsolationMVA3newDMwoLTraw;
-    float m_byIsolationMVArun2v1DBnewDMwLTraw;
-    float m_chargedIsoPtSum;
-    float m_neutralIsoPtSum;
-    float m_puCorrPtSum;
-    
-    /* float m_byLoosePileupWeightedIsolation3Hits;  */
-    /* float m_byMediumPileupWeightedIsolation3Hits; */
-    /* float m_byTightPileupWeightedIsolation3Hits;  */
-    /* float m_byPileupWeightedIsolationRaw3Hits;    */
-    float m_neutralIsoPtSumWeight;
-    float m_footprintCorrection;
-    float m_photonPtSumOutsideSignalCone;
-    
-    
-    int m_decayMode;
-  
-    Tags tags;
+  // save the bool-like id variables in an uint64_t as single bits;
+  // the bit positions correspond to the int-converted values of the enum bool_id.
+  uint64_t id_bits;
+
+  float m_byCombinedIsolationDeltaBetaCorrRaw3Hits;
+  float m_byIsolationMVA3newDMwoLTraw;
+  float m_byIsolationMVArun2v1DBnewDMwLTraw;
+  float m_chargedIsoPtSum;
+  float m_neutralIsoPtSum;
+  float m_puCorrPtSum;
+
+  /* float m_byLoosePileupWeightedIsolation3Hits;  */
+  /* float m_byMediumPileupWeightedIsolation3Hits; */
+  /* float m_byTightPileupWeightedIsolation3Hits;  */
+  /* float m_byPileupWeightedIsolationRaw3Hits;    */
+  float m_neutralIsoPtSumWeight;
+  float m_footprintCorrection;
+  float m_photonPtSumOutsideSignalCone;
+
+  int m_decayMode;
+
+  double m_minDeltaRToL1Tau;
+
+  Tags tags;
 };
 
 /*
- tau id variables available on Run II 2016 MINIAOD v1:
+tau id variables available on Run II 2016 MINIAOD v1:
 
 The available IDs are: 'againstElectronLooseMVA6' 'againstElectronMVA6Raw' 'againstElectronMVA6category' 'againstElectronMediumMVA6' 'againstElectronTightMVA6' 'againstElectronVLooseMVA6' 'againstElectronVTightMVA6' 'againstMuonLoose3' 'againstMuonTight3' 'byCombinedIsolationDeltaBetaCorrRaw3Hits' 'byIsolationMVArun2v1DBdR03oldDMwLTraw' 'byIsolationMVArun2v1DBnewDMwLTraw' 'byIsolationMVArun2v1DBoldDMwLTraw' 'byIsolationMVArun2v1PWdR03oldDMwLTraw' 'byIsolationMVArun2v1PWnewDMwLTraw' 'byIsolationMVArun2v1PWoldDMwLTraw' 'byLooseCombinedIsolationDeltaBetaCorr3Hits' 'byLooseIsolationMVArun2v1DBdR03oldDMwLT' 'byLooseIsolationMVArun2v1DBnewDMwLT' 'byLooseIsolationMVArun2v1DBoldDMwLT' 'byLooseIsolationMVArun2v1PWdR03oldDMwLT' 'byLooseIsolationMVArun2v1PWnewDMwLT' 'byLooseIsolationMVArun2v1PWoldDMwLT' 'byMediumCombinedIsolationDeltaBetaCorr3Hits' 'byMediumIsolationMVArun2v1DBdR03oldDMwLT' 'byMediumIsolationMVArun2v1DBnewDMwLT' 'byMediumIsolationMVArun2v1DBoldDMwLT' 'byMediumIsolationMVArun2v1PWdR03oldDMwLT' 'byMediumIsolationMVArun2v1PWnewDMwLT' 'byMediumIsolationMVArun2v1PWoldDMwLT' 'byPhotonPtSumOutsideSignalCone' 'byTightCombinedIsolationDeltaBetaCorr3Hits' 'byTightIsolationMVArun2v1DBdR03oldDMwLT' 'byTightIsolationMVArun2v1DBnewDMwLT' 'byTightIsolationMVArun2v1DBoldDMwLT' 'byTightIsolationMVArun2v1PWdR03oldDMwLT' 'byTightIsolationMVArun2v1PWnewDMwLT' 'byTightIsolationMVArun2v1PWoldDMwLT' 'byVLooseIsolationMVArun2v1DBdR03oldDMwLT' 'byVLooseIsolationMVArun2v1DBnewDMwLT' 'byVLooseIsolationMVArun2v1DBoldDMwLT' 'byVLooseIsolationMVArun2v1PWdR03oldDMwLT' 'byVLooseIsolationMVArun2v1PWnewDMwLT' 'byVLooseIsolationMVArun2v1PWoldDMwLT' 'byVTightIsolationMVArun2v1DBdR03oldDMwLT' 'byVTightIsolationMVArun2v1DBnewDMwLT' 'byVTightIsolationMVArun2v1DBoldDMwLT' 'byVTightIsolationMVArun2v1PWdR03oldDMwLT' 'byVTightIsolationMVArun2v1PWnewDMwLT' 'byVTightIsolationMVArun2v1PWoldDMwLT' 'byVVTightIsolationMVArun2v1DBdR03oldDMwLT' 'byVVTightIsolationMVArun2v1DBnewDMwLT' 'byVVTightIsolationMVArun2v1DBoldDMwLT' 'byVVTightIsolationMVArun2v1PWdR03oldDMwLT' 'byVVTightIsolationMVArun2v1PWnewDMwLT' 'byVVTightIsolationMVArun2v1PWoldDMwLT' 'chargedIsoPtSum' 'chargedIsoPtSumdR03' 'decayModeFinding' 'decayModeFindingNewDMs' 'footprintCorrection' 'footprintCorrectiondR03' 'neutralIsoPtSum' 'neutralIsoPtSumWeight' 'neutralIsoPtSumWeightdR03' 'neutralIsoPtSumdR03' 'photonPtSumOutsideSignalCone' 'photonPtSumOutsideSignalConedR03' 'puCorrPtSum' .
 

--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -274,7 +274,6 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
     cfg.l1egamma_src = iConfig.getParameter<edm::InputTag>("l1EGSrc");
     writer_modules.emplace_back(new NtupleWriterElectrons(cfg, true, save_lepton_keys));
     //}
-
   }
   if(doPhotons){
     using uhh2::NtupleWriterPhotons;
@@ -283,6 +282,7 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
     cfg.id_keys = iConfig.getParameter<std::vector<std::string>>("photon_IDtags");
     assert(pv_sources.size() > 0); // note: pvs are needed for electron id.
     cfg.pv_src = pv_sources[0];
+    cfg.l1egamma_src = iConfig.getParameter<edm::InputTag>("l1EGSrc");
     cfg.doPuppiIso = true;
     if (year == "2016v2") { cfg.doPuppiIso = false; } // PUPPI isolation doesn't exist in 80X
     writer_modules.emplace_back(new NtupleWriterPhotons(cfg, true, save_photon_keys));
@@ -290,7 +290,6 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
   if(doMuons){
     using uhh2::NtupleWriterMuons;
     auto muon_sources = iConfig.getParameter<std::vector<std::string>>("muon_sources");
-
     for(size_t i=0; i< muon_sources.size(); ++i){
       NtupleWriterMuons::Config cfg(*context, consumesCollector(), muon_sources[i], muon_sources[i]);
       assert(pv_sources.size() > 0); // note: pvs are required for muon id.
@@ -308,6 +307,7 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
       NtupleWriterTaus::Config cfg(*context, consumesCollector(), tau_sources[i], tau_sources[i]);
       cfg.ptmin = tau_ptmin;
       cfg.etamax = tau_etamax;
+      cfg.l1tau_src = iConfig.getParameter<edm::InputTag>("l1TauSrc");
       writer_modules.emplace_back(new NtupleWriterTaus(cfg, i==0));
     }
   }
@@ -336,6 +336,7 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
       NtupleWriterJets::Config cfg(*context, consumesCollector(), jet_sources[i], jet_sources[i]);
       cfg.ptmin = jet_ptmin;
       cfg.etamax = jet_etamax;
+      cfg.l1jet_src = iConfig.getParameter<edm::InputTag>("l1JetSrc");
       writer_modules.emplace_back(new NtupleWriterJets(cfg, i==0, muon_sources, elec_sources,doPFJetConstituentsNjets,doPFJetConstituentsMinJetPt));
     }
   }
@@ -1036,6 +1037,10 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     for(size_t j=0; j< met_tokens.size(); ++j){
       edm::Handle< std::vector<pat::MET> > met_handle;
       iEvent.getByToken(met_tokens[j], met_handle);
+
+      edm::Handle<BXVector<l1t::EtSum>> l1EtSumHandle;
+      iEvent.getByToken(l1EtSumToken_, l1EtSumHandle);
+
       const std::vector<pat::MET>& pat_mets = *met_handle;
       if(pat_mets.size()!=1){
         edm::LogWarning("NtupleWriter") << "WARNING: number of METs = " << pat_mets.size() <<", should be 1";
@@ -1048,6 +1053,15 @@ bool NtupleWriter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
         met[j].set_mEtSignificance(pat_met.metSignificance());
         met[j].set_uncorr_pt(pat_met.uncorPt());
         met[j].set_uncorr_phi(pat_met.uncorPhi());
+
+        // L1-reco matching: defaults to 10 if there's no L1 object to match
+        for(const l1t::EtSum & itL1 : *l1EtSumHandle){
+          if(itL1.getType() == l1t::EtSum::EtSumType::kMissingEt){
+            double dR_recoMET_l1MET = reco::deltaR(pat_met.eta(), pat_met.phi(), itL1.p4().Eta(), itL1.p4().Phi());
+            if(dR_recoMET_l1MET < met[j].minDeltaRToL1MET()) met[j].set_minDeltaRToL1MET(dR_recoMET_l1MET);
+          }
+        }
+
         // std::cout<<"MET uncorrPt = "<<pat_met.uncorPt()<<" uncorrPhi = "<<pat_met.uncorPhi()<<" corrPt = "<<pat_met.pt()<<" corrPhi = "<<pat_met.phi()<<std::endl;
         if(!skipMETUncertainties.at(j))
         {

--- a/core/plugins/NtupleWriterJets.h
+++ b/core/plugins/NtupleWriterJets.h
@@ -16,6 +16,8 @@
 #include "TrackingTools/IPTools/interface/IPTools.h"
 #include "fastjet/PseudoJet.hh"
 #include "RecoBTag/SecondaryVertex/interface/TrackKinematics.h"
+#include "DataFormats/L1TGlobal/interface/GlobalAlgBlk.h"
+#include "DataFormats/L1Trigger/interface/Jet.h"
 
 
 class GenericMVAJetTagComputer;
@@ -27,6 +29,16 @@ size_t add_pfpart(const reco::Candidate & pf, std::vector<PFParticle> & pfparts)
 
 class NtupleWriterJets: public NtupleWriterModule {
 public:
+
+    struct Config: public NtupleWriterModule::Config {
+      edm::InputTag l1jet_src;
+
+      // inherit constructor does not work yet :-(
+      Config(uhh2::Context & ctx_, edm::ConsumesCollector && cc_, const edm::InputTag & src_,
+             const std::string & dest_, const std::string & dest_branchname_ = ""):
+        NtupleWriterModule::Config(ctx_, std::move(cc_), src_, dest_, dest_branchname_) {}
+    };
+
     static void fill_jet_info(uhh2::Event & uevent, const pat::Jet & pat_jet, Jet & jet, bool do_btagging, bool doPuppiSpecific, bool fill_pfcand=false);
 
     explicit NtupleWriterJets(Config & cfg, bool set_jets_member, unsigned int NPFJetwConstituents, double MinPtJetwConstituents);
@@ -40,6 +52,7 @@ private:
     edm::EDGetToken src_token;
     edm::EDGetToken src_higgs_token;
     edm::EDGetToken src_softdrop_token;
+    edm::EDGetTokenT<BXVector<l1t::Jet>> l1jet_token;
     float ptmin, etamax;
     Event::Handle<std::vector<Jet>> handle; // main handle to write output to
     boost::optional<Event::Handle<std::vector<Jet>>> jets_handle; // handle of name "jets" in case set_jets_member is true

--- a/core/plugins/NtupleWriterLeptons.cxx
+++ b/core/plugins/NtupleWriterLeptons.cxx
@@ -118,7 +118,7 @@ void NtupleWriterElectrons::process(const edm::Event & event, uhh2::Event & ueve
       ele.set_tag(Electron::tagname2tag(tag_str), float(pat_ele.electronID(tag_str)));
     }
 
-    // L1-reco matching
+    // L1-reco matching: defaults to 10 if there's no L1 object to match
     for(const l1t::EGamma & itL1 : *l1electron_handle){
       double dR_recoElec_l1Elec = reco::deltaR(pat_ele.eta(), pat_ele.phi(), itL1.p4().Eta(), itL1.p4().Phi());
       if(dR_recoElec_l1Elec < ele.minDeltaRToL1Electron()) ele.set_minDeltaRToL1Electron(dR_recoElec_l1Elec);
@@ -262,9 +262,6 @@ void NtupleWriterMuons::process(const edm::Event & event, uhh2::Event & uevent, 
 
   edm::Handle<BXVector<l1t::Muon>> l1muon_handle;
   event.getByToken(l1muon_token, l1muon_handle);
-  // if(l1muon_handle->isEmpty()){
-  //   edm::LogWarning("NtupleWriterMuons") << "No L1 muons found, not doing L1-reco matching!";
-  // }
 
   std::vector<Muon> mus;
   for (const pat::Muon & pat_mu : *mu_handle) {
@@ -378,7 +375,7 @@ void NtupleWriterMuons::process(const edm::Event & event, uhh2::Event & uevent, 
     mu.set_tunePTrackPhi(tunePTrack->phi());
     mu.set_tunePTrackType(static_cast<Muon::MuonTrackType>(pat_mu.tunePMuonBestTrackType()));
 
-    // L1-reco matching
+    // L1-reco matching: defaults to 10 if there's no L1 object to match
     for(const l1t::Muon & itL1 : *l1muon_handle){
       double dR_recoMuon_l1Muon = reco::deltaR(pat_mu.eta(), pat_mu.phi(), itL1.p4().Eta(), itL1.p4().Phi());
       if(dR_recoMuon_l1Muon < mu.minDeltaRToL1Muon()) mu.set_minDeltaRToL1Muon(dR_recoMuon_l1Muon);

--- a/core/plugins/NtupleWriterLeptons.cxx
+++ b/core/plugins/NtupleWriterLeptons.cxx
@@ -220,12 +220,7 @@ void NtupleWriterPhotons::process(const edm::Event & event, uhh2::Event & uevent
     // L1-reco matching: defaults to 10 if there's no L1 object to match
     for(const l1t::EGamma & itL1 : *l1egamma_handle){
       double dR_recoPho_l1EGamma = reco::deltaR(pat_pho.eta(), pat_pho.phi(), itL1.p4().Eta(), itL1.p4().Phi());
-      if(dR_recoPho_l1EGamma < pho.minDeltaRToL1EGamma()){
-        pho.set_minDeltaRToL1EGamma(dR_recoPho_l1EGamma);
-
-        // delete this itL1 from l1egamma_handle
-
-      }
+      if(dR_recoPho_l1EGamma < pho.minDeltaRToL1EGamma()) pho.set_minDeltaRToL1EGamma(dR_recoPho_l1EGamma);
     }
 
     /* source candidates */

--- a/core/plugins/NtupleWriterLeptons.cxx
+++ b/core/plugins/NtupleWriterLeptons.cxx
@@ -8,7 +8,9 @@
 #include "DataFormats/PatCandidates/interface/Muon.h"
 #include "DataFormats/PatCandidates/interface/Tau.h"
 
-#include "DataFormats/MuonReco/interface/MuonSelectors.h"
+#include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
+
+// #include "DataFormats/MuonReco/interface/MuonSelectors.h"
 
 using namespace uhh2;
 using namespace std;
@@ -16,125 +18,136 @@ using namespace std;
 NtupleWriterElectrons::NtupleWriterElectrons(Config & cfg, bool set_electrons_member, const bool save_source_cands): save_source_candidates_(save_source_cands){
   handle = cfg.ctx.declare_event_output<vector<Electron>>(cfg.dest_branchname, cfg.dest);
   if(set_electrons_member) electrons_handle = cfg.ctx.get_handle<vector<Electron>>("electrons");
-  src_token = cfg.cc.consumes<std::vector<pat::Electron>>(cfg.src);
-  pv_token = cfg.cc.consumes<std::vector<reco::Vertex>>(cfg.pv_src);
+  src_token        = cfg.cc.consumes<std::vector<pat::Electron>>(cfg.src);
+  pv_token         = cfg.cc.consumes<std::vector<reco::Vertex>>(cfg.pv_src);
+  l1electron_token = cfg.cc.consumes<BXVector<l1t::EGamma>>(cfg.l1egamma_src);
+
   IDtag_keys = cfg.id_keys;
 }
 
 NtupleWriterElectrons::~NtupleWriterElectrons(){}
 
 void NtupleWriterElectrons::process(const edm::Event & event, uhh2::Event & uevent, const edm::EventSetup& iSetup){
-    edm::Handle< std::vector<pat::Electron> > ele_handle;
-    event.getByToken(src_token, ele_handle);
+  edm::Handle< std::vector<pat::Electron> > ele_handle;
+  event.getByToken(src_token, ele_handle);
 
-    edm::Handle<std::vector<reco::Vertex>> pv_handle;
-   event.getByToken(pv_token, pv_handle);
-   if(pv_handle->empty()){
-       edm::LogWarning("NtupleWriterElectrons") << "No PVs found, not writing electrons!";
-       return;
-   }
-   const auto & PV = pv_handle->front();
+  edm::Handle<std::vector<reco::Vertex>> pv_handle;
+  event.getByToken(pv_token, pv_handle);
+  if(pv_handle->empty()){
+    edm::LogWarning("NtupleWriterElectrons") << "No PVs found, not writing electrons!";
+    return;
+  }
+  const auto & PV = pv_handle->front();
 
-    std::vector<Electron> eles;
-    const size_t n_ele = ele_handle->size();
-    for (size_t i=0; i<n_ele; ++i){
-        const auto & pat_ele = (*ele_handle)[i];
-        eles.emplace_back();
-        Electron & ele = eles.back();
-        ele.set_charge( pat_ele.charge());
-        ele.set_pt( pat_ele.pt());
-        ele.set_eta( pat_ele.eta());
-        ele.set_phi( pat_ele.phi());
-        ele.set_energy( pat_ele.energy());
-        //	cout<<"pat_ele.pt() = "<<pat_ele.pt()<<endl;
-        ele.set_ptError( pat_ele.gsfTrack()->ptError());
-        ele.set_etaError( pat_ele.gsfTrack()->etaError());
-        ele.set_phiError( pat_ele.gsfTrack()->phiError());
-        //	ele.set_energyError( pat_ele.energyError());
-        ele.set_supercluster_eta( pat_ele.superCluster()->eta() );
-        ele.set_supercluster_phi( pat_ele.superCluster()->phi() );
-        ele.set_dB(pat_ele.dB());
-        const auto & pfiso = pat_ele.pfIsolationVariables();
-        ele.set_neutralHadronIso(pfiso.sumNeutralHadronEt);
-        ele.set_chargedHadronIso(pfiso.sumChargedHadronPt);
-        ele.set_trackIso(pfiso.sumChargedParticlePt);
-        ele.set_photonIso(pfiso.sumPhotonEt);
-        ele.set_puChargedHadronIso(pfiso.sumPUPt);
-        ele.set_gsfTrack_trackerExpectedHitsInner_numberOfLostHits(pat_ele.gsfTrack()->hitPattern().numberOfAllHits(reco::HitPattern::MISSING_INNER_HITS));
-        ele.set_gsfTrack_px(pat_ele.gsfTrack()->px());
-        ele.set_gsfTrack_py(pat_ele.gsfTrack()->py());
-        ele.set_gsfTrack_pz(pat_ele.gsfTrack()->pz());
-        ele.set_gsfTrack_vx(pat_ele.gsfTrack()->vx());
-        ele.set_gsfTrack_vy(pat_ele.gsfTrack()->vy());
-        ele.set_gsfTrack_vz(pat_ele.gsfTrack()->vz());
-        ele.set_passconversionveto(pat_ele.passConversionVeto());
-        ele.set_dEtaIn(pat_ele.deltaEtaSuperClusterTrackAtVtx());
-        ele.set_dPhiIn(pat_ele.deltaPhiSuperClusterTrackAtVtx());
-        ele.set_sigmaIEtaIEta(pat_ele.full5x5_sigmaIetaIeta());
-        ele.set_HoverE(pat_ele.hadronicOverEm());
-        ele.set_fbrem(std::max(pat_ele.fbrem(), -100.f)); // this is track frbem. default is -1e-30, making it impossible to validate on plots. -100 should be low enough to see detail around 0
-        ele.set_EoverPIn(pat_ele.eSuperClusterOverP());
-        ele.set_EcalEnergy(pat_ele.ecalEnergy());
-        ele.set_hcalOverEcal    (pat_ele.hcalOverEcal());
-        ele.set_ecalPFClusterIso(pat_ele.ecalPFClusterIso());
-        ele.set_hcalPFClusterIso(pat_ele.hcalPFClusterIso());
-        ele.set_dr03TkSumPt     (pat_ele.dr03TkSumPt());
+  edm::Handle<BXVector<l1t::EGamma>> l1electron_handle;
+  event.getByToken(l1electron_token, l1electron_handle);
 
-        ele.set_mvaGeneralPurpose(pat_ele.hasUserFloat("ElectronMVAEstimatorRun2Spring16GeneralPurposeV1Values") ? pat_ele.userFloat("ElectronMVAEstimatorRun2Spring16GeneralPurposeV1Values") : -999.);
-        ele.set_mvaHZZ(pat_ele.hasUserFloat("ElectronMVAEstimatorRun2Spring16HZZV1Values") ? pat_ele.userFloat("ElectronMVAEstimatorRun2Spring16HZZV1Values") : -999.);
+  std::vector<Electron> eles;
+  const size_t n_ele = ele_handle->size();
+  for (size_t i=0; i<n_ele; ++i){
+    const auto & pat_ele = (*ele_handle)[i];
+    eles.emplace_back();
+    Electron & ele = eles.back();
+    ele.set_charge( pat_ele.charge());
+    ele.set_pt( pat_ele.pt());
+    ele.set_eta( pat_ele.eta());
+    ele.set_phi( pat_ele.phi());
+    ele.set_energy( pat_ele.energy());
+    //	cout<<"pat_ele.pt() = "<<pat_ele.pt()<<endl;
+    ele.set_ptError( pat_ele.gsfTrack()->ptError());
+    ele.set_etaError( pat_ele.gsfTrack()->etaError());
+    ele.set_phiError( pat_ele.gsfTrack()->phiError());
+    //	ele.set_energyError( pat_ele.energyError());
+    ele.set_supercluster_eta( pat_ele.superCluster()->eta() );
+    ele.set_supercluster_phi( pat_ele.superCluster()->phi() );
+    ele.set_dB(pat_ele.dB());
+    const auto & pfiso = pat_ele.pfIsolationVariables();
+    ele.set_neutralHadronIso(pfiso.sumNeutralHadronEt);
+    ele.set_chargedHadronIso(pfiso.sumChargedHadronPt);
+    ele.set_trackIso(pfiso.sumChargedParticlePt);
+    ele.set_photonIso(pfiso.sumPhotonEt);
+    ele.set_puChargedHadronIso(pfiso.sumPUPt);
+    ele.set_gsfTrack_trackerExpectedHitsInner_numberOfLostHits(pat_ele.gsfTrack()->hitPattern().numberOfAllHits(reco::HitPattern::MISSING_INNER_HITS));
+    ele.set_gsfTrack_px(pat_ele.gsfTrack()->px());
+    ele.set_gsfTrack_py(pat_ele.gsfTrack()->py());
+    ele.set_gsfTrack_pz(pat_ele.gsfTrack()->pz());
+    ele.set_gsfTrack_vx(pat_ele.gsfTrack()->vx());
+    ele.set_gsfTrack_vy(pat_ele.gsfTrack()->vy());
+    ele.set_gsfTrack_vz(pat_ele.gsfTrack()->vz());
+    ele.set_passconversionveto(pat_ele.passConversionVeto());
+    ele.set_dEtaIn(pat_ele.deltaEtaSuperClusterTrackAtVtx());
+    ele.set_dPhiIn(pat_ele.deltaPhiSuperClusterTrackAtVtx());
+    ele.set_sigmaIEtaIEta(pat_ele.full5x5_sigmaIetaIeta());
+    ele.set_HoverE(pat_ele.hadronicOverEm());
+    ele.set_fbrem(std::max(pat_ele.fbrem(), -100.f)); // this is track frbem. default is -1e-30, making it impossible to validate on plots. -100 should be low enough to see detail around 0
+    ele.set_EoverPIn(pat_ele.eSuperClusterOverP());
+    ele.set_EcalEnergy(pat_ele.ecalEnergy());
+    ele.set_hcalOverEcal    (pat_ele.hcalOverEcal());
+    ele.set_ecalPFClusterIso(pat_ele.ecalPFClusterIso());
+    ele.set_hcalPFClusterIso(pat_ele.hcalPFClusterIso());
+    ele.set_dr03TkSumPt     (pat_ele.dr03TkSumPt());
 
-        ele.set_mvaIso(pat_ele.hasUserFloat("ElectronMVAEstimatorRun2Fall17IsoV2Values") ? pat_ele.userFloat("ElectronMVAEstimatorRun2Fall17IsoV2Values") : -999.);
-        ele.set_mvaNoIso(pat_ele.hasUserFloat("ElectronMVAEstimatorRun2Fall17NoIsoV2Values") ? pat_ele.userFloat("ElectronMVAEstimatorRun2Fall17NoIsoV2Values") : -999.);
+    ele.set_mvaGeneralPurpose(pat_ele.hasUserFloat("ElectronMVAEstimatorRun2Spring16GeneralPurposeV1Values") ? pat_ele.userFloat("ElectronMVAEstimatorRun2Spring16GeneralPurposeV1Values") : -999.);
+    ele.set_mvaHZZ(pat_ele.hasUserFloat("ElectronMVAEstimatorRun2Spring16HZZV1Values") ? pat_ele.userFloat("ElectronMVAEstimatorRun2Spring16HZZV1Values") : -999.);
 
-        ele.set_effArea(pat_ele.hasUserFloat("EffArea") ? pat_ele.userFloat("EffArea") : -999.);
+    ele.set_mvaIso(pat_ele.hasUserFloat("ElectronMVAEstimatorRun2Fall17IsoV2Values") ? pat_ele.userFloat("ElectronMVAEstimatorRun2Fall17IsoV2Values") : -999.);
+    ele.set_mvaNoIso(pat_ele.hasUserFloat("ElectronMVAEstimatorRun2Fall17NoIsoV2Values") ? pat_ele.userFloat("ElectronMVAEstimatorRun2Fall17NoIsoV2Values") : -999.);
 
-        ele.set_pfMINIIso_CH      (pat_ele.hasUserFloat("elPFMiniIsoValueCHSTAND") ? pat_ele.userFloat("elPFMiniIsoValueCHSTAND") : -999.);
-        ele.set_pfMINIIso_NH      (pat_ele.hasUserFloat("elPFMiniIsoValueNHSTAND") ? pat_ele.userFloat("elPFMiniIsoValueNHSTAND") : -999.);
-        ele.set_pfMINIIso_Ph      (pat_ele.hasUserFloat("elPFMiniIsoValuePhSTAND") ? pat_ele.userFloat("elPFMiniIsoValuePhSTAND") : -999.);
-        ele.set_pfMINIIso_PU      (pat_ele.hasUserFloat("elPFMiniIsoValuePUSTAND") ? pat_ele.userFloat("elPFMiniIsoValuePUSTAND") : -999.);
-        ele.set_pfMINIIso_NH_pfwgt(pat_ele.hasUserFloat("elPFMiniIsoValueNHPFWGT") ? pat_ele.userFloat("elPFMiniIsoValueNHPFWGT") : -999.);
-        ele.set_pfMINIIso_Ph_pfwgt(pat_ele.hasUserFloat("elPFMiniIsoValuePhPFWGT") ? pat_ele.userFloat("elPFMiniIsoValuePhPFWGT") : -999.);
+    ele.set_effArea(pat_ele.hasUserFloat("EffArea") ? pat_ele.userFloat("EffArea") : -999.);
 
-        ele.set_Nclusters(pat_ele.superCluster()->clusters().size());
-        ele.set_Class(pat_ele.classification());
+    ele.set_pfMINIIso_CH      (pat_ele.hasUserFloat("elPFMiniIsoValueCHSTAND") ? pat_ele.userFloat("elPFMiniIsoValueCHSTAND") : -999.);
+    ele.set_pfMINIIso_NH      (pat_ele.hasUserFloat("elPFMiniIsoValueNHSTAND") ? pat_ele.userFloat("elPFMiniIsoValueNHSTAND") : -999.);
+    ele.set_pfMINIIso_Ph      (pat_ele.hasUserFloat("elPFMiniIsoValuePhSTAND") ? pat_ele.userFloat("elPFMiniIsoValuePhSTAND") : -999.);
+    ele.set_pfMINIIso_PU      (pat_ele.hasUserFloat("elPFMiniIsoValuePUSTAND") ? pat_ele.userFloat("elPFMiniIsoValuePUSTAND") : -999.);
+    ele.set_pfMINIIso_NH_pfwgt(pat_ele.hasUserFloat("elPFMiniIsoValueNHPFWGT") ? pat_ele.userFloat("elPFMiniIsoValueNHPFWGT") : -999.);
+    ele.set_pfMINIIso_Ph_pfwgt(pat_ele.hasUserFloat("elPFMiniIsoValuePhPFWGT") ? pat_ele.userFloat("elPFMiniIsoValuePhPFWGT") : -999.);
 
-        ele.set_isEcalDriven(pat_ele.ecalDriven());
-        ele.set_full5x5_e1x5(pat_ele.full5x5_e1x5());
-        ele.set_full5x5_e2x5Max(pat_ele.full5x5_e2x5Max());
-        ele.set_full5x5_e5x5(pat_ele.full5x5_e5x5());
-        ele.set_dEtaInSeed(pat_ele.deltaEtaSeedClusterTrackAtVtx());
+    ele.set_Nclusters(pat_ele.superCluster()->clusters().size());
+    ele.set_Class(pat_ele.classification());
 
-        ele.set_dxy(pat_ele.gsfTrack()->dxy(PV.position()));// correct for vertex postion
+    ele.set_isEcalDriven(pat_ele.ecalDriven());
+    ele.set_full5x5_e1x5(pat_ele.full5x5_e1x5());
+    ele.set_full5x5_e2x5Max(pat_ele.full5x5_e2x5Max());
+    ele.set_full5x5_e5x5(pat_ele.full5x5_e5x5());
+    ele.set_dEtaInSeed(pat_ele.deltaEtaSeedClusterTrackAtVtx());
 
-        for(const auto& tag_str : IDtag_keys){
-          if(!pat_ele.isElectronIDAvailable(tag_str)) throw cms::Exception("Missing Electron ID", "ElectronID not found: "+tag_str);
-          ele.set_tag(Electron::tagname2tag(tag_str), float(pat_ele.electronID(tag_str)));
-        }
+    ele.set_dxy(pat_ele.gsfTrack()->dxy(PV.position()));// correct for vertex postion
 
-        /* source candidates */
-        if(save_source_candidates_){
-
-          for(unsigned int s=0; s<pat_ele.numberOfSourceCandidatePtrs(); ++s){
-
-            if(!pat_ele.sourceCandidatePtr(s).isAvailable()) continue;
-
-            source_candidate sc;
-            sc.key = pat_ele.sourceCandidatePtr(s).key();
-            sc.px  = pat_ele.sourceCandidatePtr(s)->px();
-            sc.py  = pat_ele.sourceCandidatePtr(s)->py();
-            sc.pz  = pat_ele.sourceCandidatePtr(s)->pz();
-            sc.E   = pat_ele.sourceCandidatePtr(s)->energy();
-
-            ele.add_source_candidate(std::move(sc));
-          }
-        }
-        /*-------------------*/
+    for(const auto& tag_str : IDtag_keys){
+      if(!pat_ele.isElectronIDAvailable(tag_str)) throw cms::Exception("Missing Electron ID", "ElectronID not found: "+tag_str);
+      ele.set_tag(Electron::tagname2tag(tag_str), float(pat_ele.electronID(tag_str)));
     }
 
-    uevent.set(handle, move(eles));
-    if(electrons_handle){
-        EventAccess_::set_unmanaged(uevent, *electrons_handle, &uevent.get(handle));
+    // L1-reco matching
+    for(const l1t::EGamma & itL1 : *l1electron_handle){
+      double dR_recoElec_l1Elec = reco::deltaR(pat_ele.eta(), pat_ele.phi(), itL1.p4().Eta(), itL1.p4().Phi());
+      if(dR_recoElec_l1Elec < ele.minDeltaRToL1Electron()) ele.set_minDeltaRToL1Electron(dR_recoElec_l1Elec);
     }
+
+    /* source candidates */
+    if(save_source_candidates_){
+
+      for(unsigned int s=0; s<pat_ele.numberOfSourceCandidatePtrs(); ++s){
+
+        if(!pat_ele.sourceCandidatePtr(s).isAvailable()) continue;
+
+        source_candidate sc;
+        sc.key = pat_ele.sourceCandidatePtr(s).key();
+        sc.px  = pat_ele.sourceCandidatePtr(s)->px();
+        sc.py  = pat_ele.sourceCandidatePtr(s)->py();
+        sc.pz  = pat_ele.sourceCandidatePtr(s)->pz();
+        sc.E   = pat_ele.sourceCandidatePtr(s)->energy();
+
+        ele.add_source_candidate(std::move(sc));
+      }
+    }
+    /*-------------------*/
+  }
+
+  uevent.set(handle, move(eles));
+  if(electrons_handle){
+    EventAccess_::set_unmanaged(uevent, *electrons_handle, &uevent.get(handle));
+  }
 }
 
 
@@ -153,73 +166,73 @@ NtupleWriterPhotons::NtupleWriterPhotons(Config & cfg, bool set_photons_member, 
 NtupleWriterPhotons::~NtupleWriterPhotons(){}
 
 void NtupleWriterPhotons::process(const edm::Event & event, uhh2::Event & uevent, const edm::EventSetup& iSetup){
-    edm::Handle< std::vector<pat::Photon> > pho_handle;
-    event.getByToken(src_token, pho_handle);
+  edm::Handle< std::vector<pat::Photon> > pho_handle;
+  event.getByToken(src_token, pho_handle);
 
-   //  edm::Handle<std::vector<reco::Vertex>> pv_handle;
-   // event.getByToken(pv_token, pv_handle);
-   // if(pv_handle->empty()){
-   //     edm::LogWarning("NtupleWriterPhotons") << "No PVs found, not writing phoctrons!";
-   //     return;
-   // }
-   // const auto & PV = pv_handle->front();
+  //  edm::Handle<std::vector<reco::Vertex>> pv_handle;
+  // event.getByToken(pv_token, pv_handle);
+  // if(pv_handle->empty()){
+  //     edm::LogWarning("NtupleWriterPhotons") << "No PVs found, not writing phoctrons!";
+  //     return;
+  // }
+  // const auto & PV = pv_handle->front();
 
-    std::vector<Photon> phos;
-    for (const pat::Photon & pat_pho : *pho_handle) {
-        phos.emplace_back();
-        Photon & pho = phos.back();
-        pho.set_charge( pat_pho.charge());
-        pho.set_pt( pat_pho.pt());
-        pho.set_eta( pat_pho.eta());
-        pho.set_phi( pat_pho.phi());
-        pho.set_energy( pat_pho.energy());
-        pho.set_vertex_x(pat_pho.vertex().x());
-        pho.set_vertex_y(pat_pho.vertex().y());
-        pho.set_vertex_z(pat_pho.vertex().z());
-        if (doPuppiIso_){
-          pho.set_puppiChargedHadronIso(pat_pho.puppiChargedHadronIso());
-          pho.set_puppiNeutralHadronIso(pat_pho.puppiNeutralHadronIso());
-          pho.set_puppiPhotonIso(pat_pho.puppiPhotonIso());
-        }
-        pho.set_supercluster_eta( pat_pho.superCluster()->eta() );
-        pho.set_supercluster_phi( pat_pho.superCluster()->phi() );
+  std::vector<Photon> phos;
+  for (const pat::Photon & pat_pho : *pho_handle) {
+    phos.emplace_back();
+    Photon & pho = phos.back();
+    pho.set_charge( pat_pho.charge());
+    pho.set_pt( pat_pho.pt());
+    pho.set_eta( pat_pho.eta());
+    pho.set_phi( pat_pho.phi());
+    pho.set_energy( pat_pho.energy());
+    pho.set_vertex_x(pat_pho.vertex().x());
+    pho.set_vertex_y(pat_pho.vertex().y());
+    pho.set_vertex_z(pat_pho.vertex().z());
+    if (doPuppiIso_){
+      pho.set_puppiChargedHadronIso(pat_pho.puppiChargedHadronIso());
+      pho.set_puppiNeutralHadronIso(pat_pho.puppiNeutralHadronIso());
+      pho.set_puppiPhotonIso(pat_pho.puppiPhotonIso());
+    }
+    pho.set_supercluster_eta( pat_pho.superCluster()->eta() );
+    pho.set_supercluster_phi( pat_pho.superCluster()->phi() );
 
-        pho.set_trackIso(pat_pho.trackIso());
-        pho.set_ecalIso(pat_pho.ecalIso());
-        pho.set_hcalIso(pat_pho.hcalIso());
-        pho.set_caloIso(pat_pho.caloIso());
+    pho.set_trackIso(pat_pho.trackIso());
+    pho.set_ecalIso(pat_pho.ecalIso());
+    pho.set_hcalIso(pat_pho.hcalIso());
+    pho.set_caloIso(pat_pho.caloIso());
 
-        //	pho.set_patParticleIso(pat_pho.patParticleIso());
-        pho.set_chargedHadronIso(pat_pho.chargedHadronIso());
-        pho.set_neutralHadronIso(pat_pho.neutralHadronIso());
-        pho.set_photonIso(pat_pho.photonIso());
-        pho.set_puChargedHadronIso(pat_pho.puChargedHadronIso());
+    //	pho.set_patParticleIso(pat_pho.patParticleIso());
+    pho.set_chargedHadronIso(pat_pho.chargedHadronIso());
+    pho.set_neutralHadronIso(pat_pho.neutralHadronIso());
+    pho.set_photonIso(pat_pho.photonIso());
+    pho.set_puChargedHadronIso(pat_pho.puChargedHadronIso());
 
-        for(const auto& tag_str : IDtag_keys){
-          if(!pat_pho.isPhotonIDAvailable(tag_str)) throw cms::Exception("Missing Photon ID", "PhotonID not found: "+tag_str);
-          pho.set_tag(Photon::tagname2tag(tag_str), float(pat_pho.photonID(tag_str)));
-        }
-
-        /* source candidates */
-        if(save_source_candidates_){
-          for(unsigned int s=0; s<pat_pho.numberOfSourceCandidatePtrs(); ++s){
-            if(!pat_pho.sourceCandidatePtr(s).isAvailable()) continue;
-            source_candidate sc;
-            sc.key = pat_pho.sourceCandidatePtr(s).key();
-            sc.px  = pat_pho.sourceCandidatePtr(s)->px();
-            sc.py  = pat_pho.sourceCandidatePtr(s)->py();
-            sc.pz  = pat_pho.sourceCandidatePtr(s)->pz();
-            sc.E   = pat_pho.sourceCandidatePtr(s)->energy();
-            pho.add_source_candidate(std::move(sc));
-          }
-        }
-        /*-------------------*/
+    for(const auto& tag_str : IDtag_keys){
+      if(!pat_pho.isPhotonIDAvailable(tag_str)) throw cms::Exception("Missing Photon ID", "PhotonID not found: "+tag_str);
+      pho.set_tag(Photon::tagname2tag(tag_str), float(pat_pho.photonID(tag_str)));
     }
 
-    uevent.set(handle, move(phos));
-    if(photons_handle){
-        EventAccess_::set_unmanaged(uevent, *photons_handle, &uevent.get(handle));
+    /* source candidates */
+    if(save_source_candidates_){
+      for(unsigned int s=0; s<pat_pho.numberOfSourceCandidatePtrs(); ++s){
+        if(!pat_pho.sourceCandidatePtr(s).isAvailable()) continue;
+        source_candidate sc;
+        sc.key = pat_pho.sourceCandidatePtr(s).key();
+        sc.px  = pat_pho.sourceCandidatePtr(s)->px();
+        sc.py  = pat_pho.sourceCandidatePtr(s)->py();
+        sc.pz  = pat_pho.sourceCandidatePtr(s)->pz();
+        sc.E   = pat_pho.sourceCandidatePtr(s)->energy();
+        pho.add_source_candidate(std::move(sc));
+      }
     }
+    /*-------------------*/
+  }
+
+  uevent.set(handle, move(phos));
+  if(photons_handle){
+    EventAccess_::set_unmanaged(uevent, *photons_handle, &uevent.get(handle));
+  }
 }
 
 //-------------------------
@@ -227,243 +240,257 @@ void NtupleWriterPhotons::process(const edm::Event & event, uhh2::Event & uevent
 NtupleWriterMuons::NtupleWriterMuons(Config & cfg, bool set_muons_member, const bool save_source_cands): save_source_candidates_(save_source_cands){
   handle = cfg.ctx.declare_event_output<vector<Muon>>(cfg.dest_branchname, cfg.dest);
   if(set_muons_member) muons_handle = cfg.ctx.get_handle<vector<Muon>>("muons");
-  src_token = cfg.cc.consumes<std::vector<pat::Muon>>(cfg.src);
-  pv_token = cfg.cc.consumes<std::vector<reco::Vertex>>(cfg.pv_src);
+  src_token    = cfg.cc.consumes<std::vector<pat::Muon>>(cfg.src);
+  pv_token     = cfg.cc.consumes<std::vector<reco::Vertex>>(cfg.pv_src);
+  l1muon_token = cfg.cc.consumes<BXVector<l1t::Muon>>(cfg.l1muon_src);
 }
+
 
 NtupleWriterMuons::~NtupleWriterMuons(){}
 
 void NtupleWriterMuons::process(const edm::Event & event, uhh2::Event & uevent,  const edm::EventSetup& iSetup){
-   edm::Handle<std::vector<pat::Muon>> mu_handle;
-   event.getByToken(src_token, mu_handle);
+  edm::Handle<std::vector<pat::Muon>> mu_handle;
+  event.getByToken(src_token, mu_handle);
 
-   edm::Handle<std::vector<reco::Vertex>> pv_handle;
-   event.getByToken(pv_token, pv_handle);
-   if(pv_handle->empty()){
-       edm::LogWarning("NtupleWriterMuons") << "No PVs found, not writing muons!";
-       return;
-   }
-   const auto & PV = pv_handle->front();
+  edm::Handle<std::vector<reco::Vertex>> pv_handle;
+  event.getByToken(pv_token, pv_handle);
+  if(pv_handle->empty()){
+    edm::LogWarning("NtupleWriterMuons") << "No PVs found, not writing muons!";
+    return;
+  }
+  const auto & PV = pv_handle->front();
 
-   std::vector<Muon> mus;
-   for (const pat::Muon & pat_mu : *mu_handle) {
-     mus.emplace_back();
-     Muon & mu = mus.back();
-     mu.set_charge( pat_mu.charge());
-     mu.set_pt( pat_mu.pt());
-     mu.set_eta( pat_mu.eta());
-     mu.set_phi( pat_mu.phi());
-     mu.set_energy( pat_mu.energy());
-     // mu.set_ptError( pat_mu.ptError());
-     // mu.set_etaError( pat_mu.etaError());
-     // mu.set_phiError( pat_mu.phiError());
-     // mu.set_energyError( pat_mu.energyError());
+  edm::Handle<BXVector<l1t::Muon>> l1muon_handle;
+  event.getByToken(l1muon_token, l1muon_handle);
+  // if(l1muon_handle->isEmpty()){
+  //   edm::LogWarning("NtupleWriterMuons") << "No L1 muons found, not doing L1-reco matching!";
+  // }
 
-     mu.set_selector(Muon::Global    , pat_mu.isGlobalMuon());
-     mu.set_selector(Muon::PF        , pat_mu.isPFMuon());
-     mu.set_selector(Muon::Tracker   , pat_mu.isTrackerMuon());
-     mu.set_selector(Muon::Standalone, pat_mu.isStandAloneMuon());
+  std::vector<Muon> mus;
+  for (const pat::Muon & pat_mu : *mu_handle) {
+    mus.emplace_back();
+    Muon & mu = mus.back();
+    mu.set_charge( pat_mu.charge());
+    mu.set_pt( pat_mu.pt());
+    mu.set_eta( pat_mu.eta());
+    mu.set_phi( pat_mu.phi());
+    mu.set_energy( pat_mu.energy());
+    // mu.set_ptError( pat_mu.ptError());
+    // mu.set_etaError( pat_mu.etaError());
+    // mu.set_phiError( pat_mu.phiError());
+    // mu.set_energyError( pat_mu.energyError());
 
-     // 2016v2 specific ones
-     mu.set_selector(Muon::Soft  , pat_mu.isSoftMuon(PV));
-     mu.set_selector(Muon::Loose , pat_mu.isLooseMuon());
-     mu.set_selector(Muon::Medium, pat_mu.isMediumMuon());
-     mu.set_selector(Muon::Tight , pat_mu.isTightMuon(PV));
-     mu.set_selector(Muon::Highpt, pat_mu.isHighPtMuon(PV));
+    mu.set_selector(Muon::Global    , pat_mu.isGlobalMuon());
+    mu.set_selector(Muon::PF        , pat_mu.isPFMuon());
+    mu.set_selector(Muon::Tracker   , pat_mu.isTrackerMuon());
+    mu.set_selector(Muon::Standalone, pat_mu.isStandAloneMuon());
 
-     // 2016v3 & 2017 onwards uses these instead
-     mu.set_selector(Muon::CutBasedIdLoose       , pat_mu.passed(reco::Muon::CutBasedIdLoose));
-     mu.set_selector(Muon::CutBasedIdMedium      , pat_mu.passed(reco::Muon::CutBasedIdMedium));
-     mu.set_selector(Muon::CutBasedIdMediumPrompt, pat_mu.passed(reco::Muon::CutBasedIdMediumPrompt));
-     mu.set_selector(Muon::CutBasedIdTight       , pat_mu.passed(reco::Muon::CutBasedIdTight));
-     mu.set_selector(Muon::CutBasedIdGlobalHighPt, pat_mu.passed(reco::Muon::CutBasedIdGlobalHighPt));
-     mu.set_selector(Muon::CutBasedIdTrkHighPt   , pat_mu.passed(reco::Muon::CutBasedIdTrkHighPt));
-     mu.set_selector(Muon::SoftCutBasedId        , pat_mu.passed(reco::Muon::SoftCutBasedId));
-     mu.set_selector(Muon::SoftMvaId             , pat_mu.passed(reco::Muon::SoftMvaId));
-     mu.set_selector(Muon::MvaLoose              , pat_mu.passed(reco::Muon::MvaLoose));
-     mu.set_selector(Muon::MvaMedium             , pat_mu.passed(reco::Muon::MvaMedium));
-     mu.set_selector(Muon::MvaTight              , pat_mu.passed(reco::Muon::MvaTight));
+    // 2016v2 specific ones
+    mu.set_selector(Muon::Soft  , pat_mu.isSoftMuon(PV));
+    mu.set_selector(Muon::Loose , pat_mu.isLooseMuon());
+    mu.set_selector(Muon::Medium, pat_mu.isMediumMuon());
+    mu.set_selector(Muon::Tight , pat_mu.isTightMuon(PV));
+    mu.set_selector(Muon::Highpt, pat_mu.isHighPtMuon(PV));
 
-     mu.set_selector(Muon::PFIsoVeryLoose  , pat_mu.passed(reco::Muon::PFIsoVeryLoose));
-     mu.set_selector(Muon::PFIsoLoose      , pat_mu.passed(reco::Muon::PFIsoLoose));
-     mu.set_selector(Muon::PFIsoMedium     , pat_mu.passed(reco::Muon::PFIsoMedium));
-     mu.set_selector(Muon::PFIsoTight      , pat_mu.passed(reco::Muon::PFIsoTight));
-     mu.set_selector(Muon::PFIsoVeryTight  , pat_mu.passed(reco::Muon::PFIsoVeryTight));
-     mu.set_selector(Muon::TkIsoLoose      , pat_mu.passed(reco::Muon::TkIsoLoose));
-     mu.set_selector(Muon::TkIsoTight      , pat_mu.passed(reco::Muon::TkIsoTight));
-     mu.set_selector(Muon::MiniIsoLoose    , pat_mu.passed(reco::Muon::MiniIsoLoose));
-     mu.set_selector(Muon::MiniIsoMedium   , pat_mu.passed(reco::Muon::MiniIsoMedium));
-     mu.set_selector(Muon::MiniIsoTight    , pat_mu.passed(reco::Muon::MiniIsoTight));
-     mu.set_selector(Muon::MiniIsoVeryTight, pat_mu.passed(reco::Muon::MiniIsoVeryTight));
+    // 2016v3 & 2017 onwards uses these instead
+    mu.set_selector(Muon::CutBasedIdLoose       , pat_mu.passed(reco::Muon::CutBasedIdLoose));
+    mu.set_selector(Muon::CutBasedIdMedium      , pat_mu.passed(reco::Muon::CutBasedIdMedium));
+    mu.set_selector(Muon::CutBasedIdMediumPrompt, pat_mu.passed(reco::Muon::CutBasedIdMediumPrompt));
+    mu.set_selector(Muon::CutBasedIdTight       , pat_mu.passed(reco::Muon::CutBasedIdTight));
+    mu.set_selector(Muon::CutBasedIdGlobalHighPt, pat_mu.passed(reco::Muon::CutBasedIdGlobalHighPt));
+    mu.set_selector(Muon::CutBasedIdTrkHighPt   , pat_mu.passed(reco::Muon::CutBasedIdTrkHighPt));
+    mu.set_selector(Muon::SoftCutBasedId        , pat_mu.passed(reco::Muon::SoftCutBasedId));
+    mu.set_selector(Muon::SoftMvaId             , pat_mu.passed(reco::Muon::SoftMvaId));
+    mu.set_selector(Muon::MvaLoose              , pat_mu.passed(reco::Muon::MvaLoose));
+    mu.set_selector(Muon::MvaMedium             , pat_mu.passed(reco::Muon::MvaMedium));
+    mu.set_selector(Muon::MvaTight              , pat_mu.passed(reco::Muon::MvaTight));
 
-     if(pat_mu.simType() == reco::NotMatched)                       mu.set_simType(Muon::NotMatched);
-     else if(pat_mu.simType() == reco::MatchedPunchthrough)         mu.set_simType(Muon::MatchedPunchthrough);
-     else if(pat_mu.simType() == reco::MatchedElectron)             mu.set_simType(Muon::MatchedElectron);
-     else if(pat_mu.simType() == reco::MatchedPrimaryMuon)          mu.set_simType(Muon::MatchedPrimaryMuon);
-     else if(pat_mu.simType() == reco::MatchedMuonFromLightFlavour) mu.set_simType(Muon::MatchedLightQuark);
-     else if(pat_mu.simType() == reco::GhostPunchthrough)           mu.set_simType(Muon::GhostPunchthrough);
-     else if(pat_mu.simType() == reco::GhostElectron)               mu.set_simType(Muon::GhostElectron);
-     else if(pat_mu.simType() == reco::GhostPrimaryMuon)            mu.set_simType(Muon::GhostPrimaryMuon);
-     else if(pat_mu.simType() == reco::GhostMuonFromLightFlavour)   mu.set_simType(Muon::GhostLightQuark);
-     else if(pat_mu.simType() == reco::MatchedMuonFromHeavyFlavour){
-       if(pat_mu.simExtType() == reco::MatchedMuonFromTau)          mu.set_simType(Muon::MatchedTau);
-       else                                                         mu.set_simType(Muon::MatchedHeavyQuark);
-     }
-     else if(pat_mu.simType() == reco::GhostMuonFromHeavyFlavour){
-       if(pat_mu.simExtType() == reco::GhostMuonFromTau)            mu.set_simType(Muon::GhostTau);
-       else                                                         mu.set_simType(Muon::GhostHeavyQuark);
-     }
-     else                                                           mu.set_simType(Muon::Unknown);
+    mu.set_selector(Muon::PFIsoVeryLoose  , pat_mu.passed(reco::Muon::PFIsoVeryLoose));
+    mu.set_selector(Muon::PFIsoLoose      , pat_mu.passed(reco::Muon::PFIsoLoose));
+    mu.set_selector(Muon::PFIsoMedium     , pat_mu.passed(reco::Muon::PFIsoMedium));
+    mu.set_selector(Muon::PFIsoTight      , pat_mu.passed(reco::Muon::PFIsoTight));
+    mu.set_selector(Muon::PFIsoVeryTight  , pat_mu.passed(reco::Muon::PFIsoVeryTight));
+    mu.set_selector(Muon::TkIsoLoose      , pat_mu.passed(reco::Muon::TkIsoLoose));
+    mu.set_selector(Muon::TkIsoTight      , pat_mu.passed(reco::Muon::TkIsoTight));
+    mu.set_selector(Muon::MiniIsoLoose    , pat_mu.passed(reco::Muon::MiniIsoLoose));
+    mu.set_selector(Muon::MiniIsoMedium   , pat_mu.passed(reco::Muon::MiniIsoMedium));
+    mu.set_selector(Muon::MiniIsoTight    , pat_mu.passed(reco::Muon::MiniIsoTight));
+    mu.set_selector(Muon::MiniIsoVeryTight, pat_mu.passed(reco::Muon::MiniIsoVeryTight));
 
-     mu.set_simFlavor(pat_mu.simFlavour());
-     mu.set_simPdgId(pat_mu.simPdgId());
-     mu.set_simMotherPdgId(pat_mu.simMotherPdgId());
-     mu.set_simHeaviestMotherFlavor(pat_mu.simHeaviestMotherFlavour());
+    if(pat_mu.simType() == reco::NotMatched)                       mu.set_simType(Muon::NotMatched);
+    else if(pat_mu.simType() == reco::MatchedPunchthrough)         mu.set_simType(Muon::MatchedPunchthrough);
+    else if(pat_mu.simType() == reco::MatchedElectron)             mu.set_simType(Muon::MatchedElectron);
+    else if(pat_mu.simType() == reco::MatchedPrimaryMuon)          mu.set_simType(Muon::MatchedPrimaryMuon);
+    else if(pat_mu.simType() == reco::MatchedMuonFromLightFlavour) mu.set_simType(Muon::MatchedLightQuark);
+    else if(pat_mu.simType() == reco::GhostPunchthrough)           mu.set_simType(Muon::GhostPunchthrough);
+    else if(pat_mu.simType() == reco::GhostElectron)               mu.set_simType(Muon::GhostElectron);
+    else if(pat_mu.simType() == reco::GhostPrimaryMuon)            mu.set_simType(Muon::GhostPrimaryMuon);
+    else if(pat_mu.simType() == reco::GhostMuonFromLightFlavour)   mu.set_simType(Muon::GhostLightQuark);
+    else if(pat_mu.simType() == reco::MatchedMuonFromHeavyFlavour){
+      if(pat_mu.simExtType() == reco::MatchedMuonFromTau)          mu.set_simType(Muon::MatchedTau);
+      else                                                         mu.set_simType(Muon::MatchedHeavyQuark);
+    }
+    else if(pat_mu.simType() == reco::GhostMuonFromHeavyFlavour){
+      if(pat_mu.simExtType() == reco::GhostMuonFromTau)            mu.set_simType(Muon::GhostTau);
+      else                                                         mu.set_simType(Muon::GhostHeavyQuark);
+    }
+    else                                                           mu.set_simType(Muon::Unknown);
 
-     mu.set_dxy      (pat_mu.muonBestTrack()->dxy(PV.position()));
-     mu.set_dxy_error(pat_mu.muonBestTrack()->dxyError());
-     mu.set_dz       (pat_mu.muonBestTrack()->dz(PV.position()));
-     mu.set_dz_error (pat_mu.muonBestTrack()->dzError());
+    mu.set_simFlavor(pat_mu.simFlavour());
+    mu.set_simPdgId(pat_mu.simPdgId());
+    mu.set_simMotherPdgId(pat_mu.simMotherPdgId());
+    mu.set_simHeaviestMotherFlavor(pat_mu.simHeaviestMotherFlavour());
 
-     mu.set_globalTrack_normalizedChi2       ( pat_mu.globalTrack().isNonnull() ? pat_mu.globalTrack()->normalizedChi2() : -999.);
-     mu.set_globalTrack_numberOfValidMuonHits( pat_mu.globalTrack().isNonnull() ? pat_mu.globalTrack()->hitPattern().numberOfValidMuonHits() : -1);
+    mu.set_dxy      (pat_mu.muonBestTrack()->dxy(PV.position()));
+    mu.set_dxy_error(pat_mu.muonBestTrack()->dxyError());
+    mu.set_dz       (pat_mu.muonBestTrack()->dz(PV.position()));
+    mu.set_dz_error (pat_mu.muonBestTrack()->dzError());
 
-     mu.set_numberOfMatchedStations(pat_mu.numberOfMatchedStations());
+    mu.set_globalTrack_normalizedChi2       ( pat_mu.globalTrack().isNonnull() ? pat_mu.globalTrack()->normalizedChi2() : -999.);
+    mu.set_globalTrack_numberOfValidMuonHits( pat_mu.globalTrack().isNonnull() ? pat_mu.globalTrack()->hitPattern().numberOfValidMuonHits() : -1);
 
-     mu.set_innerTrack_trackerLayersWithMeasurement(pat_mu.innerTrack().isNonnull() ? pat_mu.innerTrack()->hitPattern().trackerLayersWithMeasurement() : -1);
-     mu.set_innerTrack_numberOfValidPixelHits      (pat_mu.innerTrack().isNonnull() ? pat_mu.innerTrack()->hitPattern().numberOfValidPixelHits() : -1);
-     mu.set_innerTrack_validFraction               (pat_mu.innerTrack().isNonnull() ? pat_mu.innerTrack()->validFraction() : -999.);
+    mu.set_numberOfMatchedStations(pat_mu.numberOfMatchedStations());
 
-     mu.set_combinedQuality_chi2LocalPosition(pat_mu.combinedQuality().chi2LocalPosition);
-     mu.set_combinedQuality_trkKink          (pat_mu.combinedQuality().trkKink);
+    mu.set_innerTrack_trackerLayersWithMeasurement(pat_mu.innerTrack().isNonnull() ? pat_mu.innerTrack()->hitPattern().trackerLayersWithMeasurement() : -1);
+    mu.set_innerTrack_numberOfValidPixelHits      (pat_mu.innerTrack().isNonnull() ? pat_mu.innerTrack()->hitPattern().numberOfValidPixelHits() : -1);
+    mu.set_innerTrack_validFraction               (pat_mu.innerTrack().isNonnull() ? pat_mu.innerTrack()->validFraction() : -999.);
 
-     mu.set_segmentCompatibility(muon::segmentCompatibility(pat_mu));
+    mu.set_combinedQuality_chi2LocalPosition(pat_mu.combinedQuality().chi2LocalPosition);
+    mu.set_combinedQuality_trkKink          (pat_mu.combinedQuality().trkKink);
 
-     mu.set_sumChargedHadronPt(pat_mu.pfIsolationR04().sumChargedHadronPt);
-     mu.set_sumNeutralHadronEt(pat_mu.pfIsolationR04().sumNeutralHadronEt);
-     mu.set_sumPhotonEt       (pat_mu.pfIsolationR04().sumPhotonEt);
-     mu.set_sumPUPt           (pat_mu.pfIsolationR04().sumPUPt);
+    mu.set_segmentCompatibility(muon::segmentCompatibility(pat_mu));
 
-     mu.set_pfMINIIso_CH      (pat_mu.hasUserFloat("muPFMiniIsoValueCHSTAND") ? pat_mu.userFloat("muPFMiniIsoValueCHSTAND") : -999.);
-     mu.set_pfMINIIso_NH      (pat_mu.hasUserFloat("muPFMiniIsoValueNHSTAND") ? pat_mu.userFloat("muPFMiniIsoValueNHSTAND") : -999.);
-     mu.set_pfMINIIso_Ph      (pat_mu.hasUserFloat("muPFMiniIsoValuePhSTAND") ? pat_mu.userFloat("muPFMiniIsoValuePhSTAND") : -999.);
-     mu.set_pfMINIIso_PU      (pat_mu.hasUserFloat("muPFMiniIsoValuePUSTAND") ? pat_mu.userFloat("muPFMiniIsoValuePUSTAND") : -999.);
-     mu.set_pfMINIIso_NH_pfwgt(pat_mu.hasUserFloat("muPFMiniIsoValueNHPFWGT") ? pat_mu.userFloat("muPFMiniIsoValueNHPFWGT") : -999.);
-     mu.set_pfMINIIso_Ph_pfwgt(pat_mu.hasUserFloat("muPFMiniIsoValuePhPFWGT") ? pat_mu.userFloat("muPFMiniIsoValuePhPFWGT") : -999.);
+    mu.set_sumChargedHadronPt(pat_mu.pfIsolationR04().sumChargedHadronPt);
+    mu.set_sumNeutralHadronEt(pat_mu.pfIsolationR04().sumNeutralHadronEt);
+    mu.set_sumPhotonEt       (pat_mu.pfIsolationR04().sumPhotonEt);
+    mu.set_sumPUPt           (pat_mu.pfIsolationR04().sumPUPt);
 
-     const auto & tunePTrack = pat_mu.tunePMuonBestTrack();
-     mu.set_tunePTrackPt(tunePTrack->pt());
-     mu.set_tunePTrackEta(tunePTrack->eta());
-     mu.set_tunePTrackPhi(tunePTrack->phi());
-     mu.set_tunePTrackType(static_cast<Muon::MuonTrackType>(pat_mu.tunePMuonBestTrackType()));
+    mu.set_pfMINIIso_CH      (pat_mu.hasUserFloat("muPFMiniIsoValueCHSTAND") ? pat_mu.userFloat("muPFMiniIsoValueCHSTAND") : -999.);
+    mu.set_pfMINIIso_NH      (pat_mu.hasUserFloat("muPFMiniIsoValueNHSTAND") ? pat_mu.userFloat("muPFMiniIsoValueNHSTAND") : -999.);
+    mu.set_pfMINIIso_Ph      (pat_mu.hasUserFloat("muPFMiniIsoValuePhSTAND") ? pat_mu.userFloat("muPFMiniIsoValuePhSTAND") : -999.);
+    mu.set_pfMINIIso_PU      (pat_mu.hasUserFloat("muPFMiniIsoValuePUSTAND") ? pat_mu.userFloat("muPFMiniIsoValuePUSTAND") : -999.);
+    mu.set_pfMINIIso_NH_pfwgt(pat_mu.hasUserFloat("muPFMiniIsoValueNHPFWGT") ? pat_mu.userFloat("muPFMiniIsoValueNHPFWGT") : -999.);
+    mu.set_pfMINIIso_Ph_pfwgt(pat_mu.hasUserFloat("muPFMiniIsoValuePhPFWGT") ? pat_mu.userFloat("muPFMiniIsoValuePhPFWGT") : -999.);
 
-     /* source candidates */
-     if(save_source_candidates_){
+    const auto & tunePTrack = pat_mu.tunePMuonBestTrack();
+    mu.set_tunePTrackPt(tunePTrack->pt());
+    mu.set_tunePTrackEta(tunePTrack->eta());
+    mu.set_tunePTrackPhi(tunePTrack->phi());
+    mu.set_tunePTrackType(static_cast<Muon::MuonTrackType>(pat_mu.tunePMuonBestTrackType()));
 
-       for(unsigned int s=0; s<pat_mu.numberOfSourceCandidatePtrs(); ++s){
+    // L1-reco matching
+    for(const l1t::Muon & itL1 : *l1muon_handle){
+      double dR_recoMuon_l1Muon = reco::deltaR(pat_mu.eta(), pat_mu.phi(), itL1.p4().Eta(), itL1.p4().Phi());
+      if(dR_recoMuon_l1Muon < mu.minDeltaRToL1Muon()) mu.set_minDeltaRToL1Muon(dR_recoMuon_l1Muon);
+    }
 
-         if(!pat_mu.sourceCandidatePtr(s).isAvailable()) continue;
+    /* source candidates */
+    if(save_source_candidates_){
 
-         source_candidate sc;
-         sc.key = pat_mu.sourceCandidatePtr(s).key();
-         sc.px  = pat_mu.sourceCandidatePtr(s)->px();
-         sc.py  = pat_mu.sourceCandidatePtr(s)->py();
-         sc.pz  = pat_mu.sourceCandidatePtr(s)->pz();
-         sc.E   = pat_mu.sourceCandidatePtr(s)->energy();
+      for(unsigned int s=0; s<pat_mu.numberOfSourceCandidatePtrs(); ++s){
 
-         mu.add_source_candidate(std::move(sc));
-       }
-     }
-     /*-------------------*/
-   }
+        if(!pat_mu.sourceCandidatePtr(s).isAvailable()) continue;
 
-   uevent.set(handle, move(mus));
-   if(muons_handle){
-       EventAccess_::set_unmanaged(uevent, *muons_handle, &uevent.get(handle));
-   }
+        source_candidate sc;
+        sc.key = pat_mu.sourceCandidatePtr(s).key();
+        sc.px  = pat_mu.sourceCandidatePtr(s)->px();
+        sc.py  = pat_mu.sourceCandidatePtr(s)->py();
+        sc.pz  = pat_mu.sourceCandidatePtr(s)->pz();
+        sc.E   = pat_mu.sourceCandidatePtr(s)->energy();
+
+        mu.add_source_candidate(std::move(sc));
+      }
+    }
+    /*-------------------*/
+  }
+
+  uevent.set(handle, move(mus));
+  if(muons_handle){
+    EventAccess_::set_unmanaged(uevent, *muons_handle, &uevent.get(handle));
+  }
 }
 
 
 NtupleWriterTaus::NtupleWriterTaus(Config & cfg, bool set_taus_member){
-    handle = cfg.ctx.declare_event_output<vector<Tau>>(cfg.dest_branchname, cfg.dest);
-    if(set_taus_member){
-        taus_handle = cfg.ctx.get_handle<vector<Tau>>("taus");
-    }
-    src_token = cfg.cc.consumes<std::vector<pat::Tau>>(cfg.src);
-    ptmin = cfg.ptmin;
-    etamax = cfg.etamax;
+  handle = cfg.ctx.declare_event_output<vector<Tau>>(cfg.dest_branchname, cfg.dest);
+  if(set_taus_member){
+    taus_handle = cfg.ctx.get_handle<vector<Tau>>("taus");
+  }
+  src_token = cfg.cc.consumes<std::vector<pat::Tau>>(cfg.src);
+  ptmin = cfg.ptmin;
+  etamax = cfg.etamax;
 }
 
 NtupleWriterTaus::~NtupleWriterTaus(){}
 
 void NtupleWriterTaus::process(const edm::Event & event, uhh2::Event & uevent,  const edm::EventSetup& iSetup){
-    edm::Handle< std::vector<pat::Tau> > tau_handle;
-    event.getByToken(src_token, tau_handle);
-    std::vector<Tau> taus;
-    for (const auto & pat_tau : *tau_handle) {
-         if(pat_tau.pt() < ptmin) continue;
-         if(fabs(pat_tau.eta()) > etamax) continue;
-         taus.emplace_back();
-         Tau & tau = taus.back();
+  edm::Handle< std::vector<pat::Tau> > tau_handle;
+  event.getByToken(src_token, tau_handle);
+  std::vector<Tau> taus;
+  for (const auto & pat_tau : *tau_handle) {
+    if(pat_tau.pt() < ptmin) continue;
+    if(fabs(pat_tau.eta()) > etamax) continue;
+    taus.emplace_back();
+    Tau & tau = taus.back();
 
-         tau.set_charge( pat_tau.charge());
-         tau.set_pt( pat_tau.pt());
-         tau.set_eta( pat_tau.eta());
-         tau.set_phi( pat_tau.phi());
-         tau.set_energy( pat_tau.energy());
+    tau.set_charge( pat_tau.charge());
+    tau.set_pt( pat_tau.pt());
+    tau.set_eta( pat_tau.eta());
+    tau.set_phi( pat_tau.phi());
+    tau.set_energy( pat_tau.energy());
 
-         // use the macro to avoid typos: using this macro assures that the enum name
-         // used in the same as the string used for the pat tauID.
-         #define FILL_TAU_BIT(tauidname) tau.set_bool(Tau:: tauidname, pat_tau.tauID(#tauidname) > 0.5)
+    // use the macro to avoid typos: using this macro assures that the enum name
+    // used in the same as the string used for the pat tauID.
+    #define FILL_TAU_BIT(tauidname) tau.set_bool(Tau:: tauidname, pat_tau.tauID(#tauidname) > 0.5)
 
-         FILL_TAU_BIT(againstElectronVLooseMVA6);
-         FILL_TAU_BIT(againstElectronLooseMVA6);
-         FILL_TAU_BIT(againstElectronMediumMVA6);
-         FILL_TAU_BIT(againstElectronTightMVA6);
-         FILL_TAU_BIT(againstElectronVTightMVA6);
-         FILL_TAU_BIT(againstMuonLoose3);
-         FILL_TAU_BIT(againstMuonTight3);
-         FILL_TAU_BIT(byLooseCombinedIsolationDeltaBetaCorr3Hits);
-         FILL_TAU_BIT(byMediumCombinedIsolationDeltaBetaCorr3Hits);
-         FILL_TAU_BIT(byTightCombinedIsolationDeltaBetaCorr3Hits);
-	 // MVA based isolation discriminators not yet recommended for RunII (need to be retrained)
-	 FILL_TAU_BIT(byVLooseIsolationMVArun2v1DBnewDMwLT);
-         FILL_TAU_BIT(byLooseIsolationMVArun2v1DBnewDMwLT);
-         FILL_TAU_BIT(byMediumIsolationMVArun2v1DBnewDMwLT);
-         FILL_TAU_BIT(byTightIsolationMVArun2v1DBnewDMwLT);
-         FILL_TAU_BIT(byVTightIsolationMVArun2v1DBnewDMwLT);
-         FILL_TAU_BIT(byVVTightIsolationMVArun2v1DBnewDMwLT);
+    FILL_TAU_BIT(againstElectronVLooseMVA6);
+    FILL_TAU_BIT(againstElectronLooseMVA6);
+    FILL_TAU_BIT(againstElectronMediumMVA6);
+    FILL_TAU_BIT(againstElectronTightMVA6);
+    FILL_TAU_BIT(againstElectronVTightMVA6);
+    FILL_TAU_BIT(againstMuonLoose3);
+    FILL_TAU_BIT(againstMuonTight3);
+    FILL_TAU_BIT(byLooseCombinedIsolationDeltaBetaCorr3Hits);
+    FILL_TAU_BIT(byMediumCombinedIsolationDeltaBetaCorr3Hits);
+    FILL_TAU_BIT(byTightCombinedIsolationDeltaBetaCorr3Hits);
+    // MVA based isolation discriminators not yet recommended for RunII (need to be retrained)
+    FILL_TAU_BIT(byVLooseIsolationMVArun2v1DBnewDMwLT);
+    FILL_TAU_BIT(byLooseIsolationMVArun2v1DBnewDMwLT);
+    FILL_TAU_BIT(byMediumIsolationMVArun2v1DBnewDMwLT);
+    FILL_TAU_BIT(byTightIsolationMVArun2v1DBnewDMwLT);
+    FILL_TAU_BIT(byVTightIsolationMVArun2v1DBnewDMwLT);
+    FILL_TAU_BIT(byVVTightIsolationMVArun2v1DBnewDMwLT);
 
-	 FILL_TAU_BIT(decayModeFinding);
-         FILL_TAU_BIT(decayModeFindingNewDMs);
+    FILL_TAU_BIT(decayModeFinding);
+    FILL_TAU_BIT(decayModeFindingNewDMs);
 
 
 
-         #define FILL_TAU_FLOAT(name) tau.set_##name (pat_tau.tauID(#name))
+    #define FILL_TAU_FLOAT(name) tau.set_##name (pat_tau.tauID(#name))
 
-         FILL_TAU_FLOAT(byCombinedIsolationDeltaBetaCorrRaw3Hits);
-         FILL_TAU_FLOAT(byIsolationMVArun2v1DBnewDMwLTraw);
-         FILL_TAU_FLOAT(chargedIsoPtSum);
-         FILL_TAU_FLOAT(neutralIsoPtSum);
-         FILL_TAU_FLOAT(puCorrPtSum);
+    FILL_TAU_FLOAT(byCombinedIsolationDeltaBetaCorrRaw3Hits);
+    FILL_TAU_FLOAT(byIsolationMVArun2v1DBnewDMwLTraw);
+    FILL_TAU_FLOAT(chargedIsoPtSum);
+    FILL_TAU_FLOAT(neutralIsoPtSum);
+    FILL_TAU_FLOAT(puCorrPtSum);
 
-	 // note: only available with dynamic strip reconstruction (included by default from CMSSW_7_4_14)
-	 // FILL_TAU_BIT(byLoosePileupWeightedIsolation3Hits);
-	 // FILL_TAU_BIT(byMediumPileupWeightedIsolation3Hits);
-	 // FILL_TAU_BIT(byTightPileupWeightedIsolation3Hits);
-	 // FILL_TAU_FLOAT(byPileupWeightedIsolationRaw3Hits);
-	 FILL_TAU_FLOAT(neutralIsoPtSumWeight);
-	 FILL_TAU_FLOAT(footprintCorrection);
-	 FILL_TAU_FLOAT(photonPtSumOutsideSignalCone);
+    // note: only available with dynamic strip reconstruction (included by default from CMSSW_7_4_14)
+    // FILL_TAU_BIT(byLoosePileupWeightedIsolation3Hits);
+    // FILL_TAU_BIT(byMediumPileupWeightedIsolation3Hits);
+    // FILL_TAU_BIT(byTightPileupWeightedIsolation3Hits);
+    // FILL_TAU_FLOAT(byPileupWeightedIsolationRaw3Hits);
+    FILL_TAU_FLOAT(neutralIsoPtSumWeight);
+    FILL_TAU_FLOAT(footprintCorrection);
+    FILL_TAU_FLOAT(photonPtSumOutsideSignalCone);
 
-         #undef FILL_TAU_BIT
-         #undef FILL_TAU_FLOAT
+    #undef FILL_TAU_BIT
+    #undef FILL_TAU_FLOAT
 
-         tau.set_decayMode(pat_tau.decayMode());
+    tau.set_decayMode(pat_tau.decayMode());
 
-    }
-    uevent.set(handle, move(taus));
-    if(taus_handle){
-       EventAccess_::set_unmanaged(uevent, *taus_handle, &uevent.get(handle));
-    }
+  }
+  uevent.set(handle, move(taus));
+  if(taus_handle){
+    EventAccess_::set_unmanaged(uevent, *taus_handle, &uevent.get(handle));
+  }
 }

--- a/core/plugins/NtupleWriterLeptons.h
+++ b/core/plugins/NtupleWriterLeptons.h
@@ -5,6 +5,7 @@
 
 #include "DataFormats/L1TGlobal/interface/GlobalAlgBlk.h"
 #include "DataFormats/L1Trigger/interface/Muon.h"
+#include "DataFormats/L1Trigger/interface/Tau.h"
 #include "DataFormats/L1Trigger/interface/EGamma.h"
 
 namespace uhh2 {
@@ -31,7 +32,7 @@ public:
 private:
     edm::EDGetToken src_token;
     edm::EDGetToken pv_token;
-    edm::EDGetTokenT<BXVector<l1t::EGamma>> l1electron_token;
+    edm::EDGetTokenT<BXVector<l1t::EGamma>> l1egamma_token;
     std::vector<std::string> IDtag_keys;
     Event::Handle<std::vector<Electron>> handle; // main handle to write output to
     boost::optional<Event::Handle<std::vector<Electron>>> electrons_handle; // handle of name "electrons" in case set_electrons_member is true
@@ -44,6 +45,7 @@ public:
 
     struct Config: public NtupleWriterModule::Config {
       edm::InputTag pv_src;
+      edm::InputTag l1egamma_src;
       std::vector<std::string> id_keys;
       bool doPuppiIso;
 
@@ -61,6 +63,7 @@ public:
 private:
     edm::EDGetToken src_token;
     edm::EDGetToken pv_token;
+    edm::EDGetTokenT<BXVector<l1t::EGamma>> l1egamma_token;
     std::vector<std::string> IDtag_keys;
     Event::Handle<std::vector<Photon>> handle; // main handle to write output to
     boost::optional<Event::Handle<std::vector<Photon>>> photons_handle; // handle of name "electrons" in case set_electrons_member is true
@@ -102,6 +105,15 @@ private:
 class NtupleWriterTaus: public NtupleWriterModule {
 public:
 
+    struct Config: public NtupleWriterModule::Config {
+      edm::InputTag l1tau_src;
+
+      // inherit constructor does not work yet :-(
+      Config(uhh2::Context & ctx_, edm::ConsumesCollector && cc_, const edm::InputTag & src_,
+             const std::string & dest_, const std::string & dest_branchname_ = ""):
+        NtupleWriterModule::Config(ctx_, std::move(cc_), src_, dest_, dest_branchname_) {}
+    };
+
     explicit NtupleWriterTaus(Config & cfg, bool set_taus_member);
 
     virtual void process(const edm::Event &, uhh2::Event &, const edm::EventSetup& iSetup);
@@ -110,6 +122,7 @@ public:
 private:
     double ptmin, etamax;
     edm::EDGetToken src_token;
+    edm::EDGetTokenT<BXVector<l1t::Tau>> l1tau_token;
     Event::Handle<std::vector<Tau>> handle;
     boost::optional<Event::Handle<std::vector<Tau>>> taus_handle;
 };

--- a/core/plugins/NtupleWriterLeptons.h
+++ b/core/plugins/NtupleWriterLeptons.h
@@ -3,13 +3,18 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "UHH2/core/plugins/NtupleWriterModule.h"
 
+#include "DataFormats/L1TGlobal/interface/GlobalAlgBlk.h"
+#include "DataFormats/L1Trigger/interface/Muon.h"
+#include "DataFormats/L1Trigger/interface/EGamma.h"
+
 namespace uhh2 {
 
 class NtupleWriterElectrons: public NtupleWriterModule {
 public:
-    
-    struct Config: public NtupleWriterModule::Config {     
+
+    struct Config: public NtupleWriterModule::Config {
       edm::InputTag pv_src;
+      edm::InputTag l1egamma_src;
       std::vector<std::string> id_keys;
 
       // inherit constructor does not work yet :-(
@@ -26,6 +31,7 @@ public:
 private:
     edm::EDGetToken src_token;
     edm::EDGetToken pv_token;
+    edm::EDGetTokenT<BXVector<l1t::EGamma>> l1electron_token;
     std::vector<std::string> IDtag_keys;
     Event::Handle<std::vector<Electron>> handle; // main handle to write output to
     boost::optional<Event::Handle<std::vector<Electron>>> electrons_handle; // handle of name "electrons" in case set_electrons_member is true
@@ -35,8 +41,8 @@ private:
 
 class NtupleWriterPhotons: public NtupleWriterModule {
 public:
-    
-    struct Config: public NtupleWriterModule::Config {     
+
+    struct Config: public NtupleWriterModule::Config {
       edm::InputTag pv_src;
       std::vector<std::string> id_keys;
       bool doPuppiIso;
@@ -67,9 +73,10 @@ private:
 
 class NtupleWriterMuons: public NtupleWriterModule {
 public:
-    
+
     struct Config: public NtupleWriterModule::Config {
       edm::InputTag pv_src;
+      edm::InputTag l1muon_src;
 
       // inherit constructor does not work yet :-(
       Config(uhh2::Context & ctx_, edm::ConsumesCollector && cc_, const edm::InputTag & src_,
@@ -85,6 +92,7 @@ public:
 private:
     edm::EDGetToken src_token;
     edm::EDGetToken pv_token;
+    edm::EDGetTokenT<BXVector<l1t::Muon>> l1muon_token;
     Event::Handle<std::vector<Muon>> handle;
     boost::optional<Event::Handle<std::vector<Muon>>> muons_handle;
 
@@ -107,5 +115,3 @@ private:
 };
 
 }
-
-


### PR DESCRIPTION
This PR includes the L1/reco matching for both electrons and muons.

A new field is added for each lepton collection: ```m_minDeltaRToL1Electron, m_minDeltaRToL1Muon``` which give the minimum deltaR between the reco level lepton and the matched L1 lepton. If there's no L1 object to match, the value defaults to ```+10``` (positive value such that a cut excludes these cases). See also attached screenshots below using the default TTToSemiLeptonic test sample for UL18 with 500 events.

The file size of the ntuple should not increase significantly (in my tests: <1%).
That's why I didn't include a switch, but store these two field as default.

<img width="883" alt="Bildschirmfoto 2021-08-23 um 14 49 42" src="https://user-images.githubusercontent.com/44866552/130449965-42807ac4-4df8-4e38-97c2-4e365e75f32a.png">

<img width="883" alt="Bildschirmfoto 2021-08-23 um 14 50 53" src="https://user-images.githubusercontent.com/44866552/130450092-5bbef715-d8b9-45ef-b858-625c675a99f5.png">

