### PR TITLE
[106X] remove b-tagger combined secondary vertex (CSV)

### DIFF
--- a/common/src/JetHists.cxx
+++ b/common/src/JetHists.cxx
@@ -1,3 +1,4 @@
+
 #include "UHH2/common/include/JetHists.h"
 #include "UHH2/common/include/Utils.h"
 #include "UHH2/core/include/Event.h"
@@ -18,7 +19,6 @@ JetHistsBase::jetHist JetHistsBase::book_jetHist(const string & axisSuffix, cons
   jet_hist.eta = book<TH1F>("eta"+histSuffix,"#eta "+axisSuffix,100,-5,5);
   jet_hist.phi = book<TH1F>("phi"+histSuffix,"#phi "+axisSuffix,50,-M_PI,M_PI);
   jet_hist.mass = book<TH1F>("mass"+histSuffix,"M^{ "+axisSuffix+"} [GeV/c^{2}]", 100, 0, 300);
-  jet_hist.csv = book<TH1F>("csv"+histSuffix,"csv-disriminator "+axisSuffix,50,0,1);
   return jet_hist;
 }
 
@@ -27,7 +27,6 @@ void JetHistsBase::fill_jetHist(const Jet & jet, JetHistsBase::jetHist & jet_his
   jet_hist.eta->Fill(jet.eta(), weight);
   jet_hist.phi->Fill(jet.phi(), weight);
   jet_hist.mass->Fill(jet.v4().M(), weight);
-  jet_hist.csv->Fill(jet.btag_combinedSecondaryVertex(), weight);
 }
 
 // JetHists
