### PR TITLE
b-tag SFs: custom CSV reader, consecutive adaptations for MCBTagDiscriminantReweighting, and re-work of MCBTagScaleFactor

### DIFF
--- a/common/include/JetHists.h
+++ b/common/include/JetHists.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <boost/optional.hpp>
+
 #include "UHH2/core/include/Hists.h"
 #include "UHH2/core/include/Event.h"
 #include "UHH2/core/include/LorentzVector.h"
@@ -113,32 +115,40 @@ class TopJetHists: public JetHistsBase{
 
 
 
-static const std::vector<float> BTagMCEffBinsEta = {-2.4, 2.4};
-static const std::vector<float> BTagMCEffBinsPt = {20., 30., 50., 70., 100., 140., 200., 300., 600., 1000.};
+ // These bins are the same as the pt and abseta bins in which the wp-based b-tagging SFs are given:
+static const std::vector<float> kBTagMCEffBinsAbsEta = {0.0, 2.5}; // the wp-based SFs are given abseta-inclusively (cut-off at 2.5 for Ultra Legacy)
+static const std::vector<float> kBTagMCEffBinsPt = {20., 30., 50., 70., 100., 140., 200., 300., 600., 1000.};
 /** \brief measure btag efficiency in MC
  *
  * jets_handle_name should point to a handle of type vector<Jet> _or_
  * vector<TopJet>, were in the latter case all of the subjets are used.
+ *
+ * pt_bins / abseta_bins : You can provide custom binnings if you need to. Else the default ones (see above) will be used.
  */
 class BTagMCEfficiencyHists: public uhh2::Hists {
 public:
-  BTagMCEfficiencyHists(uhh2::Context & ctx,
-                        const std::string & dirname,
-			const JetId & jet_id,
-                        const std::string & jets_handle_name="jets");
-
+  BTagMCEfficiencyHists(
+    uhh2::Context & ctx,
+    const std::string & dirname,
+    const JetId & jet_id,
+    const boost::optional<std::string> & jets_handle_name = boost::none,
+    const boost::optional<std::vector<float>> & pt_bins = boost::none,
+    const boost::optional<std::vector<float>> & abseta_bins = boost::none
+  );
   virtual void fill(const uhh2::Event & ev) override;
 
 protected:
   void do_fill(const std::vector<TopJet> & jets, const uhh2::Event & event);
 
-  JetId btag_;
+  const JetId btag_;
+  const std::vector<float> BTagMCEffBinsPt;
+  const std::vector<float> BTagMCEffBinsAbsEta;
   TH2F * hist_b_passing_;
   TH2F * hist_b_total_;
   TH2F * hist_c_passing_;
   TH2F * hist_c_total_;
   TH2F * hist_udsg_passing_;
   TH2F * hist_udsg_total_;
-  uhh2::Event::Handle<std::vector<TopJet>> h_topjets_;
-  uhh2::Event::Handle<std::vector<Jet>>    h_jets_;
+  const uhh2::Event::Handle<std::vector<TopJet>> h_topjets_;
+  const uhh2::Event::Handle<std::vector<Jet>> h_jets_;
 };

--- a/common/include/UHH2BTagCalibReader.h
+++ b/common/include/UHH2BTagCalibReader.h
@@ -1,0 +1,104 @@
+#include <boost/optional.hpp>
+#include <limits>
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+#include <TF1.h>
+
+#define F_MAX std::numeric_limits<float>::max()
+#define F_MIN std::numeric_limits<float>::min()
+#define CENTRAL_CSV_STRING "central"
+
+namespace uhh2 { namespace BTagCalib {
+
+enum class OperatingPoint {
+  SHAPE,
+  LOOSE,
+  MEDIUM,
+  TIGHT,
+  UNDEFINED,
+};
+
+typedef struct {
+  std::string csv_string;
+  int index;
+} OperatingPointInfo;
+
+const std::map<OperatingPoint, OperatingPointInfo> kOperatingPoints = {
+  { OperatingPoint::SHAPE, { .csv_string = "shape", .index=-1 } },
+  { OperatingPoint::LOOSE, { .csv_string = "L", .index=0 } },
+  { OperatingPoint::MEDIUM, { .csv_string = "M", .index=1 } },
+  { OperatingPoint::TIGHT, { .csv_string = "T", .index=2 } },
+};
+
+enum class JetFlavor {
+  FLAV_B,
+  FLAV_C,
+  FLAV_UDSG,
+  UNDEFINED,
+};
+
+typedef struct {
+  std::string csv_string;
+} JetFlavorInfo;
+
+const std::map<JetFlavor, JetFlavorInfo> kJetFlavors = {
+  { JetFlavor::FLAV_B, { .csv_string = "5" } },
+  { JetFlavor::FLAV_C, { .csv_string = "4" } },
+  { JetFlavor::FLAV_UDSG, { .csv_string = "0" } },
+};
+
+class Reader {
+
+public:
+
+  Reader(
+    const std::string & csvFilePath,
+    const OperatingPoint op,
+    const std::string & measurementType,
+    const boost::optional<std::set<std::string> &> sysTypes = boost::none,
+    const boost::optional<bool> absEta = boost::none,
+    const boost::optional<bool> verbose = boost::none,
+    const boost::optional<float> defaultScaleFactor = boost::none,
+    const boost::optional<bool> failIfNoEntry = boost::none
+  );
+
+  float Evaluate(
+    const std::string & sysType,
+    const JetFlavor jf,
+    float eta,
+    float pt,
+    float discr = 0.f
+  ) const;
+
+private:
+
+  typedef struct {
+    float etaMin = F_MIN;
+    float etaMax = F_MAX;
+    float ptMin = F_MIN;
+    float ptMax = F_MAX;
+    float discrMin = F_MIN;
+    float discrMax = F_MAX;
+    TF1 *func = nullptr;
+  } CalibEntry;
+
+  void ReadCSV();
+
+  const std::string fCSVFilePath;
+  const OperatingPoint fOperatingPoint;
+  const std::string fMeasurementType;
+  const bool bAbsEta;
+  const bool bVerbose;
+  const float kDefaultScaleFactor;
+  const bool bFailIfNoEntry;
+  const bool bShape;
+
+  std::set<std::string> fSysTypes = { CENTRAL_CSV_STRING };
+
+  std::map<std::string, std::map<JetFlavor, std::vector<CalibEntry>>> fCalibEntries;
+};
+
+}}

--- a/common/src/UHH2BTagCalibReader.cxx
+++ b/common/src/UHH2BTagCalibReader.cxx
@@ -1,0 +1,211 @@
+#include <UHH2/common/include/UHH2BTagCalibReader.h>
+
+#include <algorithm>
+#include <iostream>
+#include <fstream>
+#include <sstream>
+#include <cmath>
+
+#include <TString.h>
+#include <TObjString.h>
+
+#define TOKEN_ELEMENT(IDX) ((TObjString*)tokens->At((IDX)))->GetString()
+
+using namespace std;
+using namespace uhh2::BTagCalib;
+
+namespace uhh2 {
+
+BTagCalib::Reader::Reader(
+  const string & csvFilePath,
+  const OperatingPoint op,
+  const string & measurementType,
+  const boost::optional<set<string> &> sysTypes,
+  const boost::optional<bool> absEta,
+  const boost::optional<bool> verbose,
+  const boost::optional<float> defaultScaleFactor,
+  const boost::optional<bool> failIfNoEntry
+):
+  fCSVFilePath(csvFilePath),
+  fOperatingPoint(op),
+  fMeasurementType(measurementType),
+  bAbsEta(absEta ? *absEta : true),
+  bVerbose(verbose ? *verbose : true),
+  kDefaultScaleFactor(defaultScaleFactor ? *defaultScaleFactor : 1.f),
+  bFailIfNoEntry(failIfNoEntry ? *failIfNoEntry : true),
+  bShape(fOperatingPoint == OperatingPoint::SHAPE)
+{
+  if(bVerbose) cout << "Hello World from BTagCalib::Reader!"
+  << "\nCSV: " << fCSVFilePath
+  << "\nWorking point: " << kOperatingPoints.at(fOperatingPoint).csv_string
+  << "\nMeasurement type: " << fMeasurementType
+  << "\nUse absolute pseudo-rapidity: " << (bAbsEta ? "true" : "false") << endl;
+  if(sysTypes) fSysTypes.insert(sysTypes->begin(), sysTypes->end());
+  ReadCSV();
+  if(bVerbose) cout << "BTagCalib::Reader has been initialized!" << endl;
+}
+
+void BTagCalib::Reader::ReadCSV()
+{
+  if (bVerbose) cout << "Reading CSV file ..." << endl;
+  vector<TString> lines;
+  string line;
+  ifstream csvFile(fCSVFilePath);
+  if (csvFile.is_open()) {
+    while (getline(csvFile, line)) {
+      if (line.empty()) continue; // skip empty lines
+      else if (line.find("OperatingPoint") != string::npos) continue; // skip CSV header line
+      else lines.push_back(TString(line));
+    }
+    csvFile.close();
+  }
+  else throw runtime_error("BTagCalib::Reader::ReadCSV(): Unable to open file");
+
+  if (bVerbose) cout << "Done reading. Constructing hash map with calibrations ..." << endl;
+  const int default_last = 10;
+  unsigned long entries = 0;
+  for (const TString & line : lines) {
+    auto tokens = line.Tokenize(",");
+    const int last = tokens->GetLast();
+    TString formula = TOKEN_ELEMENT(last);
+    if (last > default_last) { // if number of commas in line is not 10 (i.e. 11 tokens); happens if the formula itself contains a commma
+      string formula_;
+      for (int i = default_last; i <= last; ++i) {
+        formula_ += TOKEN_ELEMENT(i);
+      }
+      formula_.erase(remove(formula_.begin(), formula_.end(), '\"'), formula_.end()); // remove quotes that appear around formulas if they contain additional commas
+      formula = TString(formula_);
+    }
+    else if (last < default_last) {
+      stringstream ss;
+      ss << "BTagCalib::Reader::ReadCSV(): File contains entry that does not have required format:\n" << line.Data();
+      throw runtime_error(ss.str());
+    }
+
+    const string sysType = TOKEN_ELEMENT(2).Data();
+    if (
+      TOKEN_ELEMENT(0) != kOperatingPoints.at(fOperatingPoint).csv_string ||
+      TOKEN_ELEMENT(1) != fMeasurementType ||
+      fSysTypes.find(sysType) == fSysTypes.end()
+    ) continue;
+
+    const CalibEntry entry = {
+      .etaMin = float(TOKEN_ELEMENT(4).Atof()),
+      .etaMax = float(TOKEN_ELEMENT(5).Atof()),
+      .ptMin = float(TOKEN_ELEMENT(6).Atof()),
+      .ptMax = float(TOKEN_ELEMENT(7).Atof()),
+      .discrMin = float(TOKEN_ELEMENT(8).Atof()),
+      .discrMax = float(TOKEN_ELEMENT(9).Atof()),
+      .func = new TF1("", formula.Data(), float(TOKEN_ELEMENT(bShape ? 8 : 6).Atof()), float(TOKEN_ELEMENT(bShape ? 9 : 7).Atof()))
+    };
+
+    JetFlavor jf = JetFlavor::UNDEFINED;
+    const string jf_str = TOKEN_ELEMENT(3).Data();
+    for (const auto & kjf : kJetFlavors) {
+      if (kjf.second.csv_string == jf_str) {
+        jf = kjf.first;
+        break;
+      }
+    }
+    if (jf == JetFlavor::UNDEFINED) throw runtime_error("BTagCalib::Reader::ReadCSV(): File contains unknown flavor type: "+jf_str);
+
+    fCalibEntries[sysType][jf].push_back(entry);
+    entries++;
+  }
+  if (bVerbose) cout << "Hash map constructed. Number of entries: "+to_string(entries) << endl;
+}
+
+float BTagCalib::Reader::Evaluate(
+  const std::string & sysType,
+  const JetFlavor jf,
+  float eta,
+  float pt,
+  float discr
+) const
+{
+  if(!fCalibEntries.count(sysType)) throw runtime_error("BTagCalib::Reader::Evaluate(): No entries for sysType '"+sysType+"' found. Not loaded?");
+  else if(!fCalibEntries.at(sysType).count(jf)) {
+    stringstream ss;
+    ss << "BTagCalib::Reader::Evaluate(): No entries for jetFlavor '"+kJetFlavors.at(jf).csv_string+"' found for sysType '"+sysType+"'.\n"
+    << "This (probably) means that you request a scale factor for a particular sysType that is not provided for this jetFlavor at all.";
+    throw runtime_error(ss.str());
+  }
+
+  const auto & entries = fCalibEntries.at(sysType).at(jf);
+  bool out_of_bounds = false;
+  if(bAbsEta && eta < 0) eta = -eta;
+
+  // Restrict eta to boundaries
+  float etaMin = F_MAX;
+  float etaMax = F_MIN;
+  for(const auto & entry : entries) {
+    etaMin = min(etaMin, entry.etaMin);
+    etaMax = max(etaMax, entry.etaMax);
+  }
+  if(eta < etaMin || eta > etaMax) out_of_bounds = true;
+  eta = min(max(eta, nextafterf(etaMin, F_MAX)), nextafterf(etaMax, F_MIN));
+
+  // Restrict pt to boundaries of this eta bin
+  float ptMin = F_MAX;
+  float ptMax = F_MIN;
+  for(const auto & entry : entries) {
+    if(
+      entry.etaMin <= eta && eta <= entry.etaMax
+    ) {
+      ptMin = min(ptMin, entry.ptMin);
+      ptMax = max(ptMax, entry.ptMax);
+    }
+  }
+  if(pt < ptMin || pt > ptMax) out_of_bounds = true;
+  pt = min(max(pt, nextafterf(ptMin, F_MAX)), nextafterf(ptMax, F_MIN));
+
+  if(bShape) {
+    // Restrict discr to boundaries of this eta/pt bin
+    float discrMin = F_MAX;
+    float discrMax = F_MIN;
+    for(const auto & entry : entries) {
+      if(
+        entry.etaMin <= eta && eta <= entry.etaMax
+        && entry.ptMin <= pt && pt <= entry.ptMax
+      ) {
+        discrMin = min(discrMin, entry.discrMin);
+        discrMax = max(discrMax, entry.discrMax);
+      }
+    }
+    // Don't need an out-of-bounds check here because CSV files for the reshaping method contain an underflow and overflow bin for discr
+    discr = min(max(discr, nextafterf(discrMin, F_MAX)), nextafterf(discrMax, F_MIN));
+  }
+
+  const CalibEntry *correct_entry = nullptr;
+  for(const auto & entry : entries) {
+    if(
+      entry.etaMin <= eta && eta <= entry.etaMax
+      && entry.ptMin <= pt && pt <= entry.ptMax
+      && (bShape ? (entry.discrMin <= discr && discr <= entry.discrMax) : true)
+    ) {
+      correct_entry = &entry;
+      break;
+    }
+  }
+
+  float result = kDefaultScaleFactor;
+  if(!correct_entry) {
+    stringstream ss;
+    ss << "BTagEntry::Evaluate(): Calibration entry is null pointer!\n"
+    << "This (probably) means that no valid entry can be found for this sysType/jetFlavor/eta/pt/discr combination:\n"
+    << sysType << " / " << kJetFlavors.at(jf).csv_string << " / " << to_string(eta) << " / " << to_string(pt) << " / " << to_string(discr);
+    if(bFailIfNoEntry) throw runtime_error(ss.str());
+    else if(bVerbose) cout << ss.str() << "\nScale factor evaluated to default value "+to_string(result) << endl;
+  }
+  else {
+    const float sf = correct_entry->func->Eval(bShape ? discr : pt);
+    if(sysType != CENTRAL_CSV_STRING && out_of_bounds) {
+      const float sf_central = Evaluate(CENTRAL_CSV_STRING, jf, eta, pt, discr);
+      result = sf_central + 2*(sf - sf_central); // double uncertainty if out of eta/pt bounds
+    }
+    else result = sf;
+  }
+  return result;
+}
+
+}

--- a/examples/config/ExampleSystematics.xml
+++ b/examples/config/ExampleSystematics.xml
@@ -95,19 +95,16 @@
             <Item Name="muon_id_sf_direction" Value="down"/>
             <!-- <Item Name="muon_id_sf_direction" Value="up"/> -->
 
-            <Item Name="MCBtagEfficiencies" Value="nominal"/>
+            <Item Name="MCBtagEfficiencies" Value="nominal"/> <!-- This should actually be a file path to a ROOT file with MC efficiences... -->
             <!--
                 Btag scale factors for MC
                 Again, this is one we have set up ourselves
             -->
-            <!-- <Item Name="btag_sf_direction" Value="nominal"/> -->
-            <Item Name="btag_sf_direction" Value="down"/>
-            <!-- <Item Name="btag_sf_direction" Value="down_bc"/> -->
-            <!-- <Item Name="btag_sf_direction" Value="down_udsg"/> -->
-            <!-- <Item Name="btag_sf_direction" Value="up"/> -->
-            <!-- <Item Name="btag_sf_direction" Value="up_bc"/> -->
-            <!-- <Item Name="btag_sf_direction" Value="up_udsg"/> -->
-
+            <!-- <Item Name="SystDirection_BTaggingFixedWP" Value="central"/> -->
+            <Item Name="SystDirection_BTaggingFixedWP" Value="bc_down"/>
+            <!-- <Item Name="SystDirection_BTaggingFixedWP" Value="bc_up"/> -->
+            <!-- <Item Name="SystDirection_BTaggingFixedWP" Value="light_down"/> -->
+            <!-- <Item Name="SystDirection_BTaggingFixedWP" Value="light_up"/> -->
 
 
             <Item Name="AnalysisModule" Value="ExampleModuleSystematics" />

--- a/examples/src/ExampleModuleSystematics.cxx
+++ b/examples/src/ExampleModuleSystematics.cxx
@@ -87,12 +87,10 @@ ExampleModuleSystematics::ExampleModuleSystematics(Context & ctx)
                                       BTag::DEEPCSV, // example settings here - these should agree with whatever ID you use in your analysis
                                       BTag::WP_MEDIUM,
                                       "jets",
-                                      ctx.get("btag_sf_direction", "nominal"),  // here we link up the option in XML to the class constructor argument
                                       "mujets",
                                       "incl",
                                       "MCBtagEfficiencies",
-                                      "",
-                                      "BTagCalibration"));
+                                      ""));
 }
 
 


