### PR TITLE
EGamma residual corrections for electrons and photons

### DIFF
--- a/core/include/Electron.h
+++ b/core/include/Electron.h
@@ -131,6 +131,35 @@ class Electron : public RecParticle {
     m_puppiNoLeptonsPhotonIso = -99;
 
     m_electronMVATOP = -99;
+
+    // EGamma Residuals
+    m_ecalEnergyPreCorr = -99;
+    m_ecalEnergyErrPreCorr = -99;
+    m_ecalEnergyPostCorr = -99;
+    m_ecalEnergyErrPostCorr = -99;
+    m_ecalTrkEnergyPreCorr = -99;
+    m_ecalTrkEnergyErrPreCorr = -99;
+    m_ecalTrkEnergyPostCorr = -99;
+    m_ecalTrkEnergyErrPostCorr = -99;
+    m_energyScaleValue = -99;
+    m_energySigmaValue = -99;
+    m_energySmearNrSigma = -99;
+    m_energyScaleUp = -99;
+    m_energyScaleDown = -99;
+    m_energyScaleStatUp = -99;
+    m_energyScaleStatDown = -99;
+    m_energyScaleSystUp = -99;
+    m_energyScaleSystDown = -99;
+    m_energyScaleGainUp = -99;
+    m_energyScaleGainDown = -99;
+    m_energyScaleEtUp = -99;
+    m_energyScaleEtDown = -99;
+    m_energySigmaUp = -99;
+    m_energySigmaDown = -99;
+    m_energySigmaPhiUp = -99;
+    m_energySigmaPhiDown = -99;
+    m_energySigmaRhoUp = -99;
+    m_energySigmaRhoDown = -99;
   }
 
   float supercluster_eta() const{return m_supercluster_eta;}
