### PR TITLE
[106X] Adapted b-tagging SF application module for UL 

### DIFF
--- a/common/include/BTagCalibrationStandalone.h
+++ b/common/include/BTagCalibrationStandalone.h
@@ -23,16 +23,18 @@
 class BTagEntry
 {
 public:
+  // working points and jet flavour taken from this presentation:
+  // https://indico.cern.ch/event/1096988/contributions/4615134/attachments/2346047/4000529/Nov21_btaggingSFjsons.pdf
   enum OperatingPoint {
-    OP_LOOSE=0,
-    OP_MEDIUM=1,
-    OP_TIGHT=2,
-    OP_RESHAPING=3,
+    OP_LOOSE=0, // L
+    OP_MEDIUM=1, // M
+    OP_TIGHT=2, // T
+    OP_RESHAPING=3, // shape
   };
   enum JetFlavor {
-    FLAV_B=0,
-    FLAV_C=1,
-    FLAV_UDSG=2,
+    FLAV_B=5,
+    FLAV_C=4,
+    FLAV_UDSG=0,
   };
   struct Parameters {
     OperatingPoint operatingPoint;

--- a/common/include/BTagCalibrationStandalone.h
+++ b/common/include/BTagCalibrationStandalone.h
@@ -23,7 +23,7 @@
 class BTagEntry
 {
 public:
-  // working points and jet flavour taken from this presentation:
+  // working points and jet flavour taken from this presentation, and shifted to the previous ones:
   // https://indico.cern.ch/event/1096988/contributions/4615134/attachments/2346047/4000529/Nov21_btaggingSFjsons.pdf
   enum OperatingPoint {
     OP_LOOSE=0, // L
@@ -32,9 +32,9 @@ public:
     OP_RESHAPING=3, // shape
   };
   enum JetFlavor {
-    FLAV_B=5,
-    FLAV_C=4,
-    FLAV_UDSG=0,
+    FLAV_B=0, // 5
+    FLAV_C=1, // 4
+    FLAV_UDSG=2, // 0
   };
   struct Parameters {
     OperatingPoint operatingPoint;

--- a/common/src/BTagCalibrationStandalone.cc
+++ b/common/src/BTagCalibrationStandalone.cc
@@ -72,21 +72,29 @@ std::cerr << "ERROR in BTagCalibration: "
 throw std::exception();
   }
 
-  // make parameters
-  unsigned op = stoi(vec[0]);
-  if (op > 3) {
-std::cerr << "ERROR in BTagCalibration: "
-          << "Invalid csv line; OperatingPoint > 3: "
-          << csvLine;
-throw std::exception();
+  // read OP
+  std::vector<std::string> accepted_op_params = {"L", "M", "T", "shape"};
+  std::string op_string = vec[0];
+  if (std::find(accepted_op_params.begin(), accepted_op_params.end(), op_string) == accepted_op_params.end()) {
+    std::cerr << "ERROR in BTagCalibration: "
+              << "Invalid csv line; OperatingPoint must be L, M, T or shape: "
+              << csvLine;
+    throw std::exception();
   }
+
+  // converting to number
+  unsigned op = std::find(accepted_op_params.begin(), accepted_op_params.end(), op_string) - accepted_op_params.begin();
+
+  // read JF
+  std::vector<int> accepted_jf_params = {5, 4, 0};
   unsigned jf = stoi(vec[3]);
-  if (jf > 2) {
-std::cerr << "ERROR in BTagCalibration: "
-          << "Invalid csv line; JetFlavor > 2: "
-          << csvLine;
-throw std::exception();
+  if (std::find(accepted_jf_params.begin(), accepted_jf_params.end(), jf) == accepted_jf_params.end()) {
+    std::cerr << "ERROR in BTagCalibration: "
+              << "Invalid csv line; JetFlavor must be 5, 4 or 0: "
+              << csvLine;
+    throw std::exception();
   }
+
   params = BTagEntry::Parameters(
     BTagEntry::OperatingPoint(op),
     vec[1],
@@ -99,6 +107,7 @@ throw std::exception();
     stof(vec[8]),
     stof(vec[9])
   );
+
 }
 
 BTagEntry::BTagEntry(const std::string &func, BTagEntry::Parameters p):
@@ -333,6 +342,7 @@ void BTagCalibration::readCSV(std::istream &s)
     }
     addEntry(BTagEntry(line));
   }
+
 }
 
 void BTagCalibration::makeCSV(std::ostream &s) const

--- a/common/src/BTagCalibrationStandalone.cc
+++ b/common/src/BTagCalibrationStandalone.cc
@@ -62,15 +62,9 @@ throw std::exception();
     vec[10].erase(remove(vec[10].begin(),vec[10].end(),chars[i]),vec[10].end());
   }
 
