### PR TITLE
[106X] Removing UpdatePuppiTuneV15 from ntuple_generator

### DIFF
--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -1217,9 +1217,6 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
     )
     task.add(process.rekeyPackedPatJetsAk8PuppiJets)
 
-    #### update PUPPI to v15
-    from CommonTools.PileupAlgos.customizePuppiTune_cff import UpdatePuppiTuneV15
-    UpdatePuppiTuneV15(process, not useData)
 
     # Update DeepBoosted training to V2 for everything but 2016v2
     # Check https://twiki.cern.ch/twiki/bin/view/CMS/DeepAKXTagging for latest recommendations


### PR DESCRIPTION
This is just to perform an easy cross-check for differences, between puppi v15 from Summer20 MiniAODv2 (-> `_new`) and the recomputed puppi v15 from the `UpdatePuppiTuneV15` function (-> `_ref`). 

This can be merged, if new tests pass (now with with the test samples being UL MiniAODv2 for all 4 Years.).
The difference observed for the AK4 Puppi jets can be explained with the pT cut on the jets being different for the reclustering which is done within the Update-function, while differences in the AK8 jets are reasonable within statistical uncertainties and origin from the PUPPI calculations being based on packedPFCandidates (for the Update-function) and PFCandidates (for MiniAOD).