@@ -106,7 +105,6 @@ TopJetHists::subjetHist TopJetHists::book_subjetHist(const std::string & axisSuf
   subjet_hist.eta = book<TH1F>("eta"+histSuffix,"#eta "+axisSuffix,100,-5,5);
   subjet_hist.phi = book<TH1F>("phi"+histSuffix,"#phi "+axisSuffix,50,-M_PI,M_PI);
   subjet_hist.mass = book<TH1F>("mass"+histSuffix,"M^{ "+axisSuffix+"} [GeV/c^{2}]", 100, 0, 200);
-  subjet_hist.csv = book<TH1F>("csv"+histSuffix,"csv-disriminator "+axisSuffix,50,0,1);
   subjet_hist.sum4Vec = book<TH1F>("sum_mass"+histSuffix,"Mass sum  "+axisSuffix,100,0,350);
 
   return subjet_hist;
@@ -121,7 +119,6 @@ void TopJetHists::fill_subjetHist(const TopJet & topjet, subjetHist & subjet_his
     subjet_hist.eta->Fill(subjet.eta(), weight);
     subjet_hist.phi->Fill(subjet.phi(), weight);
     subjet_hist.mass->Fill(subjet.v4().M(), weight);
-    subjet_hist.csv->Fill(subjet.btag_combinedSecondaryVertex(), weight);
     sumLorenzv4 += subjet.v4();
   }
   subjet_hist.sum4Vec->Fill(sumLorenzv4.M(), weight);
@@ -230,7 +227,7 @@ void TopJetHists::fill(const Event & event){
             const auto & ak4jet = ak4jets[j];
             double deltaRtopjetak4jet = deltaR(jet, ak4jet);
             deltaR_ak4jet->Fill(deltaRtopjetak4jet,w);
-            invmass_topjetak4jet->Fill(inv_mass_safe(jet.v4()+ak4jet.v4())); 
+            invmass_topjetak4jet->Fill(inv_mass_safe(jet.v4()+ak4jet.v4()));
          }
       if (jet.has_tag(jet.tagname2tag("mass"))) HTT_mass ->Fill(jet.get_tag(jet.tagname2tag("mass")),w);
       if (jet.has_tag(jet.tagname2tag("fRec"))) fRec ->Fill(jet.get_tag(jet.tagname2tag("fRec")),w);

--- a/common/src/JetIds.cxx
+++ b/common/src/JetIds.cxx
@@ -8,10 +8,6 @@ using namespace uhh2;
 BTag::BTag(algo tagger, wp working_point) {
   m_working_point = (int) working_point;
   switch (tagger) {
-    case CSVV2 :
-    jet_id = CSVBTag((CSVBTag::wp) m_working_point);
-    m_algo = "CSVv2";
-    break;
     case DEEPCSV :
     jet_id = DeepCSVBTag((DeepCSVBTag::wp) m_working_point);
     m_algo = "DeepCSV";
@@ -23,50 +19,6 @@ BTag::BTag(algo tagger, wp working_point) {
     default:
     throw invalid_argument("invalid b-tagging algorithm passed to BTag");
   }
-}
-
-CSVBTag::CSVBTag(wp working_point) {
-  m_working_point = working_point;
-}
-
-CSVBTag::CSVBTag(float float_point):csv_threshold(float_point) {}
-
-
-bool CSVBTag::operator()(const Jet & jet, const Event & ev){
-  if(ev.year == "2016v2" || ev.year == "2016v3"){
-    //  https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation80XReReco
-    switch(m_working_point){
-      case WP_LOOSE:
-      csv_threshold = 0.5426;
-      break;
-      case WP_MEDIUM:
-      csv_threshold = 0.8484;
-      break;
-      case WP_TIGHT:
-      csv_threshold = 0.9535;
-      break;
-      default:
-      throw invalid_argument("invalid working point passed to CSVBTag");
-    }
-  }
-  if(ev.year.find("2017") != string::npos || ev.year.find("2018") != string::npos){
-    //https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X
-    //Note: CSV is not supported for 2018 analyses
-    switch(m_working_point){
-      case WP_LOOSE:
-      csv_threshold = 0.5803;
-      break;
-      case WP_MEDIUM:
-      csv_threshold = 0.8838;
-      break;
-      case WP_TIGHT:
-      csv_threshold = 0.9693;
-      break;
-      default:
-      throw invalid_argument("invalid working point passed to CSVBTag");
-    }
-  }
-  return jet.btag_combinedSecondaryVertex() > csv_threshold;
 }
 
 ///

--- a/common/src/MCWeight.cxx
+++ b/common/src/MCWeight.cxx
@@ -1040,8 +1040,7 @@ MCMuonScaleFactor::MCMuonScaleFactor(uhh2::Context & ctx,
                 float jet_eta = jet.eta();
 
                 float jet_btagdisc;
-                if      (algorithm_ == BTag::CSVV2)   jet_btagdisc = jet.btag_combinedSecondaryVertex();
-                else if (algorithm_ == BTag::DEEPCSV) jet_btagdisc = jet.btag_DeepCSV();
+                if (algorithm_ == BTag::DEEPCSV) jet_btagdisc = jet.btag_DeepCSV();
                 else if (algorithm_ == BTag::DEEPJET) jet_btagdisc = jet.btag_DeepJet();
                 else throw runtime_error("MCBTagDiscriminantReweighting::process: Given b-tagging algorithm is (right now) not suited to be used jointly with this routine. Please check if it is compatible and then add your chosen algorithm as option to this analysis module. Adjust the routine if necessary.");
 

--- a/core/include/Jet.h
+++ b/core/include/Jet.h
@@ -45,16 +45,14 @@ class Jet : public FlavorParticle {
     m_HFEMPuppiMultiplicity = 0;
     // Discriminants should have a initial value of something clear "wrong"
     // -2 is safe as some discrimintants start at -1, some start at 0
-    m_btag_combinedSecondaryVertex = -2;
-    m_btag_combinedSecondaryVertexMVA = -2;
     m_btag_DeepCSV_probb = -2;
     m_btag_DeepCSV_probbb = -2;
-    m_btag_DeepFlavour_probbb=-2;
-    m_btag_DeepFlavour_probb=-2;
-    m_btag_DeepFlavour_problepb=-2;
-    m_btag_DeepFlavour_probc=-2;
-    m_btag_DeepFlavour_probuds=-2;
-    m_btag_DeepFlavour_probg=-2;
+    m_btag_DeepFlavour_probbb = -2;
+    m_btag_DeepFlavour_probb = -2;
+    m_btag_DeepFlavour_problepb = -2;
+    m_btag_DeepFlavour_probc = -2;
+    m_btag_DeepFlavour_probuds = -2;
+    m_btag_DeepFlavour_probg = -2;
 
     m_JEC_factor_raw = 0;
     m_JEC_L1factor_raw = 0;
@@ -86,8 +84,6 @@ class Jet : public FlavorParticle {
   float photonPuppiMultiplicity() const{return m_photonPuppiMultiplicity;}
   float HFHadronPuppiMultiplicity() const{return m_HFHadronPuppiMultiplicity;}
   float HFEMPuppiMultiplicity() const{return m_HFEMPuppiMultiplicity;}
-  float btag_combinedSecondaryVertex() const{return m_btag_combinedSecondaryVertex;} // combinedInclusiveSecondaryVertexV2BJetTags
-  float btag_combinedSecondaryVertexMVA() const{return m_btag_combinedSecondaryVertexMVA;}
   float btag_DeepCSV() const{return m_btag_DeepCSV_probb + m_btag_DeepCSV_probbb;} // pfDeepCSVJetTags:probb + pfDeepCSVJetTags:probbb
   float btag_DeepFlavour_bb() const{return m_btag_DeepFlavour_probbb;}
   float btag_DeepFlavour_b() const{return m_btag_DeepFlavour_probb;}
@@ -128,8 +124,6 @@ class Jet : public FlavorParticle {
   void set_photonPuppiMultiplicity(float x){m_photonPuppiMultiplicity=x;}
   void set_HFHadronPuppiMultiplicity(float x){m_HFHadronPuppiMultiplicity=x;}
   void set_HFEMPuppiMultiplicity(float x){m_HFEMPuppiMultiplicity=x;}
-  void set_btag_combinedSecondaryVertex(float x){m_btag_combinedSecondaryVertex=x;} // for 72, this is combinedInclusiveSecondaryVertexV2BJetTags
-  void set_btag_combinedSecondaryVertexMVA(float x){m_btag_combinedSecondaryVertexMVA=x;}
   void set_btag_DeepCSV_probb(float x){m_btag_DeepCSV_probb=x;} // pfDeepCSVJetTags:probb
   void set_btag_DeepCSV_probbb(float x){m_btag_DeepCSV_probbb=x;} // pfDeepCSVJetTags:probbb
   void set_btag_DeepFlavour_probbb(float x){m_btag_DeepFlavour_probbb=x;}
@@ -175,8 +169,6 @@ class Jet : public FlavorParticle {
   float m_HFHadronPuppiMultiplicity;
   float m_HFEMPuppiMultiplicity;
 
-  float m_btag_combinedSecondaryVertex;
-  float m_btag_combinedSecondaryVertexMVA;
   float m_btag_DeepCSV_probb;
   float m_btag_DeepCSV_probbb;
   float m_btag_DeepFlavour_probbb;

--- a/core/plugins/NtupleWriterJets.cxx
+++ b/core/plugins/NtupleWriterJets.cxx
@@ -318,20 +318,12 @@ void NtupleWriterJets::fill_jet_info(uhh2::Event & uevent, const pat::Jet & pat_
 
   if(do_btagging){
     const auto & bdisc = pat_jet.getPairDiscri();
-    bool csv = false, csvmva = false,  deepcsv_b = false, deepcsv_bb = false;
+    bool deepcsv_b = false, deepcsv_bb = false;
     bool deepflavour_bb=false, deepflavour_b=false, deepflavour_lepb=false, deepflavour_c=false, deepflavour_uds=false, deepflavour_g=false;
     for(const auto & name_value : bdisc){
       const auto & name = name_value.first;
       const auto & value = name_value.second;
-      if(name == "pfCombinedInclusiveSecondaryVertexV2BJetTags"){
-        jet.set_btag_combinedSecondaryVertex(value);
-        csv = true;
-      }
-      else if(name == "pfCombinedMVAV2BJetTags"){
-        jet.set_btag_combinedSecondaryVertexMVA(value);
-        csvmva = true;
-      }
-      else if(name == "pfDeepCSVJetTags:probb"){
+      if(name == "pfDeepCSVJetTags:probb"){
         jet.set_btag_DeepCSV_probb(value);
         deepcsv_b = true;
       }
@@ -367,9 +359,7 @@ void NtupleWriterJets::fill_jet_info(uhh2::Event & uevent, const pat::Jet & pat_
 
 
 
-    if(!csv || !csvmva || !deepcsv_b || !deepcsv_bb
-       || !deepflavour_bb || !deepflavour_b || !deepflavour_lepb
-       || !deepflavour_uds || !deepflavour_c || !deepflavour_g){
+    if(!deepcsv_b || !deepcsv_bb || !deepflavour_bb || !deepflavour_b || !deepflavour_lepb || !deepflavour_uds || !deepflavour_c || !deepflavour_g){
       if(btag_warning){
         std::string btag_list = "";
         for(const auto & name_value : bdisc){

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -94,8 +94,6 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
         raise RuntimeError("Cannot setup process for this year, may need to add a new entry.")
 
     bTagDiscriminators = [
-        'pfCombinedInclusiveSecondaryVertexV2BJetTags',
-        'pfCombinedMVAV2BJetTags',
         'pfDeepCSVJetTags:probb',
         'pfDeepCSVJetTags:probbb',
         'pfBoostedDoubleSecondaryVertexAK8BJetTags',

--- a/examples/src/ExampleModule2.cxx
+++ b/examples/src/ExampleModule2.cxx
@@ -17,21 +17,21 @@ using namespace uhh2;
 namespace uhh2examples {
 
 /** \brief Another analysis example of an AnalysisModule
- * 
+ *
  * In contrast to ExampleModule, this class uses more code from 'common' to achieve
  * similar effects.
- * 
+ *
  * It implements a preselection of
  *   - at least one lepton (electron or muon) with pt > 20, |eta| < 2.4 (electrons: |eta| < 2.5), using the tight id for
  *     muons and the medium cut-based id for electrons.
  *   - at least two jets with pt > 30, eta < 2.4
- *   - at least one b-tagged jet with above kinematics with loose csv b-tag
- * 
+ *   (- at least one b-tagged jet with above kinematics with loose csv b-tag) removed since CSV is no longer recommended and available
+ *
  * In the output, only leptons passing the id and jets with pt > 30 GeV and eta < 2.4 are kept.
  */
 class ExampleModule2: public AnalysisModule {
 public:
-    
+
     explicit ExampleModule2(Context & ctx);
     virtual bool process(Event & event);
 
@@ -39,30 +39,30 @@ private:
     JetId jet_kinematic, btag;
     MuonId muid;
     ElectronId eleid;
-    
+
     std::vector<std::unique_ptr<AnalysisModule>> modules;
-    
+
     AndSelection ele_selection, mu_selection;
 };
 
 
 ExampleModule2::ExampleModule2(Context & ctx): ele_selection(ctx, "ele"), mu_selection(ctx, "mu") {
     jet_kinematic = PtEtaCut(30.0, 2.4);
-    btag = CSVBTag(CSVBTag::WP_LOOSE);
+    // btag = CSVBTag(CSVBTag::WP_LOOSE);
     muid = AndId<Muon>(MuonID(Muon::CutBasedIdTight), PtEtaCut(20.0, 2.4));
     eleid = AndId<Electron>(ElectronID_Summer16_tight, PtEtaCut(20.0, 2.5));
-    
+
     // clean the objects:
     modules.emplace_back(new JetCleaner(ctx, jet_kinematic));
     modules.emplace_back(new MuonCleaner(muid));
     modules.emplace_back(new ElectronCleaner(eleid));
-    
+
     // make the selection, step-by-step. Note that in most cases, no explicit
     // object id is passed, as the cleaners have removed the objects not passing the id already.
     ele_selection.add<NElectronSelection>("ne >= 1", 1);
     ele_selection.add<NJetSelection>("nj >= 2", 2);
     ele_selection.add<NJetSelection>("nb >= 1", 1, -1, btag);
-    
+
     mu_selection.add<NMuonSelection>("nm >= 1", 1);
     mu_selection.add<NJetSelection>("nj >= 2", 2);
     mu_selection.add<NJetSelection>("nb >= 1", 1, -1, btag);
@@ -73,7 +73,7 @@ bool ExampleModule2::process(Event & event) {
     for(auto & m : modules){
         m->process(event);
     }
-    
+
     // note that always both selections are tested, even if we could
     // short-circuit after mu_selection is passed. This is done
     // to ensure that both cutflow histograms are filled.


### PR DESCRIPTION
This PR removes the CSV b-tagger since it's no longer recommended, see [Twiki](https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation#Recommendation_for_13_TeV_Data).