### PR TITLE
[106X] Fixed negative eta application of DiscriminantReweighting b-tagging SFs

### DIFF
--- a/common/src/BTagCalibrationStandalone.cc
+++ b/common/src/BTagCalibrationStandalone.cc
@@ -532,6 +532,7 @@ double BTagCalibrationReader::BTagCalibrationReaderImpl::eval(
                                              float pt,
                                              float discr) const
 {
+  
   bool use_discr = (op_ == BTagEntry::OP_RESHAPING);
   if (useAbsEta_[jf] && eta < 0) {
     eta = -eta;
@@ -566,6 +567,12 @@ double BTagCalibrationReader::BTagCalibrationReaderImpl::eval_auto_bounds(
                                              float pt,
                                              float discr) const
 {
+  
+  // added by Finn, without this the SF would only be applied to jets with positive eta!
+  if (useAbsEta_[jf] && eta < 0) {
+    eta = -eta;
+  }
+
   auto sf_bounds_eta = min_max_eta(jf, discr);
   bool eta_is_out_of_bounds = false;
 


### PR DESCRIPTION
[only compile]

In a past PR (https://github.com/UHH2/UHH2/pull/1620) I updated the b-tagging SF module to handle the new UL CSV files. One change included in those files was to give the SF as function of abs(eta), and not just eta, as was previously done. This (I thought) should be properly handled by the module, as abs(eta)-dependant SFs are detected [here](https://github.com/UHH2/UHH2/blob/RunII_106X_v2/common/src/BTagCalibrationStandalone.cc#L523), by

```
if (te.etaMin < 0) {
      useAbsEta_[be.params.jetFlavor] = false;
    }
```

which is then used [here](https://github.com/UHH2/UHH2/blob/RunII_106X_v2/common/src/BTagCalibrationStandalone.cc#L536) in the eval function to take the absolute of eta. However, there is the `eval_auto_bounds`-method, which we use, that does an additional thing: it checks whether the jet is out of bounds, if so sets the SF to 1, and otherwise calls the eval function. In that `eval_auto_bounds`, abs(eta) is not accounted for, leading to a SF of 1 for all events with negative eta [here](https://github.com/UHH2/UHH2/blob/RunII_106X_v2/common/src/BTagCalibrationStandalone.cc#L577).

I added a check of `useAbsEta_` also to that method to ensure that the SFs are properly applied. This issue, and change, should only affect the Discriminant-Reweighting, but not the WP-based SF module (as that does not use `eval_auto_bounds`). 