### PR DESCRIPTION
[only compile]

The official (but no longer supported) BTagCalibrationStandalone.h is quite buggy. I noticed that it does not return the correct scale factors for the different up/down variations. I gave up on trying to debug this old code and just wrote my own CSV reader from scratch whose code length is only about 1/4 compared to the old code, which does not unnecessarily use multiple classes, ... which is just better. I put it into `namespace uhh2` out of habit but it actually is a standalone code that could be used in other environments as well.

As a consequence, I adjusted the `MCBTagDiscriminantReweighting` class (for the reshaping method) and completely re-worked the `MCBTagScaleFactor` class (for WP-based SFs). The latter one's old code, that I have now replaced, had actually used a definition of up and down variations which is not in compliance with what BTV recommends. Only one up/down variation for light and b/c flavor jets, respectively, was computed, although one should futher distinguish between components that are correlated or uncorrelated between years. Moreover, the old class symmetrized the up/down variations - something that is not recommended by BTV afaik.

I have done some tests with the new code in my setups and it now produces the correct up/down variations (all of them!) and writes them to the AnalysisTree. Some more documentation can be found in the code. Feedback from fellow b-taggers is welcome!

Bonus: You can know set custom abseta/pt bins for `BTagMCEfficiencyHists` (constructor parameters). The default bins are lined up with the bins currently available in the Run II UL CSV files.