### PR TITLE
[106X] hotfix for L1-reco matching (PR#1579)

### DIFF
--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -634,11 +634,11 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
     prefweightdown_token = consumes<double>(edm::InputTag(prefire_source, "nonPrefiringProbDown"));
   }
   l1GtToken_ = consumes<BXVector<GlobalAlgBlk>>(iConfig.getParameter<edm::InputTag>("l1GtSrc"));
+  l1EtSumToken_ = consumes<BXVector<l1t::EtSum>>(iConfig.getParameter<edm::InputTag>("l1EtSumSrc"));
   if(doL1TriggerObjects){
     l1EGToken_ = consumes<BXVector<l1t::EGamma>>(iConfig.getParameter<edm::InputTag>("l1EGSrc"));
     l1JetToken_ = consumes<BXVector<l1t::Jet>>(iConfig.getParameter<edm::InputTag>("l1JetSrc"));
     l1MuonToken_ = consumes<BXVector<l1t::Muon>>(iConfig.getParameter<edm::InputTag>("l1MuonSrc"));
-    l1EtSumToken_ = consumes<BXVector<l1t::EtSum>>(iConfig.getParameter<edm::InputTag>("l1EtSumSrc"));
     l1TauToken_ = consumes<BXVector<l1t::Tau>>(iConfig.getParameter<edm::InputTag>("l1TauSrc"));
 
     branch(tr,"L1EGamma_seeds","std::vector<L1EGamma>",&L1EG_seeds);


### PR DESCRIPTION
This PR is a hotfix for the L1-reco matching [PR#1579](https://github.com/UHH2/UHH2/pull/1579).
It fixes the ```BadToken``` exception which appears when ```doL1TriggerObjects``` is set to ```False``` (which is the default).
I guess, it didn't appear in the tests, because all boolean switches are switched on there?!