### PR TITLE
[106X_v1] fix for crab template and CrabScript

### DIFF
--- a/scripts/crab/CrabScript.py
+++ b/scripts/crab/CrabScript.py
@@ -15,6 +15,23 @@ class CrabConfig:
         self.options = options
         self.command = command
 
+        self.storeJetConstituents = False
+        self.DefaultPsetName = True
+        self.DefaultOutLFNDirBase = True
+        self.outLFNDirBasePrefix = None
+        #getting values for UHH2 specific from crab config fields
+        if(hasattr(self.config,'UHH2')):
+            if(hasattr(self.config.UHH2,'storeJetConstituents')):
+                self.storeJetConstituents = self.config.UHH2.storeJetConstituents
+            if(hasattr(self.config.UHH2,'DefaultPsetName')):
+                self.DefaultPsetName = self.config.UHH2.DefaultPsetName
+            if(hasattr(self.config.UHH2,'DefaultOutLFNDirBase')):
+                self.DefaultOutLFNDirBase = self.config.UHH2.DefaultOutLFNDirBase
+            if(hasattr(self.config.UHH2,'outLFNDirBasePrefix')):
+                self.outLFNDirBasePrefix = self.config.UHH2.outLFNDirBasePrefix
+            #delete complete UHH2 specific ConfigSection, since crab will check against internal ConfigMapping for mispelled config attributes
+            del self.config.UHH2
+
     def _submit_(self, myconfig):
         try:
             if 'submit' not in self.command or 'resubmit' in self.command:
@@ -32,14 +49,6 @@ class CrabConfig:
     def ByDatasets(self,listOfDatasets, listOfNames, namePostfix):
         #print "DataSets", listOfDatasets,"Request Name", listOfNames, "Postfix",namePostfix
         
-        #setting default values for UHH2 specific crab config fields, if User has not set them earlier 
-        if(not hasattr(self.config.General,'storeJetConstituents')):
-            self.config.General.storeJetConstituents = False
-        if(not hasattr(self.config.JobType,'DefaultPsetName')):
-            self.config.JobType.DefaultPsetName = True
-        if(not hasattr(self.config.Data,'DefaultOutLFNDirBase')):
-            self.config.Data.DefaultOutLFNDirBase = True
-
         if(len(listOfNames)==len(listOfDatasets)):
             for i in range(0,len(listOfDatasets)):
                 print "Working on", listOfNames[i]+namePostfix
@@ -48,11 +57,11 @@ class CrabConfig:
 
 
                 #if user wants to provied psetname/outLFNDirBase themself, don't overwrite it here
-                if(self.config.JobType.DefaultPsetName):
-                    self.config.JobType.psetName = os.path.join(os.environ['CMSSW_BASE'], 'src/UHH2/core/python/', get_ntuplewriter(listOfDatasets[i],self.config.General.storeJetConstituents))
-                if(self.config.Data.DefaultOutLFNDirBase):
-                    if(hasattr(self.config.Data,'outLFNDirBasePrefix')):
-                        self.config.Data.outLFNDirBase = get_outLFNDirBase(listOfDatasets[i],prefix=self.config.Data.outLFNDirBasePrefix)
+                if(self.DefaultPsetName):
+                    self.config.JobType.psetName = os.path.join(os.environ['CMSSW_BASE'], 'src/UHH2/core/python/', get_ntuplewriter(listOfDatasets[i],self.storeJetConstituents))
+                if(self.DefaultOutLFNDirBase):
+                    if(self.outLFNDirBasePrefix is not None):
+                        self.config.Data.outLFNDirBase = get_outLFNDirBase(listOfDatasets[i],prefix=self.outLFNDirBasePrefix)
                     else:
                         self.config.Data.outLFNDirBase = get_outLFNDirBase(listOfDatasets[i])
 

--- a/scripts/crab/crab_template.py
+++ b/scripts/crab/crab_template.py
@@ -43,7 +43,7 @@ if __name__=='__main__':
 
 from CRABClient.UserUtilities import config
 from CRABClient.ClientExceptions import ProxyException
