### PR TITLE
[106X_v1] Modules and ID for GenTopJets

### DIFF
--- a/common/include/CleaningModules.h
+++ b/common/include/CleaningModules.h
@@ -128,6 +128,18 @@ private:
     uhh2::Event::Handle<std::vector<TopJet>> hndl;
 };
 
+
+class GenTopJetCleaner : public uhh2::AnalysisModule {
+public:
+
+    explicit GenTopJetCleaner(uhh2::Context & ctx, const GenTopJetId & jet_id_, std::string const & label_ = "gentopjets");
+    virtual bool process(uhh2::Event & event) override;
+
+private:
+    GenTopJetId gentopjet_id;
+    uhh2::Event::Handle<std::vector<GenTopJet>> hndl;
+};
+
 class JetMuonOverlapRemoval: public uhh2::AnalysisModule {
    public:
       explicit JetMuonOverlapRemoval(double deltaRmax);

--- a/common/include/NSelections.h
+++ b/common/include/NSelections.h
@@ -82,6 +82,18 @@ private:
     boost::optional<Event::Handle<std::vector<TopJet> > > topjetcollection;
 };
 
+class NGenTopJetSelection: public uhh2::Selection {
+public:
+    explicit NGenTopJetSelection(int nmin, int nmax = -1,
+        const boost::optional<GenTopJetId> & gentopjetid = boost::none,
+        const boost::optional<Event::Handle<std::vector<GenTopJet> > > & gentopjetcollection = boost::none);
+    virtual bool passes(const uhh2::Event & event);
+private:
+    int nmin, nmax;
+    boost::optional<GenTopJetId> gentopjetid;
+    boost::optional<Event::Handle<std::vector<GenTopJet> > > gentopjetcollection;
+};
+
 class NPVSelection: public uhh2::Selection {
 public:
     explicit NPVSelection(int nmin, int nmax = -1, const boost::optional<PrimaryVertexId> & pvid = boost::none);

--- a/common/include/ObjectIdUtils.h
+++ b/common/include/ObjectIdUtils.h
@@ -21,6 +21,7 @@ typedef std::function<bool (const Tau &, const uhh2::Event &)> TauId;
 typedef std::function<bool (const TopJet &, const uhh2::Event &)> TopJetId;
 typedef std::function<bool (const GenParticle &, const uhh2::Event &)> GenParticleId;
 typedef std::function<bool (const GenJet &, const uhh2::Event &)> GenJetId;
+typedef std::function<bool (const GenTopJet &, const uhh2::Event &)> GenTopJetId;
 
 
 /** \brief Cut on minimum pt and maximum |eta| of a particle

--- a/common/src/CleaningModules.cxx
+++ b/common/src/CleaningModules.cxx
@@ -109,3 +109,16 @@ bool TopJetCleaner::process(uhh2::Event & event){
     clean_collection(topjet_collection, event, topjet_id);
     return true;
 }
+
+GenTopJetCleaner::GenTopJetCleaner(Context & ctx, const GenTopJetId & gentopjet_id_, string const & label_):
+    gentopjet_id(gentopjet_id_), hndl(ctx.get_handle<vector<GenTopJet>>(label_)) {}
+
+bool GenTopJetCleaner::process(uhh2::Event & event){
+    if (!event.is_valid(hndl)) {
+        cerr << "In GenTopJetCleaner: Handle not valid!\n";
+        assert(false);
+    }
+    vector<GenTopJet> & gentopjet_collection = event.get(hndl);
+    clean_collection(gentopjet_collection, event, gentopjet_id);
+    return true;
+}

--- a/common/src/NSelections.cxx
+++ b/common/src/NSelections.cxx
@@ -61,6 +61,16 @@ bool NTopJetSelection::passes(const Event & event){
     return passes_minmax(jets, nmin, nmax, event, topjetid);
 }
 
+NGenTopJetSelection::NGenTopJetSelection(int nmin_, int nmax_,
+    const boost::optional<GenTopJetId> & gentopjetid_,
+    const boost::optional<Event::Handle<std::vector<GenTopJet> > > & gentopjetcollection_) :
+    nmin(nmin_), nmax(nmax_), gentopjetid(gentopjetid_), gentopjetcollection(gentopjetcollection_){}
+
+bool NGenTopJetSelection::passes(const Event & event){
+    const auto & jets = gentopjetcollection ? event.get(*gentopjetcollection) : *event.gentopjets;
+    return passes_minmax(jets, nmin, nmax, event, gentopjetid);
+}
+
 NPVSelection::NPVSelection(int nmin_, int nmax_,const boost::optional<PrimaryVertexId> & pvid_): nmin(nmin_), nmax(nmax_), pvid(pvid_){
 }
 


### PR DESCRIPTION
Port of PR #1599 :

> This copy pastes The Cleaning-Module and Selection as well as the ObjectId for GenTopJets.
> These were so far only available for Jets,TopJets and GenJets - so this just closes this small gap.
> 

[only compile]