### PR TITLE
[RunII_106X_v2] multicrab: fix double-slashes in ntuple paths in XML files

### DIFF
--- a/scripts/crab/multicrab.py
+++ b/scripts/crab/multicrab.py
@@ -136,7 +136,7 @@ if __name__ == '__main__':
         for i,name in enumerate(ConfigFile.requestNames):
             help_name = ConfigFile.inputDatasets[i].split('/')[1]
             #print help_name
-            dirname = '/pnfs/desy.de/cms/tier2/'+get_outLFNDirBase(ConfigFile.inputDatasets[i])+'/'+help_name+'/crab_'+name+args.postfix+'/**/**/*.root'
+            dirname = os.path.join('/pnfs/desy.de/cms/tier2', get_outLFNDirBase(ConfigFile.inputDatasets[i]).strip('/'), help_name, 'crab_'+name+args.postfix, '**/**/*.root')
             xmlname = name+'.xml'
             #print dirname
             print 'For',xmlname


### PR DESCRIPTION
[ci skip]
