### PR TITLE
[106X_v2] updating crab_template.py to fix multicrab with newest crab3 version

### DIFF
--- a/scripts/crab/CrabScript.py
+++ b/scripts/crab/CrabScript.py
@@ -31,6 +31,7 @@ class CrabConfig:
                 self.outLFNDirBasePrefix = self.config.UHH2.outLFNDirBasePrefix
             #delete complete UHH2 specific ConfigSection, since crab will check against internal ConfigMapping for mispelled config attributes
             del self.config.UHH2
+            self.config._internal_sections.remove("UHH2")
 
     def _submit_(self, myconfig):
         try:

--- a/scripts/crab/crab_template.py
+++ b/scripts/crab/crab_template.py
@@ -104,7 +104,6 @@ if len(inputDatasets) > 0 and len(requestNames) > 0:
 # If you are running multicrab in an additional wrapper, you might have to move everything out of the if-statement.
 if('multicrab' in sys.argv[0]):
     config.section_("UHH2")
-    config.UHH2.document_("Config Section for UHH2 specific settings")
     config.UHH2.storeJetConstituents = storeJetConstituents
     config.UHH2.DefaultPsetName = globals().get('DefaultPsetName',True)
     config.UHH2.DefaultOutLFNDirBase = globals().get('DefaultOutLFNDirBase',True)


### PR DESCRIPTION
removing unnecessary line with doc string for UHH2 Crab ConfigSection, since this results in error in newest version of crab.

[ci skip]