### PR TITLE
[102X] Fixed typo in TF2 deployment script

### DIFF
--- a/common/python/prepare_for_deployment_TF2.py
+++ b/common/python/prepare_for_deployment_TF2.py
@@ -13,7 +13,7 @@ parser.add_argument('inputpath', help='path to input model')
 parser.add_argument('-o', "--outputpath", help='output path', default=".")
 args = parser.parse_args()
 inputpath = args.inputpath
-outputpath = args.outputpath
+frozen_out_path = args.outputpath
 
 # definine output filename base
 frozen_graph_filename = "frozen_graph"


### PR DESCRIPTION
[ci skip]

Quick fix for the TF2 deployment script - there was a typo in there which crashed the script. Will make the same change in 106X afterwards.