### PR TITLE
Avoid possible compiler error by including fstream in some files

### DIFF
--- a/common/src/PDFWeights.cxx
+++ b/common/src/PDFWeights.cxx
@@ -1,5 +1,6 @@
 #include "UHH2/common/include/PDFWeights.h"
 #include <iostream>
+#include <fstream>
 
 PDFWeights::PDFWeights(TString pdfname, TString pdfweightdir) 
 {

--- a/common/test/PDFWeightsModule.cpp
+++ b/common/test/PDFWeightsModule.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <fstream>
 #include <memory>
 
 #include "UHH2/core/include/AnalysisModule.h"


### PR DESCRIPTION
[only compile]

I did some tests in a different CMSSW version (10.6.29 instead of the current 10.6.28) and noticed that there are compiler erros in case you don't include fstream in the files that are changed with this PR. When doing the installation/compiling of this branch with the installation script as-is, this compiler error does not appear for some reason. But it doesn't hurt to take the precaution and just include fstream, I guess.