-import os
+import os, sys
 import re
 
 
@@ -68,16 +68,14 @@ config.JobType.sendExternalFolder = True
 
 config.Site.storageSite = 'T2_DE_DESY'
 
-config.General.storeJetConstituents = storeJetConstituents
-
 
 # The remaining lines are only used if one does not run this template with multicrab, but rather 'manually ' with crab itself.
 # In this case crab will only run on the first entry in inputDatasets!
 
 # If you know what you are doing and would like multicrab not to overwrite the psetname or outLFNDirBase
 # set respective flag to False:
-# config.JobType.DefaultPsetName = False
-# config.Data.DefaultOutLFNDirBase = False
+# DefaultPsetName = False
+# DefaultOutLFNDirBase = False
 
 # By default choose the ntuplewriter based on the DAS string
 # You can also choose the ntuplewriter yourself by replacing the function get_ntuplewriter with the name of the ntuplewriter_*_*.py
@@ -92,11 +90,22 @@ config.Data.outLFNDirBase = CrabYearUtilities.get_outLFNDirBase(inputDatasets[0]
 # replacing YOUR_CERN_USERNAME_HERE as appropriate
 # config.Data.outLFNDirBase = CrabYearUtilities.get_outLFNDirBase(inputDatasets[0],prefix='/store/user/YOUR_CERN_USERNAME_HERE/RunII_106X_v1/') # FIXME: change to RunII_106X_v2 before central production in autumn 2021
 # If you still want multicrab to choose year dependent sub-directories, but not put it in the group area, you can provide the base-dir prefix:
-# config.Data.outLFNDirBasePrefix = '/store/user/YOUR_CERN_USERNAME_HERE/RunII_106X_v1/'
+# outLFNDirBasePrefix = '/store/user/YOUR_CERN_USERNAME_HERE/RunII_106X_v1/'
 
-if 'YOUR_CERN_USERNAME_HERE' in config.Data.outLFNDirBase or (hasattr(config.Data,'outLFNDirBasePrefix') and ('YOUR_CERN_USERNAME_HERE' in config.Data.outLFNDirBasePrefix)):
-    raise RuntimeError("You didn't insert your CERN username in config.Data.outLFNDirBase or config.Data.outLFNDirBasePrefix, please fix it")
+if 'YOUR_CERN_USERNAME_HERE' in config.Data.outLFNDirBase or ('YOUR_CERN_USERNAME_HERE' in globals().get('outLFNDirBasePrefix','')):
+    raise RuntimeError("You didn't insert your CERN username in config.Data.outLFNDirBase or outLFNDirBasePrefix, please fix it")
 
 if len(inputDatasets) > 0 and len(requestNames) > 0:
     config.General.requestName = requestNames[0]
     config.Data.inputDataset = inputDatasets[0]
+
+# If one runs in multicrab we need to set these UHH2 specific Configuration attributes,
+# in order to be able to make decisions on a per dataset basis.
+# If you are running multicrab in an additional wrapper, you might have to move everything out of the if-statement. 
+if('multicrab' in sys.argv[0]):
+    config.section_("UHH2")
+    config.UHH2.document_("Config Section for UHH2 specific settings")
+    config.UHH2.storeJetConstituents = storeJetConstituents
+    config.UHH2.DefaultPsetName = globals().get('DefaultPsetName',True)
+    config.UHH2.DefaultOutLFNDirBase = globals().get('DefaultOutLFNDirBase',True)
+    config.UHH2.outLFNDirBasePrefix  = globals().get('outLFNDirBasePrefix',None)


### PR DESCRIPTION
This fixes a bug introduced with #1597 - spotted by @apaasch.
Initially i added additional attributes to the crab `config`-object, but crab does not like that.
It will run a SpellChecker against all given config-attributes and matches them against an internal map.
So it will complain about any given by us, since i have not figured out how to add stuff to that [mapping](https://github.com/dmwm/CRABClient/blob/v3.210607patch/src/python/CRABClient/ClientMapping.py).

Now we add a separate Config-section with our UHH2 specific stuff, that will get removed completely before we call crab submit

[only compile]