### PR TITLE
include MET uncertainties for PUPPI MET

### DIFF
--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -536,9 +536,7 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
     for(size_t j=0; j< met_sources.size(); ++j){
       met_tokens.push_back(consumes<vector<pat::MET>>(met_sources[j]));
       branch(tr, met_sources[j].c_str(), "MET", &met[j]);
-      // if (met_sources[j]=="slimmedMETsPuppi") skipMETUncertainties.push_back(true);  // Puppi doesn't have METUncertainty
-      // else skipMETUncertainties.push_back(false);
-      skipMETUncertainties.push_back(false); // New: Puppi MET does have uncertainties (e.g. unclustered energy variations)
+      skipMETUncertainties.push_back(false); // In previous versions, PUPPI MET didn't have uncertainties (e.g. unclustered energy variations); so we needed to differentiate here between PF and PUPPI MET
     }
     if(!met_sources.empty()){
       event->met = &met[0];

--- a/core/plugins/NtupleWriter.cc
+++ b/core/plugins/NtupleWriter.cc
@@ -536,8 +536,9 @@ NtupleWriter::NtupleWriter(const edm::ParameterSet& iConfig): outfile(0), tr(0),
     for(size_t j=0; j< met_sources.size(); ++j){
       met_tokens.push_back(consumes<vector<pat::MET>>(met_sources[j]));
       branch(tr, met_sources[j].c_str(), "MET", &met[j]);
-      if (met_sources[j]=="slimmedMETsPuppi") skipMETUncertainties.push_back(true);  // Puppi doesn't have METUncertainty
-      else skipMETUncertainties.push_back(false);
+      // if (met_sources[j]=="slimmedMETsPuppi") skipMETUncertainties.push_back(true);  // Puppi doesn't have METUncertainty
+      // else skipMETUncertainties.push_back(false);
+      skipMETUncertainties.push_back(false); // New: Puppi MET does have uncertainties (e.g. unclustered energy variations)
     }
     if(!met_sources.empty()){
       event->met = &met[0];


### PR DESCRIPTION
Right now, PUPPI MET uncertainties are missing in our ntuples; this PR fixes it for future productions (data members are already there; they just weren't filled...)