@@ -193,6 +222,35 @@ class Electron : public RecParticle {
   float puppiNoLeptonsPhotonIso()         const { return m_puppiNoLeptonsPhotonIso;}
 
   float electronMVATOP()                      const { return m_electronMVATOP;}
+
+  // EGamma Residuals
+  float ecalEnergyPreCorr() const { return m_ecalEnergyPreCorr; }
+  float ecalEnergyErrPreCorr() const { return m_ecalEnergyErrPreCorr; }
+  float ecalEnergyPostCorr() const { return m_ecalEnergyPostCorr; }
+  float ecalEnergyErrPostCorr() const { return m_ecalEnergyErrPostCorr; }
+  float ecalTrkEnergyPreCorr() const { return m_ecalTrkEnergyPreCorr; }
+  float ecalTrkEnergyErrPreCorr() const { return m_ecalTrkEnergyErrPreCorr; }
+  float ecalTrkEnergyPostCorr() const { return m_ecalTrkEnergyPostCorr; }
+  float ecalTrkEnergyErrPostCorr() const { return m_ecalTrkEnergyErrPostCorr; }
+  float energyScaleValue() const { return m_energyScaleValue; }
+  float energySigmaValue() const { return m_energySigmaValue; }
+  float energySmearNrSigma() const { return m_energySmearNrSigma; }
+  float energyScaleUp() const { return m_energyScaleUp; }
+  float energyScaleDown() const { return m_energyScaleDown; }
+  float energyScaleStatUp() const { return m_energyScaleStatUp; }
+  float energyScaleStatDown() const { return m_energyScaleStatDown; }
+  float energyScaleSystUp() const { return m_energyScaleSystUp; }
+  float energyScaleSystDown() const { return m_energyScaleSystDown; }
+  float energyScaleGainUp() const { return m_energyScaleGainUp; }
+  float energyScaleGainDown() const { return m_energyScaleGainDown; }
+  float energyScaleEtUp() const { return m_energyScaleEtUp; }
+  float energyScaleEtDown() const { return m_energyScaleEtDown; }
+  float energySigmaUp() const { return m_energySigmaUp; }
+  float energySigmaDown() const { return m_energySigmaDown; }
+  float energySigmaPhiUp() const { return m_energySigmaPhiUp; }
+  float energySigmaPhiDown() const { return m_energySigmaPhiDown; }
+  float energySigmaRhoUp() const { return m_energySigmaRhoUp; }
+  float energySigmaRhoDown() const { return m_energySigmaRhoDown; }
 
   const std::vector<source_candidate>& source_candidates() const { return m_source_candidates; }
 
@@ -272,6 +330,34 @@ class Electron : public RecParticle {
   void set_puppiNoLeptonsNeutralHadronIso(float x)   { m_puppiNoLeptonsNeutralHadronIso=x;}
   void set_puppiNoLeptonsPhotonIso(float x)          { m_puppiNoLeptonsPhotonIso=x;}
 
+  // EGamma Residuals
+  void set_ecalEnergyPreCorr(float x) { m_ecalEnergyPreCorr=x; }
+  void set_ecalEnergyErrPreCorr(float x) { m_ecalEnergyErrPreCorr=x; }
+  void set_ecalEnergyPostCorr(float x) { m_ecalEnergyPostCorr=x; }
+  void set_ecalEnergyErrPostCorr(float x) { m_ecalEnergyErrPostCorr=x; }
+  void set_ecalTrkEnergyPreCorr(float x) { m_ecalTrkEnergyPreCorr=x; }
+  void set_ecalTrkEnergyErrPreCorr(float x) { m_ecalTrkEnergyErrPreCorr=x; }
+  void set_ecalTrkEnergyPostCorr(float x) { m_ecalTrkEnergyPostCorr=x; }
+  void set_ecalTrkEnergyErrPostCorr(float x) { m_ecalTrkEnergyErrPostCorr=x; }
+  void set_energyScaleValue(float x) { m_energyScaleValue=x; }
+  void set_energySigmaValue(float x) { m_energySigmaValue=x; }
+  void set_energySmearNrSigma(float x) { m_energySmearNrSigma=x; }
+  void set_energyScaleUp(float x) { m_energyScaleUp=x; }
+  void set_energyScaleDown(float x) { m_energyScaleDown=x; }
+  void set_energyScaleStatUp(float x) { m_energyScaleStatUp=x; }
+  void set_energyScaleStatDown(float x) { m_energyScaleStatDown=x; }
+  void set_energyScaleSystUp(float x) { m_energyScaleSystUp=x; }
+  void set_energyScaleSystDown(float x) { m_energyScaleSystDown=x; }
+  void set_energyScaleGainUp(float x) { m_energyScaleGainUp=x; }
+  void set_energyScaleGainDown(float x) { m_energyScaleGainDown=x; }
+  void set_energyScaleEtUp(float x) { m_energyScaleEtUp=x; }
+  void set_energyScaleEtDown(float x) { m_energyScaleEtDown=x; }
+  void set_energySigmaUp(float x) { m_energySigmaUp=x; }
+  void set_energySigmaDown(float x) { m_energySigmaDown=x; }
+  void set_energySigmaPhiUp(float x) { m_energySigmaPhiUp=x; }
+  void set_energySigmaPhiDown(float x) { m_energySigmaPhiDown=x; }
+  void set_energySigmaRhoUp(float x) { m_energySigmaRhoUp=x; }
+  void set_energySigmaRhoDown(float x) { m_energySigmaRhoDown=x; }
 
   float gsfTrack_dxy_vertex(const float point_x, const float point_y) const{
     return ( - (m_gsfTrack_vx-point_x) * m_gsfTrack_py + (m_gsfTrack_vy-point_y) * m_gsfTrack_px ) / sqrt(m_gsfTrack_px*m_gsfTrack_px+m_gsfTrack_py*m_gsfTrack_py);
@@ -391,4 +477,33 @@ class Electron : public RecParticle {
   float m_puppiNoLeptonsPhotonIso;
 
   float m_electronMVATOP;
+
+  // EGamma Residuals
+  float m_ecalEnergyPreCorr;
+  float m_ecalEnergyErrPreCorr;
+  float m_ecalEnergyPostCorr;
+  float m_ecalEnergyErrPostCorr;
+  float m_ecalTrkEnergyPreCorr;
+  float m_ecalTrkEnergyErrPreCorr;
+  float m_ecalTrkEnergyPostCorr;
+  float m_ecalTrkEnergyErrPostCorr;
+  float m_energyScaleValue;
+  float m_energySigmaValue;
+  float m_energySmearNrSigma;
+  float m_energyScaleUp;
+  float m_energyScaleDown;
+  float m_energyScaleStatUp;
+  float m_energyScaleStatDown;
+  float m_energyScaleSystUp;
+  float m_energyScaleSystDown;
+  float m_energyScaleGainUp;
+  float m_energyScaleGainDown;
+  float m_energyScaleEtUp;
+  float m_energyScaleEtDown;
+  float m_energySigmaUp;
+  float m_energySigmaDown;
+  float m_energySigmaPhiUp;
+  float m_energySigmaPhiDown;
+  float m_energySigmaRhoUp;
+  float m_energySigmaRhoDown;
 };

--- a/core/include/Electron.h
+++ b/core/include/Electron.h
@@ -32,7 +32,37 @@ class Electron : public RecParticle {
     mvaEleID_Fall17_noIso_V2_wpLoose,
     mvaEleID_Fall17_iso_V2_wp90,
     mvaEleID_Fall17_iso_V2_wp80,
-    mvaEleID_Fall17_iso_V2_wpLoose
+    mvaEleID_Fall17_iso_V2_wpLoose,
+
+    // EGamma Residuals
+    // In general it would be better to implement these corrections as usual class members: see commented out code below. But we use the "Tags" solution here for backwards compatibility with older ntuples of the RunII_106X_v2 branch.
+    residual_ecalEnergyPreCorr,
+    residual_ecalEnergyErrPreCorr,
+    residual_ecalEnergyPostCorr,
+    residual_ecalEnergyErrPostCorr,
+    residual_ecalTrkEnergyPreCorr,
+    residual_ecalTrkEnergyErrPreCorr,
+    residual_ecalTrkEnergyPostCorr,
+    residual_ecalTrkEnergyErrPostCorr,
+    residual_energyScaleValue,
+    residual_energySigmaValue,
+    residual_energySmearNrSigma,
+    residual_energyScaleUp,
+    residual_energyScaleDown,
+    residual_energyScaleStatUp,
+    residual_energyScaleStatDown,
+    residual_energyScaleSystUp,
+    residual_energyScaleSystDown,
+    residual_energyScaleGainUp,
+    residual_energyScaleGainDown,
+    residual_energyScaleEtUp,
+    residual_energyScaleEtDown,
+    residual_energySigmaUp,
+    residual_energySigmaDown,
+    residual_energySigmaPhiUp,
+    residual_energySigmaPhiDown,
+    residual_energySigmaRhoUp,
+    residual_energySigmaRhoDown,
   };
 
   static tag tagname2tag(const std::string & tagname){
@@ -54,6 +84,36 @@ class Electron : public RecParticle {
     if(tagname == "mvaEleID-Fall17-iso-V2-wp90") return mvaEleID_Fall17_iso_V2_wp90;
     if(tagname == "mvaEleID-Fall17-iso-V2-wp80") return mvaEleID_Fall17_iso_V2_wp80;
     if(tagname == "mvaEleID-Fall17-iso-V2-wpLoose") return mvaEleID_Fall17_iso_V2_wpLoose;
+
+    // EGamma Residuals
+    if(tagname == "residual_ecalEnergyPreCorr") return residual_ecalEnergyPreCorr;
+    if(tagname == "residual_ecalEnergyErrPreCorr") return residual_ecalEnergyErrPreCorr;
+    if(tagname == "residual_ecalEnergyPostCorr") return residual_ecalEnergyPostCorr;
+    if(tagname == "residual_ecalEnergyErrPostCorr") return residual_ecalEnergyErrPostCorr;
+    if(tagname == "residual_ecalTrkEnergyPreCorr") return residual_ecalTrkEnergyPreCorr;
+    if(tagname == "residual_ecalTrkEnergyErrPreCorr") return residual_ecalTrkEnergyErrPreCorr;
+    if(tagname == "residual_ecalTrkEnergyPostCorr") return residual_ecalTrkEnergyPostCorr;
+    if(tagname == "residual_ecalTrkEnergyErrPostCorr") return residual_ecalTrkEnergyErrPostCorr;
+    if(tagname == "residual_energyScaleValue") return residual_energyScaleValue;
+    if(tagname == "residual_energySigmaValue") return residual_energySigmaValue;
+    if(tagname == "residual_energySmearNrSigma") return residual_energySmearNrSigma;
+    if(tagname == "residual_energyScaleUp") return residual_energyScaleUp;
+    if(tagname == "residual_energyScaleDown") return residual_energyScaleDown;
+    if(tagname == "residual_energyScaleStatUp") return residual_energyScaleStatUp;
+    if(tagname == "residual_energyScaleStatDown") return residual_energyScaleStatDown;
+    if(tagname == "residual_energyScaleSystUp") return residual_energyScaleSystUp;
+    if(tagname == "residual_energyScaleSystDown") return residual_energyScaleSystDown;
+    if(tagname == "residual_energyScaleGainUp") return residual_energyScaleGainUp;
+    if(tagname == "residual_energyScaleGainDown") return residual_energyScaleGainDown;
+    if(tagname == "residual_energyScaleEtUp") return residual_energyScaleEtUp;
+    if(tagname == "residual_energyScaleEtDown") return residual_energyScaleEtDown;
+    if(tagname == "residual_energySigmaUp") return residual_energySigmaUp;
+    if(tagname == "residual_energySigmaDown") return residual_energySigmaDown;
+    if(tagname == "residual_energySigmaPhiUp") return residual_energySigmaPhiUp;
+    if(tagname == "residual_energySigmaPhiDown") return residual_energySigmaPhiDown;
+    if(tagname == "residual_energySigmaRhoUp") return residual_energySigmaRhoUp;
+    if(tagname == "residual_energySigmaRhoDown") return residual_energySigmaRhoDown;
+
     throw std::runtime_error("unknown Electron::tag '" + tagname + "'");
   }
 
@@ -133,6 +193,7 @@ class Electron : public RecParticle {
     m_electronMVATOP = -99;
 
     // EGamma Residuals
+    /*
     m_ecalEnergyPreCorr = -99;
     m_ecalEnergyErrPreCorr = -99;
     m_ecalEnergyPostCorr = -99;
@@ -160,6 +221,7 @@ class Electron : public RecParticle {
     m_energySigmaPhiDown = -99;
     m_energySigmaRhoUp = -99;
     m_energySigmaRhoDown = -99;
+    */
   }
 
   float supercluster_eta() const{return m_supercluster_eta;}
@@ -224,6 +286,7 @@ class Electron : public RecParticle {
   float electronMVATOP()                      const { return m_electronMVATOP;}
 
   // EGamma Residuals
+  /*
   float ecalEnergyPreCorr() const { return m_ecalEnergyPreCorr; }
   float ecalEnergyErrPreCorr() const { return m_ecalEnergyErrPreCorr; }
   float ecalEnergyPostCorr() const { return m_ecalEnergyPostCorr; }
@@ -251,6 +314,7 @@ class Electron : public RecParticle {
   float energySigmaPhiDown() const { return m_energySigmaPhiDown; }
   float energySigmaRhoUp() const { return m_energySigmaRhoUp; }
   float energySigmaRhoDown() const { return m_energySigmaRhoDown; }
+  */
 
   const std::vector<source_candidate>& source_candidates() const { return m_source_candidates; }
 
@@ -331,6 +395,7 @@ class Electron : public RecParticle {
   void set_puppiNoLeptonsPhotonIso(float x)          { m_puppiNoLeptonsPhotonIso=x;}
 
   // EGamma Residuals
+  /*
   void set_ecalEnergyPreCorr(float x) { m_ecalEnergyPreCorr=x; }
   void set_ecalEnergyErrPreCorr(float x) { m_ecalEnergyErrPreCorr=x; }
   void set_ecalEnergyPostCorr(float x) { m_ecalEnergyPostCorr=x; }
@@ -358,6 +423,7 @@ class Electron : public RecParticle {
   void set_energySigmaPhiDown(float x) { m_energySigmaPhiDown=x; }
   void set_energySigmaRhoUp(float x) { m_energySigmaRhoUp=x; }
   void set_energySigmaRhoDown(float x) { m_energySigmaRhoDown=x; }
+  */
 
   float gsfTrack_dxy_vertex(const float point_x, const float point_y) const{
     return ( - (m_gsfTrack_vx-point_x) * m_gsfTrack_py + (m_gsfTrack_vy-point_y) * m_gsfTrack_px ) / sqrt(m_gsfTrack_px*m_gsfTrack_px+m_gsfTrack_py*m_gsfTrack_py);
@@ -479,6 +545,7 @@ class Electron : public RecParticle {
   float m_electronMVATOP;
 
   // EGamma Residuals
+  /*
   float m_ecalEnergyPreCorr;
   float m_ecalEnergyErrPreCorr;
   float m_ecalEnergyPostCorr;
@@ -506,4 +573,5 @@ class Electron : public RecParticle {
   float m_energySigmaPhiDown;
   float m_energySigmaRhoUp;
   float m_energySigmaRhoDown;
+  */
 };

--- a/core/include/Photon.h
+++ b/core/include/Photon.h
@@ -22,7 +22,37 @@ public:
     cutBasedPhotonID_Fall17_94X_V2_medium,
     cutBasedPhotonID_Fall17_94X_V2_tight,
     mvaPhoID_Fall17_iso_V2_wp90,
-    mvaPhoID_Fall17_iso_V2_wp80
+    mvaPhoID_Fall17_iso_V2_wp80,
+
+    // EGamma Residuals
+    // In general it would be better to implement these corrections as usual class members: see commented out code below. But we use the "Tags" solution here for backwards compatibility with older ntuples of the RunII_106X_v2 branch.
+    residual_ecalEnergyPreCorr,
+    residual_ecalEnergyErrPreCorr,
+    residual_ecalEnergyPostCorr,
+    residual_ecalEnergyErrPostCorr,
+    residual_ecalTrkEnergyPreCorr,
+    residual_ecalTrkEnergyErrPreCorr,
+    residual_ecalTrkEnergyPostCorr,
+    residual_ecalTrkEnergyErrPostCorr,
+    residual_energyScaleValue,
+    residual_energySigmaValue,
+    residual_energySmearNrSigma,
+    residual_energyScaleUp,
+    residual_energyScaleDown,
+    residual_energyScaleStatUp,
+    residual_energyScaleStatDown,
+    residual_energyScaleSystUp,
+    residual_energyScaleSystDown,
+    residual_energyScaleGainUp,
+    residual_energyScaleGainDown,
+    residual_energyScaleEtUp,
+    residual_energyScaleEtDown,
+    residual_energySigmaUp,
+    residual_energySigmaDown,
+    residual_energySigmaPhiUp,
+    residual_energySigmaPhiDown,
+    residual_energySigmaRhoUp,
+    residual_energySigmaRhoDown,
   };
 
   static tag tagname2tag(const std::string & tagname){
@@ -36,6 +66,36 @@ public:
     if(tagname == "cutBasedPhotonID-Fall17-94X-V2-tight") return cutBasedPhotonID_Fall17_94X_V2_tight;
     if(tagname == "mvaPhoID-RunIIFall17-v2-wp90") return mvaPhoID_Fall17_iso_V2_wp90;
     if(tagname == "mvaPhoID-RunIIFall17-v2-wp80") return mvaPhoID_Fall17_iso_V2_wp80;
+
+    // EGamma Residuals
+    if(tagname == "residual_ecalEnergyPreCorr") return residual_ecalEnergyPreCorr;
+    if(tagname == "residual_ecalEnergyErrPreCorr") return residual_ecalEnergyErrPreCorr;
+    if(tagname == "residual_ecalEnergyPostCorr") return residual_ecalEnergyPostCorr;
+    if(tagname == "residual_ecalEnergyErrPostCorr") return residual_ecalEnergyErrPostCorr;
+    if(tagname == "residual_ecalTrkEnergyPreCorr") return residual_ecalTrkEnergyPreCorr;
+    if(tagname == "residual_ecalTrkEnergyErrPreCorr") return residual_ecalTrkEnergyErrPreCorr;
+    if(tagname == "residual_ecalTrkEnergyPostCorr") return residual_ecalTrkEnergyPostCorr;
+    if(tagname == "residual_ecalTrkEnergyErrPostCorr") return residual_ecalTrkEnergyErrPostCorr;
+    if(tagname == "residual_energyScaleValue") return residual_energyScaleValue;
+    if(tagname == "residual_energySigmaValue") return residual_energySigmaValue;
+    if(tagname == "residual_energySmearNrSigma") return residual_energySmearNrSigma;
+    if(tagname == "residual_energyScaleUp") return residual_energyScaleUp;
+    if(tagname == "residual_energyScaleDown") return residual_energyScaleDown;
+    if(tagname == "residual_energyScaleStatUp") return residual_energyScaleStatUp;
+    if(tagname == "residual_energyScaleStatDown") return residual_energyScaleStatDown;
+    if(tagname == "residual_energyScaleSystUp") return residual_energyScaleSystUp;
+    if(tagname == "residual_energyScaleSystDown") return residual_energyScaleSystDown;
+    if(tagname == "residual_energyScaleGainUp") return residual_energyScaleGainUp;
+    if(tagname == "residual_energyScaleGainDown") return residual_energyScaleGainDown;
+    if(tagname == "residual_energyScaleEtUp") return residual_energyScaleEtUp;
+    if(tagname == "residual_energyScaleEtDown") return residual_energyScaleEtDown;
+    if(tagname == "residual_energySigmaUp") return residual_energySigmaUp;
+    if(tagname == "residual_energySigmaDown") return residual_energySigmaDown;
+    if(tagname == "residual_energySigmaPhiUp") return residual_energySigmaPhiUp;
+    if(tagname == "residual_energySigmaPhiDown") return residual_energySigmaPhiDown;
+    if(tagname == "residual_energySigmaRhoUp") return residual_energySigmaRhoUp;
+    if(tagname == "residual_energySigmaRhoDown") return residual_energySigmaRhoDown;
+
     throw std::runtime_error("unknown Photon::tag '" + tagname + "'");
   }
 
@@ -62,6 +122,7 @@ public:
     m_minDeltaRToL1EGamma = 10.;
 
     // EGamma Residuals
+    /*
     m_ecalEnergyPreCorr = -99;
     m_ecalEnergyErrPreCorr = -99;
     m_ecalEnergyPostCorr = -99;
@@ -89,6 +150,7 @@ public:
     m_energySigmaPhiDown = -99;
     m_energySigmaRhoUp = -99;
     m_energySigmaRhoDown = -99;
+    */
 
     m_source_candidates.clear();
   }
@@ -118,6 +180,7 @@ public:
   //  float get_tag(tag t) const{ return tags.get_tag(static_cast<int>(t));}
 
   // EGamma Residuals
+  /*
   float ecalEnergyPreCorr() const { return m_ecalEnergyPreCorr; }
   float ecalEnergyErrPreCorr() const { return m_ecalEnergyErrPreCorr; }
   float ecalEnergyPostCorr() const { return m_ecalEnergyPostCorr; }
@@ -145,6 +208,7 @@ public:
   float energySigmaPhiDown() const { return m_energySigmaPhiDown; }
   float energySigmaRhoUp() const { return m_energySigmaRhoUp; }
   float energySigmaRhoDown() const { return m_energySigmaRhoDown; }
+  */
 
   void set_vertex_x(float x){m_vertex_x=x;}
   void set_vertex_y(float x){m_vertex_y=x;}
@@ -178,6 +242,7 @@ public:
   void  set_tag(tag t, float value) { tags.set_tag(static_cast<int>(t), value);}
 
   // EGamma Residuals
+  /*
   void set_ecalEnergyPreCorr(float x) { m_ecalEnergyPreCorr=x; }
   void set_ecalEnergyErrPreCorr(float x) { m_ecalEnergyErrPreCorr=x; }
   void set_ecalEnergyPostCorr(float x) { m_ecalEnergyPostCorr=x; }
@@ -205,6 +270,7 @@ public:
   void set_energySigmaPhiDown(float x) { m_energySigmaPhiDown=x; }
   void set_energySigmaRhoUp(float x) { m_energySigmaRhoUp=x; }
   void set_energySigmaRhoDown(float x) { m_energySigmaRhoDown=x; }
+  */
 
 private:
   float m_vertex_x;
@@ -235,6 +301,7 @@ private:
   Tags tags;
 
   // EGamma Residuals
+  /*
   float m_ecalEnergyPreCorr;
   float m_ecalEnergyErrPreCorr;
   float m_ecalEnergyPostCorr;
@@ -262,4 +329,5 @@ private:
   float m_energySigmaPhiDown;
   float m_energySigmaRhoUp;
   float m_energySigmaRhoDown;
+  */
 };

--- a/core/include/Photon.h
+++ b/core/include/Photon.h
@@ -61,6 +61,35 @@ public:
 
     m_minDeltaRToL1EGamma = 10.;
 
+    // EGamma Residuals
+    m_ecalEnergyPreCorr = -99;
+    m_ecalEnergyErrPreCorr = -99;
+    m_ecalEnergyPostCorr = -99;
+    m_ecalEnergyErrPostCorr = -99;
+    m_ecalTrkEnergyPreCorr = -99;
+    m_ecalTrkEnergyErrPreCorr = -99;
+    m_ecalTrkEnergyPostCorr = -99;
+    m_ecalTrkEnergyErrPostCorr = -99;
+    m_energyScaleValue = -99;
+    m_energySigmaValue = -99;
+    m_energySmearNrSigma = -99;
+    m_energyScaleUp = -99;
+    m_energyScaleDown = -99;
+    m_energyScaleStatUp = -99;
+    m_energyScaleStatDown = -99;
+    m_energyScaleSystUp = -99;
+    m_energyScaleSystDown = -99;
+    m_energyScaleGainUp = -99;
+    m_energyScaleGainDown = -99;
+    m_energyScaleEtUp = -99;
+    m_energyScaleEtDown = -99;
+    m_energySigmaUp = -99;
+    m_energySigmaDown = -99;
+    m_energySigmaPhiUp = -99;
+    m_energySigmaPhiDown = -99;
+    m_energySigmaRhoUp = -99;
+    m_energySigmaRhoDown = -99;
+
     m_source_candidates.clear();
   }
 
@@ -87,6 +116,35 @@ public:
   double minDeltaRToL1EGamma() const{return m_minDeltaRToL1EGamma;}
 
   //  float get_tag(tag t) const{ return tags.get_tag(static_cast<int>(t));}
+
+  // EGamma Residuals
+  float ecalEnergyPreCorr() const { return m_ecalEnergyPreCorr; }
+  float ecalEnergyErrPreCorr() const { return m_ecalEnergyErrPreCorr; }
+  float ecalEnergyPostCorr() const { return m_ecalEnergyPostCorr; }
+  float ecalEnergyErrPostCorr() const { return m_ecalEnergyErrPostCorr; }
+  float ecalTrkEnergyPreCorr() const { return m_ecalTrkEnergyPreCorr; }
+  float ecalTrkEnergyErrPreCorr() const { return m_ecalTrkEnergyErrPreCorr; }
+  float ecalTrkEnergyPostCorr() const { return m_ecalTrkEnergyPostCorr; }
+  float ecalTrkEnergyErrPostCorr() const { return m_ecalTrkEnergyErrPostCorr; }
+  float energyScaleValue() const { return m_energyScaleValue; }
+  float energySigmaValue() const { return m_energySigmaValue; }
+  float energySmearNrSigma() const { return m_energySmearNrSigma; }
+  float energyScaleUp() const { return m_energyScaleUp; }
+  float energyScaleDown() const { return m_energyScaleDown; }
+  float energyScaleStatUp() const { return m_energyScaleStatUp; }
+  float energyScaleStatDown() const { return m_energyScaleStatDown; }
+  float energyScaleSystUp() const { return m_energyScaleSystUp; }
+  float energyScaleSystDown() const { return m_energyScaleSystDown; }
+  float energyScaleGainUp() const { return m_energyScaleGainUp; }
+  float energyScaleGainDown() const { return m_energyScaleGainDown; }
+  float energyScaleEtUp() const { return m_energyScaleEtUp; }
+  float energyScaleEtDown() const { return m_energyScaleEtDown; }
+  float energySigmaUp() const { return m_energySigmaUp; }
+  float energySigmaDown() const { return m_energySigmaDown; }
+  float energySigmaPhiUp() const { return m_energySigmaPhiUp; }
+  float energySigmaPhiDown() const { return m_energySigmaPhiDown; }
+  float energySigmaRhoUp() const { return m_energySigmaRhoUp; }
+  float energySigmaRhoDown() const { return m_energySigmaRhoDown; }
 
   void set_vertex_x(float x){m_vertex_x=x;}
   void set_vertex_y(float x){m_vertex_y=x;}
@@ -119,6 +177,35 @@ public:
   float get_tag(tag t) const { return tags.get_tag(static_cast<int>(t)); }
   void  set_tag(tag t, float value) { tags.set_tag(static_cast<int>(t), value);}
 
+  // EGamma Residuals
+  void set_ecalEnergyPreCorr(float x) { m_ecalEnergyPreCorr=x; }
+  void set_ecalEnergyErrPreCorr(float x) { m_ecalEnergyErrPreCorr=x; }
+  void set_ecalEnergyPostCorr(float x) { m_ecalEnergyPostCorr=x; }
+  void set_ecalEnergyErrPostCorr(float x) { m_ecalEnergyErrPostCorr=x; }
+  void set_ecalTrkEnergyPreCorr(float x) { m_ecalTrkEnergyPreCorr=x; }
+  void set_ecalTrkEnergyErrPreCorr(float x) { m_ecalTrkEnergyErrPreCorr=x; }
+  void set_ecalTrkEnergyPostCorr(float x) { m_ecalTrkEnergyPostCorr=x; }
+  void set_ecalTrkEnergyErrPostCorr(float x) { m_ecalTrkEnergyErrPostCorr=x; }
+  void set_energyScaleValue(float x) { m_energyScaleValue=x; }
+  void set_energySigmaValue(float x) { m_energySigmaValue=x; }
+  void set_energySmearNrSigma(float x) { m_energySmearNrSigma=x; }
+  void set_energyScaleUp(float x) { m_energyScaleUp=x; }
+  void set_energyScaleDown(float x) { m_energyScaleDown=x; }
+  void set_energyScaleStatUp(float x) { m_energyScaleStatUp=x; }
+  void set_energyScaleStatDown(float x) { m_energyScaleStatDown=x; }
+  void set_energyScaleSystUp(float x) { m_energyScaleSystUp=x; }
+  void set_energyScaleSystDown(float x) { m_energyScaleSystDown=x; }
+  void set_energyScaleGainUp(float x) { m_energyScaleGainUp=x; }
+  void set_energyScaleGainDown(float x) { m_energyScaleGainDown=x; }
+  void set_energyScaleEtUp(float x) { m_energyScaleEtUp=x; }
+  void set_energyScaleEtDown(float x) { m_energyScaleEtDown=x; }
+  void set_energySigmaUp(float x) { m_energySigmaUp=x; }
+  void set_energySigmaDown(float x) { m_energySigmaDown=x; }
+  void set_energySigmaPhiUp(float x) { m_energySigmaPhiUp=x; }
+  void set_energySigmaPhiDown(float x) { m_energySigmaPhiDown=x; }
+  void set_energySigmaRhoUp(float x) { m_energySigmaRhoUp=x; }
+  void set_energySigmaRhoDown(float x) { m_energySigmaRhoDown=x; }
+
 private:
   float m_vertex_x;
   float m_vertex_y;
@@ -146,4 +233,33 @@ private:
   std::vector<source_candidate> m_source_candidates;
 
   Tags tags;
+
+  // EGamma Residuals
+  float m_ecalEnergyPreCorr;
+  float m_ecalEnergyErrPreCorr;
+  float m_ecalEnergyPostCorr;
+  float m_ecalEnergyErrPostCorr;
+  float m_ecalTrkEnergyPreCorr;
+  float m_ecalTrkEnergyErrPreCorr;
+  float m_ecalTrkEnergyPostCorr;
+  float m_ecalTrkEnergyErrPostCorr;
+  float m_energyScaleValue;
+  float m_energySigmaValue;
+  float m_energySmearNrSigma;
+  float m_energyScaleUp;
+  float m_energyScaleDown;
+  float m_energyScaleStatUp;
+  float m_energyScaleStatDown;
+  float m_energyScaleSystUp;
+  float m_energyScaleSystDown;
+  float m_energyScaleGainUp;
+  float m_energyScaleGainDown;
+  float m_energyScaleEtUp;
+  float m_energyScaleEtDown;
+  float m_energySigmaUp;
+  float m_energySigmaDown;
+  float m_energySigmaPhiUp;
+  float m_energySigmaPhiDown;
+  float m_energySigmaRhoUp;
+  float m_energySigmaRhoDown;
 };

--- a/core/plugins/NtupleWriterLeptons.cxx
+++ b/core/plugins/NtupleWriterLeptons.cxx
@@ -138,6 +138,7 @@ void NtupleWriterElectrons::process(const edm::Event & event, uhh2::Event & ueve
     ele.set_puppiNoLeptonsPhotonIso(pat_ele.puppiNoLeptonsPhotonIso());
 
     // EGamma Residuals
+    /*
     ele.set_ecalEnergyPreCorr(pat_ele.hasUserFloat("ecalEnergyPreCorr")?pat_ele.userFloat("ecalEnergyPreCorr"):-999.);
     ele.set_ecalEnergyErrPreCorr(pat_ele.hasUserFloat("ecalEnergyErrPreCorr")?pat_ele.userFloat("ecalEnergyErrPreCorr"):-999.);
     ele.set_ecalEnergyPostCorr(pat_ele.hasUserFloat("ecalEnergyPostCorr")?pat_ele.userFloat("ecalEnergyPostCorr"):-999.);
@@ -165,7 +166,35 @@ void NtupleWriterElectrons::process(const edm::Event & event, uhh2::Event & ueve
     ele.set_energySigmaPhiDown(pat_ele.hasUserFloat("energySigmaPhiDown")?pat_ele.userFloat("energySigmaPhiDown"):-999.);
     ele.set_energySigmaRhoUp(pat_ele.hasUserFloat("energySigmaRhoUp")?pat_ele.userFloat("energySigmaRhoUp"):-999.);
     ele.set_energySigmaRhoDown(pat_ele.hasUserFloat("energySigmaRhoDown")?pat_ele.userFloat("energySigmaRhoDown"):-999.);
+    */
 
+    ele.set_tag(Electron::tag::residual_ecalEnergyPreCorr, float(pat_ele.hasUserFloat("ecalEnergyPreCorr")?pat_ele.userFloat("ecalEnergyPreCorr"):-999.));
+    ele.set_tag(Electron::tag::residual_ecalEnergyErrPreCorr, float(pat_ele.hasUserFloat("ecalEnergyErrPreCorr")?pat_ele.userFloat("ecalEnergyErrPreCorr"):-999.));
+    ele.set_tag(Electron::tag::residual_ecalEnergyPostCorr, float(pat_ele.hasUserFloat("ecalEnergyPostCorr")?pat_ele.userFloat("ecalEnergyPostCorr"):-999.));
+    ele.set_tag(Electron::tag::residual_ecalEnergyErrPostCorr, float(pat_ele.hasUserFloat("ecalEnergyErrPostCorr")?pat_ele.userFloat("ecalEnergyErrPostCorr"):-999.));
+    ele.set_tag(Electron::tag::residual_ecalTrkEnergyPreCorr, float(pat_ele.hasUserFloat("ecalTrkEnergyPreCorr")?pat_ele.userFloat("ecalTrkEnergyPreCorr"):-999.));
+    ele.set_tag(Electron::tag::residual_ecalTrkEnergyErrPreCorr, float(pat_ele.hasUserFloat("ecalTrkEnergyErrPreCorr")?pat_ele.userFloat("ecalTrkEnergyErrPreCorr"):-999.));
+    ele.set_tag(Electron::tag::residual_ecalTrkEnergyPostCorr, float(pat_ele.hasUserFloat("ecalTrkEnergyPostCorr")?pat_ele.userFloat("ecalTrkEnergyPostCorr"):-999.));
+    ele.set_tag(Electron::tag::residual_ecalTrkEnergyErrPostCorr, float(pat_ele.hasUserFloat("ecalTrkEnergyErrPostCorr")?pat_ele.userFloat("ecalTrkEnergyErrPostCorr"):-999.));
+    ele.set_tag(Electron::tag::residual_energyScaleValue, float(pat_ele.hasUserFloat("energyScaleValue")?pat_ele.userFloat("energyScaleValue"):-999.));
+    ele.set_tag(Electron::tag::residual_energySigmaValue, float(pat_ele.hasUserFloat("energySigmaValue")?pat_ele.userFloat("energySigmaValue"):-999.));
+    ele.set_tag(Electron::tag::residual_energySmearNrSigma, float(pat_ele.hasUserFloat("energySmearNrSigma")?pat_ele.userFloat("energySmearNrSigma"):-999.));
+    ele.set_tag(Electron::tag::residual_energyScaleUp, float(pat_ele.hasUserFloat("energyScaleUp")?pat_ele.userFloat("energyScaleUp"):-999.));
+    ele.set_tag(Electron::tag::residual_energyScaleDown, float(pat_ele.hasUserFloat("energyScaleDown")?pat_ele.userFloat("energyScaleDown"):-999.));
+    ele.set_tag(Electron::tag::residual_energyScaleStatUp, float(pat_ele.hasUserFloat("energyScaleStatUp")?pat_ele.userFloat("energyScaleStatUp"):-999.));
+    ele.set_tag(Electron::tag::residual_energyScaleStatDown, float(pat_ele.hasUserFloat("energyScaleStatDown")?pat_ele.userFloat("energyScaleStatDown"):-999.));
+    ele.set_tag(Electron::tag::residual_energyScaleSystUp, float(pat_ele.hasUserFloat("energyScaleSystUp")?pat_ele.userFloat("energyScaleSystUp"):-999.));
+    ele.set_tag(Electron::tag::residual_energyScaleSystDown, float(pat_ele.hasUserFloat("energyScaleSystDown")?pat_ele.userFloat("energyScaleSystDown"):-999.));
+    ele.set_tag(Electron::tag::residual_energyScaleGainUp, float(pat_ele.hasUserFloat("energyScaleGainUp")?pat_ele.userFloat("energyScaleGainUp"):-999.));
+    ele.set_tag(Electron::tag::residual_energyScaleGainDown, float(pat_ele.hasUserFloat("energyScaleGainDown")?pat_ele.userFloat("energyScaleGainDown"):-999.));
+    ele.set_tag(Electron::tag::residual_energyScaleEtUp, float(pat_ele.hasUserFloat("energyScaleEtUp")?pat_ele.userFloat("energyScaleEtUp"):-999.));
+    ele.set_tag(Electron::tag::residual_energyScaleEtDown, float(pat_ele.hasUserFloat("energyScaleEtDown")?pat_ele.userFloat("energyScaleEtDown"):-999.));
+    ele.set_tag(Electron::tag::residual_energySigmaUp, float(pat_ele.hasUserFloat("energySigmaUp")?pat_ele.userFloat("energySigmaUp"):-999.));
+    ele.set_tag(Electron::tag::residual_energySigmaDown, float(pat_ele.hasUserFloat("energySigmaDown")?pat_ele.userFloat("energySigmaDown"):-999.));
+    ele.set_tag(Electron::tag::residual_energySigmaPhiUp, float(pat_ele.hasUserFloat("energySigmaPhiUp")?pat_ele.userFloat("energySigmaPhiUp"):-999.));
+    ele.set_tag(Electron::tag::residual_energySigmaPhiDown, float(pat_ele.hasUserFloat("energySigmaPhiDown")?pat_ele.userFloat("energySigmaPhiDown"):-999.));
+    ele.set_tag(Electron::tag::residual_energySigmaRhoUp, float(pat_ele.hasUserFloat("energySigmaRhoUp")?pat_ele.userFloat("energySigmaRhoUp"):-999.));
+    ele.set_tag(Electron::tag::residual_energySigmaRhoDown, float(pat_ele.hasUserFloat("energySigmaRhoDown")?pat_ele.userFloat("energySigmaRhoDown"):-999.));
 
     for(const auto& tag_str : IDtag_keys){
       if(!pat_ele.isElectronIDAvailable(tag_str)) throw cms::Exception("Missing Electron ID", "ElectronID not found: "+tag_str);
@@ -278,6 +307,7 @@ void NtupleWriterPhotons::process(const edm::Event & event, uhh2::Event & uevent
     }
 
     // EGamma Residuals
+    /*
     pho.set_ecalEnergyPreCorr(pat_pho.hasUserFloat("ecalEnergyPreCorr")?pat_pho.userFloat("ecalEnergyPreCorr"):-999.);
     pho.set_ecalEnergyErrPreCorr(pat_pho.hasUserFloat("ecalEnergyErrPreCorr")?pat_pho.userFloat("ecalEnergyErrPreCorr"):-999.);
     pho.set_ecalEnergyPostCorr(pat_pho.hasUserFloat("ecalEnergyPostCorr")?pat_pho.userFloat("ecalEnergyPostCorr"):-999.);
@@ -305,6 +335,35 @@ void NtupleWriterPhotons::process(const edm::Event & event, uhh2::Event & uevent
     pho.set_energySigmaPhiDown(pat_pho.hasUserFloat("energySigmaPhiDown")?pat_pho.userFloat("energySigmaPhiDown"):-999.);
     pho.set_energySigmaRhoUp(pat_pho.hasUserFloat("energySigmaRhoUp")?pat_pho.userFloat("energySigmaRhoUp"):-999.);
     pho.set_energySigmaRhoDown(pat_pho.hasUserFloat("energySigmaRhoDown")?pat_pho.userFloat("energySigmaRhoDown"):-999.);
+    */
+
+    pho.set_tag(Photon::tag::residual_ecalEnergyPreCorr, float(pat_pho.hasUserFloat("ecalEnergyPreCorr")?pat_pho.userFloat("ecalEnergyPreCorr"):-999.));
+    pho.set_tag(Photon::tag::residual_ecalEnergyErrPreCorr, float(pat_pho.hasUserFloat("ecalEnergyErrPreCorr")?pat_pho.userFloat("ecalEnergyErrPreCorr"):-999.));
+    pho.set_tag(Photon::tag::residual_ecalEnergyPostCorr, float(pat_pho.hasUserFloat("ecalEnergyPostCorr")?pat_pho.userFloat("ecalEnergyPostCorr"):-999.));
+    pho.set_tag(Photon::tag::residual_ecalEnergyErrPostCorr, float(pat_pho.hasUserFloat("ecalEnergyErrPostCorr")?pat_pho.userFloat("ecalEnergyErrPostCorr"):-999.));
+    pho.set_tag(Photon::tag::residual_ecalTrkEnergyPreCorr, float(pat_pho.hasUserFloat("ecalTrkEnergyPreCorr")?pat_pho.userFloat("ecalTrkEnergyPreCorr"):-999.));
+    pho.set_tag(Photon::tag::residual_ecalTrkEnergyErrPreCorr, float(pat_pho.hasUserFloat("ecalTrkEnergyErrPreCorr")?pat_pho.userFloat("ecalTrkEnergyErrPreCorr"):-999.));
+    pho.set_tag(Photon::tag::residual_ecalTrkEnergyPostCorr, float(pat_pho.hasUserFloat("ecalTrkEnergyPostCorr")?pat_pho.userFloat("ecalTrkEnergyPostCorr"):-999.));
+    pho.set_tag(Photon::tag::residual_ecalTrkEnergyErrPostCorr, float(pat_pho.hasUserFloat("ecalTrkEnergyErrPostCorr")?pat_pho.userFloat("ecalTrkEnergyErrPostCorr"):-999.));
+    pho.set_tag(Photon::tag::residual_energyScaleValue, float(pat_pho.hasUserFloat("energyScaleValue")?pat_pho.userFloat("energyScaleValue"):-999.));
+    pho.set_tag(Photon::tag::residual_energySigmaValue, float(pat_pho.hasUserFloat("energySigmaValue")?pat_pho.userFloat("energySigmaValue"):-999.));
+    pho.set_tag(Photon::tag::residual_energySmearNrSigma, float(pat_pho.hasUserFloat("energySmearNrSigma")?pat_pho.userFloat("energySmearNrSigma"):-999.));
+    pho.set_tag(Photon::tag::residual_energyScaleUp, float(pat_pho.hasUserFloat("energyScaleUp")?pat_pho.userFloat("energyScaleUp"):-999.));
+    pho.set_tag(Photon::tag::residual_energyScaleDown, float(pat_pho.hasUserFloat("energyScaleDown")?pat_pho.userFloat("energyScaleDown"):-999.));
+    pho.set_tag(Photon::tag::residual_energyScaleStatUp, float(pat_pho.hasUserFloat("energyScaleStatUp")?pat_pho.userFloat("energyScaleStatUp"):-999.));
+    pho.set_tag(Photon::tag::residual_energyScaleStatDown, float(pat_pho.hasUserFloat("energyScaleStatDown")?pat_pho.userFloat("energyScaleStatDown"):-999.));
+    pho.set_tag(Photon::tag::residual_energyScaleSystUp, float(pat_pho.hasUserFloat("energyScaleSystUp")?pat_pho.userFloat("energyScaleSystUp"):-999.));
+    pho.set_tag(Photon::tag::residual_energyScaleSystDown, float(pat_pho.hasUserFloat("energyScaleSystDown")?pat_pho.userFloat("energyScaleSystDown"):-999.));
+    pho.set_tag(Photon::tag::residual_energyScaleGainUp, float(pat_pho.hasUserFloat("energyScaleGainUp")?pat_pho.userFloat("energyScaleGainUp"):-999.));
+    pho.set_tag(Photon::tag::residual_energyScaleGainDown, float(pat_pho.hasUserFloat("energyScaleGainDown")?pat_pho.userFloat("energyScaleGainDown"):-999.));
+    pho.set_tag(Photon::tag::residual_energyScaleEtUp, float(pat_pho.hasUserFloat("energyScaleEtUp")?pat_pho.userFloat("energyScaleEtUp"):-999.));
+    pho.set_tag(Photon::tag::residual_energyScaleEtDown, float(pat_pho.hasUserFloat("energyScaleEtDown")?pat_pho.userFloat("energyScaleEtDown"):-999.));
+    pho.set_tag(Photon::tag::residual_energySigmaUp, float(pat_pho.hasUserFloat("energySigmaUp")?pat_pho.userFloat("energySigmaUp"):-999.));
+    pho.set_tag(Photon::tag::residual_energySigmaDown, float(pat_pho.hasUserFloat("energySigmaDown")?pat_pho.userFloat("energySigmaDown"):-999.));
+    pho.set_tag(Photon::tag::residual_energySigmaPhiUp, float(pat_pho.hasUserFloat("energySigmaPhiUp")?pat_pho.userFloat("energySigmaPhiUp"):-999.));
+    pho.set_tag(Photon::tag::residual_energySigmaPhiDown, float(pat_pho.hasUserFloat("energySigmaPhiDown")?pat_pho.userFloat("energySigmaPhiDown"):-999.));
+    pho.set_tag(Photon::tag::residual_energySigmaRhoUp, float(pat_pho.hasUserFloat("energySigmaRhoUp")?pat_pho.userFloat("energySigmaRhoUp"):-999.));
+    pho.set_tag(Photon::tag::residual_energySigmaRhoDown, float(pat_pho.hasUserFloat("energySigmaRhoDown")?pat_pho.userFloat("energySigmaRhoDown"):-999.));
 
     /* source candidates */
     if(save_source_candidates_){

--- a/core/plugins/NtupleWriterLeptons.cxx
+++ b/core/plugins/NtupleWriterLeptons.cxx
@@ -123,7 +123,7 @@ void NtupleWriterElectrons::process(const edm::Event & event, uhh2::Event & ueve
     ele.set_jetNDauChargedMVASel(pat_ele.hasUserCand("jetForLepJetVar")?pat_ele.userFloat("jetNDauChargedMVASel"):-999.);
     ele.set_pTRel(pat_ele.hasUserCand("jetForLepJetVar")?pat_ele.userFloat("ptRel"):-999.);
     ele.set_ptRatio(pat_ele.hasUserCand("jetForLepJetVar")?min(pat_ele.userFloat("ptRatio"),float(1.5)):-999.);
-    
+
     const pat::Jet* closestJet = nullptr;
     if (pat_ele.hasUserCand("jetForLepJetVar")){closestJet = dynamic_cast<const pat::Jet*>(pat_ele.userCand("jetForLepJetVar").get());}
     ele.set_bTagDeepJetClosestJet(closestJet?max(closestJet->bDiscriminator("pfDeepFlavourJetTags:probbb")+closestJet->bDiscriminator("pfDeepFlavourJetTags:probb")+closestJet->bDiscriminator("pfDeepFlavourJetTags:problepb"),float(0.0)):-1.);
@@ -131,11 +131,40 @@ void NtupleWriterElectrons::process(const edm::Event & event, uhh2::Event & ueve
     ele.set_electronMVATOP(pat_ele.hasUserFloat("mvaTOP")?pat_ele.userFloat("mvaTOP"):-999.);
 
     ele.set_puppiChargedHadronIso(pat_ele.puppiChargedHadronIso());
-    ele.set_puppiNeutralHadronIso(pat_ele.puppiNeutralHadronIso());          
-    ele.set_puppiPhotonIso(pat_ele.puppiPhotonIso());            
+    ele.set_puppiNeutralHadronIso(pat_ele.puppiNeutralHadronIso());
+    ele.set_puppiPhotonIso(pat_ele.puppiPhotonIso());
     ele.set_puppiNoLeptonsChargedHadronIso(pat_ele.puppiNoLeptonsChargedHadronIso());
-    ele.set_puppiNoLeptonsNeutralHadronIso(pat_ele.puppiNoLeptonsNeutralHadronIso()); 
-    ele.set_puppiNoLeptonsPhotonIso(pat_ele.puppiNoLeptonsPhotonIso());   
+    ele.set_puppiNoLeptonsNeutralHadronIso(pat_ele.puppiNoLeptonsNeutralHadronIso());
+    ele.set_puppiNoLeptonsPhotonIso(pat_ele.puppiNoLeptonsPhotonIso());
+
+    // EGamma Residuals
+    ele.set_ecalEnergyPreCorr(pat_ele.hasUserFloat("ecalEnergyPreCorr")?pat_ele.userFloat("ecalEnergyPreCorr"):-999.);
+    ele.set_ecalEnergyErrPreCorr(pat_ele.hasUserFloat("ecalEnergyErrPreCorr")?pat_ele.userFloat("ecalEnergyErrPreCorr"):-999.);
+    ele.set_ecalEnergyPostCorr(pat_ele.hasUserFloat("ecalEnergyPostCorr")?pat_ele.userFloat("ecalEnergyPostCorr"):-999.);
+    ele.set_ecalEnergyErrPostCorr(pat_ele.hasUserFloat("ecalEnergyErrPostCorr")?pat_ele.userFloat("ecalEnergyErrPostCorr"):-999.);
+    ele.set_ecalTrkEnergyPreCorr(pat_ele.hasUserFloat("ecalTrkEnergyPreCorr")?pat_ele.userFloat("ecalTrkEnergyPreCorr"):-999.);
+    ele.set_ecalTrkEnergyErrPreCorr(pat_ele.hasUserFloat("ecalTrkEnergyErrPreCorr")?pat_ele.userFloat("ecalTrkEnergyErrPreCorr"):-999.);
+    ele.set_ecalTrkEnergyPostCorr(pat_ele.hasUserFloat("ecalTrkEnergyPostCorr")?pat_ele.userFloat("ecalTrkEnergyPostCorr"):-999.);
+    ele.set_ecalTrkEnergyErrPostCorr(pat_ele.hasUserFloat("ecalTrkEnergyErrPostCorr")?pat_ele.userFloat("ecalTrkEnergyErrPostCorr"):-999.);
+    ele.set_energyScaleValue(pat_ele.hasUserFloat("energyScaleValue")?pat_ele.userFloat("energyScaleValue"):-999.);
+    ele.set_energySigmaValue(pat_ele.hasUserFloat("energySigmaValue")?pat_ele.userFloat("energySigmaValue"):-999.);
+    ele.set_energySmearNrSigma(pat_ele.hasUserFloat("energySmearNrSigma")?pat_ele.userFloat("energySmearNrSigma"):-999.);
+    ele.set_energyScaleUp(pat_ele.hasUserFloat("energyScaleUp")?pat_ele.userFloat("energyScaleUp"):-999.);
+    ele.set_energyScaleDown(pat_ele.hasUserFloat("energyScaleDown")?pat_ele.userFloat("energyScaleDown"):-999.);
+    ele.set_energyScaleStatUp(pat_ele.hasUserFloat("energyScaleStatUp")?pat_ele.userFloat("energyScaleStatUp"):-999.);
+    ele.set_energyScaleStatDown(pat_ele.hasUserFloat("energyScaleStatDown")?pat_ele.userFloat("energyScaleStatDown"):-999.);
+    ele.set_energyScaleSystUp(pat_ele.hasUserFloat("energyScaleSystUp")?pat_ele.userFloat("energyScaleSystUp"):-999.);
+    ele.set_energyScaleSystDown(pat_ele.hasUserFloat("energyScaleSystDown")?pat_ele.userFloat("energyScaleSystDown"):-999.);
+    ele.set_energyScaleGainUp(pat_ele.hasUserFloat("energyScaleGainUp")?pat_ele.userFloat("energyScaleGainUp"):-999.);
+    ele.set_energyScaleGainDown(pat_ele.hasUserFloat("energyScaleGainDown")?pat_ele.userFloat("energyScaleGainDown"):-999.);
+    ele.set_energyScaleEtUp(pat_ele.hasUserFloat("energyScaleEtUp")?pat_ele.userFloat("energyScaleEtUp"):-999.);
+    ele.set_energyScaleEtDown(pat_ele.hasUserFloat("energyScaleEtDown")?pat_ele.userFloat("energyScaleEtDown"):-999.);
+    ele.set_energySigmaUp(pat_ele.hasUserFloat("energySigmaUp")?pat_ele.userFloat("energySigmaUp"):-999.);
+    ele.set_energySigmaDown(pat_ele.hasUserFloat("energySigmaDown")?pat_ele.userFloat("energySigmaDown"):-999.);
+    ele.set_energySigmaPhiUp(pat_ele.hasUserFloat("energySigmaPhiUp")?pat_ele.userFloat("energySigmaPhiUp"):-999.);
+    ele.set_energySigmaPhiDown(pat_ele.hasUserFloat("energySigmaPhiDown")?pat_ele.userFloat("energySigmaPhiDown"):-999.);
+    ele.set_energySigmaRhoUp(pat_ele.hasUserFloat("energySigmaRhoUp")?pat_ele.userFloat("energySigmaRhoUp"):-999.);
+    ele.set_energySigmaRhoDown(pat_ele.hasUserFloat("energySigmaRhoDown")?pat_ele.userFloat("energySigmaRhoDown"):-999.);
 
 
     for(const auto& tag_str : IDtag_keys){
@@ -247,6 +276,35 @@ void NtupleWriterPhotons::process(const edm::Event & event, uhh2::Event & uevent
       double dR_recoPho_l1EGamma = reco::deltaR(pat_pho.eta(), pat_pho.phi(), itL1.p4().Eta(), itL1.p4().Phi());
       if(dR_recoPho_l1EGamma < pho.minDeltaRToL1EGamma()) pho.set_minDeltaRToL1EGamma(dR_recoPho_l1EGamma);
     }
+
+    // EGamma Residuals
+    pho.set_ecalEnergyPreCorr(pat_pho.hasUserFloat("ecalEnergyPreCorr")?pat_pho.userFloat("ecalEnergyPreCorr"):-999.);
+    pho.set_ecalEnergyErrPreCorr(pat_pho.hasUserFloat("ecalEnergyErrPreCorr")?pat_pho.userFloat("ecalEnergyErrPreCorr"):-999.);
+    pho.set_ecalEnergyPostCorr(pat_pho.hasUserFloat("ecalEnergyPostCorr")?pat_pho.userFloat("ecalEnergyPostCorr"):-999.);
+    pho.set_ecalEnergyErrPostCorr(pat_pho.hasUserFloat("ecalEnergyErrPostCorr")?pat_pho.userFloat("ecalEnergyErrPostCorr"):-999.);
+    pho.set_ecalTrkEnergyPreCorr(pat_pho.hasUserFloat("ecalTrkEnergyPreCorr")?pat_pho.userFloat("ecalTrkEnergyPreCorr"):-999.);
+    pho.set_ecalTrkEnergyErrPreCorr(pat_pho.hasUserFloat("ecalTrkEnergyErrPreCorr")?pat_pho.userFloat("ecalTrkEnergyErrPreCorr"):-999.);
+    pho.set_ecalTrkEnergyPostCorr(pat_pho.hasUserFloat("ecalTrkEnergyPostCorr")?pat_pho.userFloat("ecalTrkEnergyPostCorr"):-999.);
+    pho.set_ecalTrkEnergyErrPostCorr(pat_pho.hasUserFloat("ecalTrkEnergyErrPostCorr")?pat_pho.userFloat("ecalTrkEnergyErrPostCorr"):-999.);
+    pho.set_energyScaleValue(pat_pho.hasUserFloat("energyScaleValue")?pat_pho.userFloat("energyScaleValue"):-999.);
+    pho.set_energySigmaValue(pat_pho.hasUserFloat("energySigmaValue")?pat_pho.userFloat("energySigmaValue"):-999.);
+    pho.set_energySmearNrSigma(pat_pho.hasUserFloat("energySmearNrSigma")?pat_pho.userFloat("energySmearNrSigma"):-999.);
+    pho.set_energyScaleUp(pat_pho.hasUserFloat("energyScaleUp")?pat_pho.userFloat("energyScaleUp"):-999.);
+    pho.set_energyScaleDown(pat_pho.hasUserFloat("energyScaleDown")?pat_pho.userFloat("energyScaleDown"):-999.);
+    pho.set_energyScaleStatUp(pat_pho.hasUserFloat("energyScaleStatUp")?pat_pho.userFloat("energyScaleStatUp"):-999.);
+    pho.set_energyScaleStatDown(pat_pho.hasUserFloat("energyScaleStatDown")?pat_pho.userFloat("energyScaleStatDown"):-999.);
+    pho.set_energyScaleSystUp(pat_pho.hasUserFloat("energyScaleSystUp")?pat_pho.userFloat("energyScaleSystUp"):-999.);
+    pho.set_energyScaleSystDown(pat_pho.hasUserFloat("energyScaleSystDown")?pat_pho.userFloat("energyScaleSystDown"):-999.);
+    pho.set_energyScaleGainUp(pat_pho.hasUserFloat("energyScaleGainUp")?pat_pho.userFloat("energyScaleGainUp"):-999.);
+    pho.set_energyScaleGainDown(pat_pho.hasUserFloat("energyScaleGainDown")?pat_pho.userFloat("energyScaleGainDown"):-999.);
+    pho.set_energyScaleEtUp(pat_pho.hasUserFloat("energyScaleEtUp")?pat_pho.userFloat("energyScaleEtUp"):-999.);
+    pho.set_energyScaleEtDown(pat_pho.hasUserFloat("energyScaleEtDown")?pat_pho.userFloat("energyScaleEtDown"):-999.);
+    pho.set_energySigmaUp(pat_pho.hasUserFloat("energySigmaUp")?pat_pho.userFloat("energySigmaUp"):-999.);
+    pho.set_energySigmaDown(pat_pho.hasUserFloat("energySigmaDown")?pat_pho.userFloat("energySigmaDown"):-999.);
+    pho.set_energySigmaPhiUp(pat_pho.hasUserFloat("energySigmaPhiUp")?pat_pho.userFloat("energySigmaPhiUp"):-999.);
+    pho.set_energySigmaPhiDown(pat_pho.hasUserFloat("energySigmaPhiDown")?pat_pho.userFloat("energySigmaPhiDown"):-999.);
+    pho.set_energySigmaRhoUp(pat_pho.hasUserFloat("energySigmaRhoUp")?pat_pho.userFloat("energySigmaRhoUp"):-999.);
+    pho.set_energySigmaRhoDown(pat_pho.hasUserFloat("energySigmaRhoDown")?pat_pho.userFloat("energySigmaRhoDown"):-999.);
 
     /* source candidates */
     if(save_source_candidates_){
@@ -411,11 +469,11 @@ void NtupleWriterMuons::process(const edm::Event & event, uhh2::Event & uevent, 
     mu.set_dzlog(log(abs(pat_mu.dB(pat::Muon::PVDZ))));
 
     mu.set_puppiChargedHadronIso(pat_mu.puppiChargedHadronIso());
-    mu.set_puppiNeutralHadronIso(pat_mu.puppiNeutralHadronIso());          
-    mu.set_puppiPhotonIso(pat_mu.puppiPhotonIso());            
+    mu.set_puppiNeutralHadronIso(pat_mu.puppiNeutralHadronIso());
+    mu.set_puppiPhotonIso(pat_mu.puppiPhotonIso());
     mu.set_puppiNoLeptonsChargedHadronIso(pat_mu.puppiNoLeptonsChargedHadronIso());
-    mu.set_puppiNoLeptonsNeutralHadronIso(pat_mu.puppiNoLeptonsNeutralHadronIso()); 
-    mu.set_puppiNoLeptonsPhotonIso(pat_mu.puppiNoLeptonsPhotonIso());   
+    mu.set_puppiNoLeptonsNeutralHadronIso(pat_mu.puppiNoLeptonsNeutralHadronIso());
+    mu.set_puppiNoLeptonsPhotonIso(pat_mu.puppiNoLeptonsPhotonIso());
 
     mu.set_jetNDauChargedMVASel(pat_mu.hasUserCand("jetForLepJetVar")?pat_mu.userFloat("jetNDauChargedMVASel"):-999.);
     mu.set_pTRel(pat_mu.hasUserCand("jetForLepJetVar")?pat_mu.userFloat("ptRel"):-999.);

--- a/core/python/ntuple_generator.py
+++ b/core/python/ntuple_generator.py
@@ -1948,12 +1948,16 @@ def generate_process(year, useData=True, isDebug=False, fatjet_ptmin=120.):
     elif(year == "UL17"): doRunVID=True
     elif(year == "UL18"): doRunVID=True
 
+    # The following means that the energy corrections are calculated for each electron/photon and are thus accessible but they are not actually applied to the electron/photon written to the ntuple.
+    # In order to apply the energy corrections on analysis-level, one can use members of electron/photon class which store the calculated corrections (if they have been written to the electron/photon
+    # class, see NtupleWriterLeptons).
     doRunEnergyCorrections=True
-    if(year == "2016v3"): runEnergyCorrections=False
+    if(year == "2016v3"): doRunEnergyCorrections=False
+    doApplyEnergyCorrections=False
 
     # this is the magic thing by the Egamma POG that does *everything*
     from RecoEgamma.EgammaTools.EgammaPostRecoTools import setupEgammaPostRecoSeq
-    setupEgammaPostRecoSeq(process, era=egamma_era, runVID=doRunVID, runEnergyCorrections=doRunEnergyCorrections)
+    setupEgammaPostRecoSeq(process, era=egamma_era, runVID=doRunVID, runEnergyCorrections=doRunEnergyCorrections, applyEnergyCorrections=doApplyEnergyCorrections)
 
     el_isovals = []
 


### PR DESCRIPTION
Implemented residual corrections for electrons and photons, see Twikis [1, 2]. Already mentioned/explained in issue https://github.com/UHH2/UHH2/issues/1638

These corrections should in principle be implemented as new data members in the `Electron`/`Photon` classes. But this would currently break backwards compatibility with earlier ntuple productions of the `RunII_106X_v2` branch. Therefore, I am using the capabilities of the `Tags` class which ensures backwards compatibility. Nonetheless, I added the "correct way" of implementing these data members already as commented-out code, so future developers can just de-comment it once backwards compatibility is not needed anymore. In fact, I am pushing two commits with this PR: The first one is the "correct" implementation with plain class members, and the second commit changes it to the implementation using the `Tags` class. So, in principle, future developers just need to revert the second commit...

[1] https://twiki.cern.ch/twiki/bin/view/CMS/EgammaUL2016To2018#Scale_and_smearing_corrections_f
[2] https://twiki.cern.ch/twiki/bin/viewauth/CMS/EgammaMiniAODV2#Energy_Scale_and_Smearing