### PR TITLE
[106X] removed defaults from JEC and JER xml file parsing

### DIFF
--- a/common/src/JetCorrections.cxx
+++ b/common/src/JetCorrections.cxx
@@ -143,7 +143,7 @@ namespace {
 
   JetCorrectionUncertainty* corrector_uncertainty(uhh2::Context & ctx, const std::vector<std::string> & filenames, int &direction){
 
-    auto dir = ctx.get("jecsmear_direction", "nominal");
+    auto dir = ctx.get("jecsmear_direction");
     if (ctx.get("dataset_type") != "MC") {
       direction = 0;
     }
@@ -612,7 +612,7 @@ GenericJetResolutionSmearer::GenericJetResolutionSmearer(uhh2::Context& ctx, con
   if(ctx.get("meta_jer_applied__"+recjet_label, "") != "true") ctx.set_metadata("jer_applied__"+recjet_label, "true");
   else throw std::runtime_error("GenericJetResolutionSmearer::GenericJetResolutionSmearer -- JER smearing already applied to this RECO-jets collection: "+recjet_label);
 
-  const std::string& dir = ctx.get("jersmear_direction", "nominal");
+  const std::string& dir = ctx.get("jersmear_direction");
   if     (dir == "nominal") direction =  0;
   else if(dir == "up")      direction =  1;
   else if(dir == "down")    direction = -1;

--- a/examples/config/Example.xml
+++ b/examples/config/Example.xml
@@ -66,6 +66,10 @@
             <Item Name="pileup_directory" Value="common/data/2018/MyMCPileupHistogram.root" />
             <Item Name="pileup_directory_data" Value="common/data/2018/MyDataPileupHistogram2018.root" />
 
+            <!-- configuration for JEC and JER smearing (run as part of CommonModules): -->
+            <Item Name="jersmear_direction" Value="nominal" />
+            <Item Name="jecsmear_direction" Value="nominal" />
+
             <!-- Some test configuration; see ExampleModule.cxx for how to access it: -->
             <Item Name="TestKey" Value="TestKeyValue" />
         </UserConfig>

--- a/examples/config/ExampleJetComposition.xml
+++ b/examples/config/ExampleJetComposition.xml
@@ -39,6 +39,10 @@
             <!-- configuration for MCPileupReweight (run as part of CommonModules): -->
 <!--            <Item Name="pileup_directory" Value="" /> -->
 
+            <!-- configuration for JEC and JER smearing (run as part of CommonModules): -->
+            <!-- <Item Name="jersmear_direction" Value="nominal" /> -->
+            <!-- <Item Name="jecsmear_direction" Value="nominal" /> -->
+
             <!-- Some test configuration; see ExampleJetComposition.cxx for how to access it: -->
             <Item Name="TestKey" Value="TestKeyValue" />
         </UserConfig>


### PR DESCRIPTION
[only compile]

In the recent changes by @MatthiesC to the b-tagging SF modules (see here https://github.com/UHH2/UHH2/pull/1631), JES smearing dependent handling was added. This included reading the `jecsmear_direction` parameter from the xml config file, which was deliberately set to have no default in that code, enforcing a proper setting of the variation in each config file.

I think it would make sense to have the reading of the parameters always behave in the same way, and agree with Christopher that not including a default might help in preventing mix-ups. Therefore, I removed the defaults in this PR also in the jet correction modules.

Please feel free to comment if you have any arguments for or against this change we are suggesting :)