### PR TITLE
[106X] update UL16 JECs and JERs

### DIFF
--- a/common/src/CommonModules.cxx
+++ b/common/src/CommonModules.cxx
@@ -31,16 +31,15 @@ CommonModules::CommonModules(){
   jec_tag_2018 = "Autumn18";
   jec_ver_2018 = "19";
 
-  jec_tag_UL16preVFP = "Summer19UL16";
-  jec_ver_UL16preVFP = "2";
+  jec_tag_UL16preVFP = "Summer19UL16APV";
+  jec_ver_UL16preVFP = "7";
 
-  jec_tag_UL16postVFP = "Summer19UL16APV";
-  jec_ver_UL16postVFP = "2";
+  jec_tag_UL16postVFP = "Summer19UL16";
+  jec_ver_UL16postVFP = "7";
 
   jec_tag_UL17 = "Summer19UL17";
   jec_ver_UL17 = "5";
 
-  // FIXME: update when official set
   jec_tag_UL18 = "Summer19UL18";
   jec_ver_UL18 = "5";
 
@@ -227,12 +226,12 @@ void CommonModules::init(Context & ctx, const std::string & SysType_PU){
 
       JLC_switcher_UL16preVFP.reset(new RunSwitcher(ctx, "2016"));
       for (const auto & runItr : runPeriodsUL16preVFP) {
-        JLC_switcher_UL16preVFP->setupRun(runItr, std::make_shared<JetCorrector>(ctx, JERFiles::JECFilesDATA(jec_tag_UL17, jec_ver_UL17, jec_jet_coll, runItr)));
+        JLC_switcher_UL16preVFP->setupRun(runItr, std::make_shared<JetCorrector>(ctx, JERFiles::JECFilesDATA(jec_tag_UL16preVFP, jec_ver_UL16preVFP, jec_jet_coll, runItr)));
       }
 
       JLC_switcher_UL16postVFP.reset(new RunSwitcher(ctx, "2016"));
       for (const auto & runItr : runPeriodsUL16postVFP) {
-        JLC_switcher_UL16postVFP->setupRun(runItr, std::make_shared<JetCorrector>(ctx, JERFiles::JECFilesDATA(jec_tag_UL17, jec_ver_UL17, jec_jet_coll, runItr)));
+        JLC_switcher_UL16postVFP->setupRun(runItr, std::make_shared<JetCorrector>(ctx, JERFiles::JECFilesDATA(jec_tag_UL16postVFP, jec_ver_UL16postVFP, jec_jet_coll, runItr)));
       }
 
       JLC_switcher_UL17.reset(new RunSwitcher(ctx, "2017"));

--- a/common/src/JetCorrections.cxx
+++ b/common/src/JetCorrections.cxx
@@ -575,13 +575,19 @@ JetResolutionSmearer::JetResolutionSmearer(uhh2::Context & ctx){
     version = "Fall17_V3";
   } else if (year == Year::is2018) {
     version = "Autumn18_V7";
-  }  else if (year == Year::isUL17) {
+  } else if (year == Year::isUL16preVFP) {
+    version = "Summer20UL16APV_JRV3";
+  } else if (year == Year::isUL16postVFP) {
+    version = "Summer20UL16_JRV3";
+  } else if (year == Year::isUL17) {
     version = "Summer19UL17_JRV2";
   } else if (year == Year::isUL18) {
     version = "Summer19UL18_JRV2";
   } else {
     throw runtime_error("Cannot find suitable jet resolution file & scale factors for this year for JetResolutionSmearer");
   }
+
+  cout << "Setting up JER smearing with version " << version << endl;
 
   m_gjrs = new GenericJetResolutionSmearer(ctx, "jets", "genjets",JERFiles::JERPathStringMC(version,jetCollection,"SF"), JERFiles::JERPathStringMC(version,jetCollection,"PtResolution"));
 


### PR DESCRIPTION
This Pull Request will start automatic compilation, then making + testing of ntuples:

- Don't want to run any of this? (e.g. only XML files) Remove the @: [ci @ skip]

- Only want to compile, but don't make + test ntuples? (e.g. change `CommonModules.cxx`) Remove the @: [only @ compile]

Please include destination branch in title, e.g. `[102X]`, + short meaningful title

Please include an explanation message if it's something more complex than just XML dataset files:

Updating UL16 JECs and JERs to the latest recommended.
@anmalara Feel free to simply close this PR if it overlaps with any of your developments.