### PR TITLE
[106X] update CMSSW version from 10_6_26 to 10_6_28

### DIFF
--- a/scripts/install.csh
+++ b/scripts/install.csh
@@ -20,7 +20,7 @@ else
     echo "Please log into one and run this again"
     exit 1
 endif
-set CMSREL=CMSSW_10_6_26
+set CMSREL=CMSSW_10_6_28
 eval `cmsrel ${CMSREL}`
 cd ${CMSREL}/src
 eval `scramv1 runtime -csh`

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -119,7 +119,7 @@ time git clone https://github.com/UHH2/SFrame.git
 # Get CMSSW
 export SCRAM_ARCH=slc7_amd64_gcc700
 checkArch
-CMSREL=CMSSW_10_6_26
+CMSREL=CMSSW_10_6_28
 eval `cmsrel ${CMSREL}`
 cd ${CMSREL}/src
 eval `scramv1 runtime -sh`


### PR DESCRIPTION
This PR updates the CMSSW version from ```10_6_26``` to ```10_6_28``` as recommended, see [Twiki](https://twiki.cern.ch/twiki/bin/viewauth/CMS/PdmVRun2LegacyAnalysis) and [HN](https://hypernews.cern.ch/HyperNews/CMS/get/generators/5153.html).
