### PR TITLE
avoid compiler warnings about unused parameters

### DIFF
--- a/common/src/NeuralNetworkBase.cxx
+++ b/common/src/NeuralNetworkBase.cxx
@@ -9,6 +9,7 @@ using namespace std;
 
 
 NeuralNetworkBase::NeuralNetworkBase(Context& ctx, const std::string & ModelName, const std::string& ConfigName){
+    (void) ctx;
     tensorflow::SessionOptions sessionOptions;
     tensorflow::setThreading(sessionOptions, 1, "no_threads");
     tensorflow::setLogging("3");
@@ -40,6 +41,7 @@ NeuralNetworkBase::NeuralNetworkBase(Context& ctx, const std::string & ModelName
 }
 
 void NeuralNetworkBase::CreateInputs(Event & event){
+    (void) event;
     NNInputs.clear();
     NNoutputs.clear();
 


### PR DESCRIPTION
[only compile]

`(void) something` will prevent compiler's "unused parameter" warnings related to `something` being unused; does not change the behaviour of the code