+
   // make formula
   formula = vec[10];
-  TF1 f1("", formula.c_str());  // compile formula to check validity
-  if (f1.IsZombie()) {
-std::cerr << "ERROR in BTagCalibration: "
-          << "Invalid csv line; formula does not compile: "
-          << csvLine;
-throw std::exception();
-  }
 
   // read OP
   std::vector<std::string> accepted_op_params = {"L", "M", "T", "shape"};
@@ -87,14 +81,15 @@ throw std::exception();
 
   // read JF
   std::vector<int> accepted_jf_params = {5, 4, 0};
-  unsigned jf = stoi(vec[3]);
-  if (std::find(accepted_jf_params.begin(), accepted_jf_params.end(), jf) == accepted_jf_params.end()) {
+  unsigned jf_preConversion = stoi(vec[3]);
+  if (std::find(accepted_jf_params.begin(), accepted_jf_params.end(), jf_preConversion) == accepted_jf_params.end()) {
     std::cerr << "ERROR in BTagCalibration: "
               << "Invalid csv line; JetFlavor must be 5, 4 or 0: "
               << csvLine;
     throw std::exception();
   }
 
+  unsigned jf = std::find(accepted_jf_params.begin(), accepted_jf_params.end(), jf_preConversion) - accepted_jf_params.begin();
   params = BTagEntry::Parameters(
     BTagEntry::OperatingPoint(op),
     vec[1],
@@ -107,7 +102,6 @@ throw std::exception();
     stof(vec[8]),
     stof(vec[9])
   );
-
 }
 
 BTagEntry::BTagEntry(const std::string &func, BTagEntry::Parameters p):
@@ -334,7 +328,6 @@ void BTagCalibration::readCSV(std::istream &s)
   if (line.find("OperatingPoint") == std::string::npos) {
     addEntry(BTagEntry(line));
   }
-
   while (getline(s,line)) {
     line = BTagEntry::trimStr(line);
     if (line.empty()) {  // skip empty lines
@@ -466,6 +459,7 @@ void BTagCalibrationReader::BTagCalibrationReaderImpl::load(
                                              BTagEntry::JetFlavor jf,
                                              std::string measurementType)
 {
+
   if (tmpData_[jf].size()) {
 std::cerr << "ERROR in BTagCalibrationReader: "
           << "Data for this jet-flavor is already loaded: "


### PR DESCRIPTION
This PR changes the b-tagging SF application module to work with the updated CSV files.

Slides summarizing the changes can be found [here](https://indico.desy.de/event/33014/) - the working points and jet flavors were renamed. The new names are "converted" to the old ones to keep our code working with minimal changes.

Additionally, an issue with very large timing was found, as reported in the same meeting. Both initialization and runtime of an analysis module increased dramatically when including the module. The source was found in this code block

```
TF1 f1("", formula.c_str());  // compile formula to check validity
  if (f1.IsZombie()) {
std::cerr << "ERROR in BTagCalibration: "
          << "Invalid csv line; formula does not compile: "
          << csvLine;
throw std::exception();
  }
 ``` 
 
 as explained in some slides [here](https://indico.desy.de/event/33015/) - the TF1s do not get deleted from memory properly. As this block is only used to validate whether the CSV file is correct, if we trust that POG-provided file we do not really need this check. Therefore, I just removed it for the moment.
 
 Note: I haven't checked yet how these changes affect the WP-based corrections - maybe someone using those in UL could check? As I only changed the underlying module, I expect no problem however.
 
--
 Edit: in case there are problems with indico access, I have uploaded the slides to [this syncandshare folder](https://syncandshare.desy.de/index.php/s/4FDx5rsexTRMede).