### PR TITLE
[106X] Update CI test files to UL for 2017

### DIFF
--- a/core/python/ntuplewriter_data_UL17.py
+++ b/core/python/ntuplewriter_data_UL17.py
@@ -13,9 +13,9 @@ process = generate_process(year="UL17", useData=True)
 
 # Please do not commit changes to source filenames - used for consistency testing
 process.source.fileNames = cms.untracked.vstring([
-    '/store/data/Run2017D/JetHT/MINIAOD/09Aug2019_UL2017-v1/50000/8320FFCD-A41A-1849-A506-52EF233246F4.root'
-    # '/store/data/Run2017D/SingleElectron/MINIAOD/09Aug2019_UL2017-v1/270000/9CEAFD24-9D9D-304D-BEC0-3FE3B4903429.root'
-    # '/store/data/Run2017D/SingleMuon/MINIAOD/09Aug2019_UL2017-v1/50000/ACB10C92-4B9B-5749-8C96-60942152E15C.root'
+    '/store/data/Run2017D/JetHT/MINIAOD/UL2017_MiniAODv2-v1/40000/C9790EDE-0D90-1947-8FC9-0855F0AA810A.root'
+    # '/store/data/Run2017D/SingleElectron/MINIAOD/UL2017_MiniAODv2-v1/250000/9E13F7BD-475C-5648-A170-6DF56ADE7DFD.root'
+    # '/store/data/Run2017D/SingleMuon/MINIAOD/UL2017_MiniAODv2-v1/280000/BA4F67E1-5894-4C44-92FF-E1D4374D459D.root'
 ])
 
 # Do this after setting process.source.fileNames, since we want the ability to override it on the commandline

--- a/core/python/ntuplewriter_data_UL17_leadingjetConstits.py
+++ b/core/python/ntuplewriter_data_UL17_leadingjetConstits.py
@@ -13,9 +13,9 @@ process = generate_process(year="UL17", useData=True)
 
 # Please do not commit changes to source filenames - used for consistency testing
 process.source.fileNames = cms.untracked.vstring([
-    '/store/data/Run2017D/JetHT/MINIAOD/09Aug2019_UL2017-v1/50000/8320FFCD-A41A-1849-A506-52EF233246F4.root'
-    # '/store/data/Run2017D/SingleElectron/MINIAOD/09Aug2019_UL2017-v1/270000/9CEAFD24-9D9D-304D-BEC0-3FE3B4903429.root'
-    # '/store/data/Run2017D/SingleMuon/MINIAOD/09Aug2019_UL2017-v1/50000/ACB10C92-4B9B-5749-8C96-60942152E15C.root'
+    '/store/data/Run2017D/JetHT/MINIAOD/UL2017_MiniAODv2-v1/40000/C9790EDE-0D90-1947-8FC9-0855F0AA810A.root'
+    # '/store/data/Run2017D/SingleElectron/MINIAOD/UL2017_MiniAODv2-v1/250000/9E13F7BD-475C-5648-A170-6DF56ADE7DFD.root'
+    # '/store/data/Run2017D/SingleMuon/MINIAOD/UL2017_MiniAODv2-v1/280000/BA4F67E1-5894-4C44-92FF-E1D4374D459D.root'
 ])
 
 # Turn on jet constituent storing for leading three AK4 jets

--- a/core/python/ntuplewriter_mc_UL17.py
+++ b/core/python/ntuplewriter_mc_UL17.py
@@ -13,7 +13,7 @@ process = generate_process(year="UL17", useData=False)
 
 # Please do not commit changes to source filenames - used for consistency testing
 process.source.fileNames = cms.untracked.vstring([
-    '/store/mc/RunIISummer19UL17MiniAOD/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/106X_mc2017_realistic_v6-v2/30000/BE7AE880-FE10-334A-89DC-35CCB590D9DD.root'
+    '/store/mc/RunIISummer20UL17MiniAODv2/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/106X_mc2017_realistic_v9-v1/230000/24FDC9A3-8E72-CC41-9C37-5D696614A816.root'
 ])
 
 # Do this after setting process.source.fileNames, since we want the ability to override it on the commandline

--- a/core/python/ntuplewriter_mc_UL17_leadingjetConstits.py
+++ b/core/python/ntuplewriter_mc_UL17_leadingjetConstits.py
@@ -13,7 +13,7 @@ process = generate_process(year="UL17", useData=False)
 
 # Please do not commit changes to source filenames - used for consistency testing
 process.source.fileNames = cms.untracked.vstring([
-    '/store/mc/RunIISummer19UL17MiniAOD/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/106X_mc2017_realistic_v6-v2/30000/BE7AE880-FE10-334A-89DC-35CCB590D9DD.root'
+    '/store/mc/RunIISummer20UL17MiniAODv2/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/106X_mc2017_realistic_v9-v1/230000/24FDC9A3-8E72-CC41-9C37-5D696614A816.root'
 ])
 
 # Turn on jet constituent storing for leading three AK4 jets


### PR DESCRIPTION
Synchronised with [this commit](https://gitlab.cern.ch/mschrode/UHH2-integration/-/commit/662b1fffab9a8c6414d9bb1b1212fb66a88c8770) in the UHH2 integration repo
