### PR TITLE
MC{Muon,Elec}ScaleFactor class: add argument whether to use abseta or eta to find correct SF

### DIFF
--- a/common/include/MCWeight.h
+++ b/common/include/MCWeight.h
@@ -103,6 +103,9 @@ class MCScaleVariation: public uhh2::AnalysisModule {
  *     "down" or "nominal".
  *   - muons_handle_name: handle to the muon collection (the default points to
  *     event.muons)
+ *   - absolute_eta: should be true if the eta range in the scale factor histogram is positive only
+ *     (i.e. only shows absolute eta values); should be false if eta can also be negative (i.e. scale
+ *     factors are not strictly symmetric around zero)
  */
 class MCMuonScaleFactor: public uhh2::AnalysisModule {
 public:
@@ -113,7 +116,8 @@ public:
                              const std::string & weight_postfix="",
 			     bool etaYaxis=false,
                              const std::string & sys_uncert="nominal",
-                             const std::string & muons_handle_name="muons");
+                             const std::string & muons_handle_name="muons",
+                             const bool absolute_eta = true);
 
   virtual bool process(uhh2::Event & event) override;
   virtual bool process_onemuon(uhh2::Event & event, int i);
@@ -128,6 +132,7 @@ private:
   float eta_min_, eta_max_, pt_min_, pt_max_;
   int sys_direction_;
   bool etaYaxis_;
+  const bool fAbsoluteEta;
 };
 
 // Muon tracking efficiency
@@ -176,6 +181,9 @@ private:
  *     "down" or "nominal".
  *   - electrons_handle_name: handle to the electrons collection (the default points to
  *     event.electrons)
+ *   - absolute_eta: should be true if the eta range in the scale factor histogram is positive only
+ *     (i.e. only shows absolute eta values); should be false if eta can also be negative (i.e. scale
+ *     factors are not strictly symmetric around zero)
  */
 class MCElecScaleFactor: public uhh2::AnalysisModule {
 public:
@@ -185,7 +193,8 @@ public:
                              const std::string & weight_postfix="",
                              const std::string & sys_uncert="nominal",
                              const std::string & elecs_handle_name="electrons",
-                             const std::string & sf_name="EGamma_SF2D");
+                             const std::string & sf_name="EGamma_SF2D",
+                             const bool absolute_eta = true);
 
   virtual bool process(uhh2::Event & event) override;
 
@@ -198,6 +207,7 @@ private:
   float sys_error_factor_;
   float eta_min_, eta_max_, pt_min_, pt_max_;
   int sys_direction_;
+  const bool fAbsoluteEta;
 };
 
 

--- a/common/src/MCWeight.cxx
+++ b/common/src/MCWeight.cxx
@@ -287,12 +287,14 @@ MCMuonScaleFactor::MCMuonScaleFactor(uhh2::Context & ctx,
   const std::string & weight_postfix,
   bool etaYaxis,
   const std::string & sys_uncert,
-  const std::string & muons_handle_name):
+  const std::string & muons_handle_name,
+  const bool absolute_eta):
   h_muons_            (ctx.get_handle<std::vector<Muon>>(muons_handle_name)),
   h_muon_weight_      (ctx.declare_event_output<float>("weight_sfmu_" + weight_postfix)),
   h_muon_weight_up_   (ctx.declare_event_output<float>("weight_sfmu_" + weight_postfix + "_up")),
   h_muon_weight_down_ (ctx.declare_event_output<float>("weight_sfmu_" + weight_postfix + "_down")),
-  sys_error_factor_(sys_error_percantage/100.), etaYaxis_(etaYaxis)
+  sys_error_factor_(sys_error_percantage/100.), etaYaxis_(etaYaxis),
+  fAbsoluteEta(absolute_eta)
   {
     auto dataset_type = ctx.get("dataset_type");
     bool is_mc = dataset_type == "MC";
@@ -355,7 +357,7 @@ MCMuonScaleFactor::MCMuonScaleFactor(uhh2::Context & ctx,
     const auto & muons = event.get(h_muons_);
     float weight = 1., weight_up = 1., weight_down = 1.;
     for (const auto & mu : muons) {
-      float eta = fabs(mu.eta());
+      float eta = fAbsoluteEta ? fabs(mu.eta()) : mu.eta();
       float pt = mu.pt();
       if (eta_min_ < eta && eta_max_ > eta){
         bool out_of_range = false;
@@ -423,7 +425,7 @@ MCMuonScaleFactor::MCMuonScaleFactor(uhh2::Context & ctx,
     const auto & muons = event.get(h_muons_);
     float weight = 1., weight_up = 1., weight_down = 1.;
     Muon mu = muons.at(i);
-    float eta = fabs(mu.eta());
+    float eta = fAbsoluteEta ? fabs(mu.eta()) : mu.eta();
     float pt = mu.pt();
     if (eta_min_ < eta && eta_max_ > eta){
       bool out_of_range = false;
@@ -586,12 +588,14 @@ MCMuonScaleFactor::MCMuonScaleFactor(uhh2::Context & ctx,
       const std::string & weight_postfix,
       const std::string & sys_uncert,
       const std::string & elecs_handle_name,
-      const std::string & sf_name):
+      const std::string & sf_name,
+      const bool absolute_eta):
       h_elecs_            (ctx.get_handle<std::vector<Electron>>(elecs_handle_name)),
       h_elec_weight_      (ctx.declare_event_output<float>("weight_sfelec_" + weight_postfix)),
       h_elec_weight_up_   (ctx.declare_event_output<float>("weight_sfelec_" + weight_postfix + "_up")),
       h_elec_weight_down_ (ctx.declare_event_output<float>("weight_sfelec_" + weight_postfix + "_down")),
-      sys_error_factor_(sys_error_percantage/100.)
+      sys_error_factor_(sys_error_percantage/100.),
+      fAbsoluteEta(absolute_eta)
       {
         auto dataset_type = ctx.get("dataset_type");
         bool is_mc = dataset_type == "MC";
@@ -636,7 +640,7 @@ MCMuonScaleFactor::MCMuonScaleFactor(uhh2::Context & ctx,
         const auto & elecs = event.get(h_elecs_);
         float weight = 1., weight_up = 1., weight_down = 1.;
         for (const auto & el : elecs) {
-          float eta = fabs(el.supercluster_eta());
+          float eta = fAbsoluteEta ? fabs(el.supercluster_eta()) : el.supercluster_eta();
           float pt = el.pt();
           if (eta_min_ < eta && eta_max_ > eta){
             bool out_of_range = false;


### PR DESCRIPTION
[only compile]

Added option to constructor of `MC{Muon,Elec}ScaleFactor`: Now you can decide whether you want to use absolute eta or signed eta of muon/electron for reading the correct SF from the TH2F passed to the class.

The changes should be backwards compatible since the new argument is the last one passed to the constructor and has a default value that leads to the previous behaviour, namely using absolute eta always.