### PR TITLE
fix parsing issue of btagging SF CSVs where commas in equations were …

### DIFF
--- a/common/include/BTagCalibrationStandalone.h
+++ b/common/include/BTagCalibrationStandalone.h
@@ -73,6 +73,7 @@ public:
   static std::string makeCSVHeader();
   std::string makeCSVLine() const;
   static std::string trimStr(std::string str);
+  void SplitLineByCommas(const std::string &csvLine, std::vector<std::string> &vec);
 
   // public, no getters needed
   std::string formula;


### PR DESCRIPTION
…not ignored

This Pull Request will start automatic compilation, then making + testing of ntuples:

- Don't want to run any of this? (e.g. only XML files) Remove the @: [ci @ skip]

- Only want to compile, but don't make + test ntuples? (e.g. change `CommonModules.cxx`) Remove the @: [only @ compile]

Please include destination branch in title, e.g. `[102X]`, + short meaningful title

Please include an explanation message if it's something more complex than just XML dataset files:

