### PR TITLE
remove RecoBTag/TensorFlow from BuildFiles

### DIFF
--- a/common/BuildFile.xml
+++ b/common/BuildFile.xml
@@ -9,7 +9,6 @@
 <use name="tensorflow"/>
 <use name="protobuf"/>
 <use name="Eigen"/>
-<use name="RecoBTag/TensorFlow"/>
 <export>
     <lib name="1" />
 </export>

--- a/examples/BuildFile.xml
+++ b/examples/BuildFile.xml
@@ -7,4 +7,3 @@
 <use name="tensorflow"/>
 <use name="protobuf"/>
 <use name="Eigen"/>
-<use name="RecoBTag/TensorFlow"/>


### PR DESCRIPTION
[only compile]

Fix compiler warnings (appearing when running `make` in `CMSSW*/src/UHH2`):
```
****WARNING: Invalid tool RecoBTag/TensorFlow. Please fix src/UHH2/examples/BuildFile.xml file.
****WARNING: Invalid tool RecoBTag/TensorFlow. Please fix src/UHH2/common/BuildFile.xml file.
```
This particular tensorflow library is not used anywhere in UHH2 and is, as the compiler tells us, invalid.