### PR TITLE
[106X] handle samples with negative weights

### DIFF
--- a/common/src/MCWeight.cxx
+++ b/common/src/MCWeight.cxx
@@ -24,7 +24,7 @@ MCLumiWeight::MCLumiWeight(Context & ctx){
     cout << "Warning: MCLumiWeight will not have an effect on this non-MC sample (dataset_type = '" + dataset_type + "')" << endl;
     return;
   } else {
-    double dataset_lumi = string2double(ctx.get("dataset_lumi"));
+    double dataset_lumi = abs(string2double(ctx.get("dataset_lumi")));
     double reweight_to_lumi = string2double(ctx.get("target_lumi"));
     if(reweight_to_lumi <= 0.0){
       throw runtime_error("MCLumiWeight: target_lumi <= 0.0 not allowed");


### PR DESCRIPTION
Samples with negative weights, e.g. signal interference samples, are scaled according to the lumi specified in the config xmls. Since this lumi is also negative (the negative weight goes in again), the same minus sign appears twice and cancels out in the end.
To prevent this, the absolute value of ```dataset_lumi``` is taken, such that samples with positive weights (and lumis) are not affected.

In principle this is also relevant for 102X, although I doubt that anything else than 106X will be used in the future.