### PR TITLE
[RunII_106X_v2] MCPileupReweight: fix up/down in branch names of varied pileup weights

### DIFF
--- a/common/src/MCWeight.cxx
+++ b/common/src/MCWeight.cxx
@@ -44,8 +44,8 @@ bool MCLumiWeight::process(uhh2::Event & event){
 
 MCPileupReweight::MCPileupReweight(Context & ctx, const std::string & sysType):
 h_pu_weight_(ctx.declare_event_output<float>("weight_pu")),
-h_pu_weight_up_(ctx.declare_event_output<float>("weight_pu_down")),
-h_pu_weight_down_(ctx.declare_event_output<float>("weight_pu_up")),
+h_pu_weight_up_(ctx.declare_event_output<float>("weight_pu_up")),
+h_pu_weight_down_(ctx.declare_event_output<float>("weight_pu_down")),
 h_npu_data_up(0),
 h_npu_data_down(0),
 sysType_(sysType)


### PR DESCRIPTION
[ci skip]