### PR TITLE
[106X] add QCD flag for MC scale variations

### DIFF
--- a/common/include/MCWeight.h
+++ b/common/include/MCWeight.h
@@ -79,6 +79,7 @@ class MCScaleVariation: public uhh2::AnalysisModule {
   double syst_weight;
   bool is_dy;
   bool is_wjets;
+  bool is_qcd;
   bool is_alps;
   bool is_azh;
   int i_mu_r = 0, i_mu_f = 0;

--- a/common/include/MCWeight.h
+++ b/common/include/MCWeight.h
@@ -79,7 +79,7 @@ class MCScaleVariation: public uhh2::AnalysisModule {
   double syst_weight;
   bool is_dy;
   bool is_wjets;
-  bool is_qcd;
+  bool is_qcd_HTbinned;
   bool is_alps;
   bool is_azh;
   int i_mu_r = 0, i_mu_f = 0;

--- a/common/src/MCWeight.cxx
+++ b/common/src/MCWeight.cxx
@@ -245,6 +245,7 @@ MCScaleVariation::MCScaleVariation(Context & ctx){
   auto s_mu_f = ctx.get("ScaleVariationMuF");
   is_dy = ctx.get("dataset_version").find("DYJets") == 0;
   is_wjets = ctx.get("dataset_version").find("WJets") == 0;
+  is_qcd = ctx.get("dataset_version").find("QCD") == 0;
   is_alps = ctx.get("dataset_version").find("ALP") == 0;
   is_azh = ctx.get("dataset_version").find("AZH") == 0;
 
@@ -295,7 +296,7 @@ void MCScaleVariation::initialise_handles(Event & event){
 
 bool MCScaleVariation::process(Event & event){
 
-  
+
   initialise_handles(event);  // Set weights to 1 for data
   if (event.isRealData) return true;
 
@@ -305,7 +306,7 @@ bool MCScaleVariation::process(Event & event){
 
     // Set handles, written for all relevant cases irrespective of
     // the values of mu_r and mu_f specified in the config file
-    if ( is_dy || is_wjets || is_alps || is_azh ) {
+    if ( is_dy || is_wjets || is_qcd || is_alps || is_azh ) {
       event.set(h_murmuf_weight_upup_, event.genInfo->systweights().at(20)/event.genInfo->originalXWGTUP());
       event.set(h_murmuf_dyn1_weight_upup_, event.genInfo->systweights().at(21)/event.genInfo->originalXWGTUP());
       event.set(h_murmuf_dyn2_weight_upup_, event.genInfo->systweights().at(22)/event.genInfo->originalXWGTUP());

--- a/common/src/MCWeight.cxx
+++ b/common/src/MCWeight.cxx
@@ -245,7 +245,7 @@ MCScaleVariation::MCScaleVariation(Context & ctx){
   auto s_mu_f = ctx.get("ScaleVariationMuF");
   is_dy = ctx.get("dataset_version").find("DYJets") == 0;
   is_wjets = ctx.get("dataset_version").find("WJets") == 0;
-  is_qcd = ctx.get("dataset_version").find("QCD") == 0;
+  is_qcd_HTbinned = ctx.get("dataset_version").find("QCD_HT") == 0;
   is_alps = ctx.get("dataset_version").find("ALP") == 0;
   is_azh = ctx.get("dataset_version").find("AZH") == 0;
 
@@ -306,7 +306,7 @@ bool MCScaleVariation::process(Event & event){
 
     // Set handles, written for all relevant cases irrespective of
     // the values of mu_r and mu_f specified in the config file
-    if ( is_dy || is_wjets || is_qcd || is_alps || is_azh ) {
+    if ( is_dy || is_wjets || is_qcd_HTbinned || is_alps || is_azh ) {
       event.set(h_murmuf_weight_upup_, event.genInfo->systweights().at(20)/event.genInfo->originalXWGTUP());
       event.set(h_murmuf_dyn1_weight_upup_, event.genInfo->systweights().at(21)/event.genInfo->originalXWGTUP());
       event.set(h_murmuf_dyn2_weight_upup_, event.genInfo->systweights().at(22)/event.genInfo->originalXWGTUP());


### PR DESCRIPTION
When checking the MC scale variations for all SM backgrounds used in our analysis, I noticed that the ones for QCD also were below 1 (as observed before for e.g. DY and WJets). 
We use the ```QCD_HT*``` ones. Although only some of them have the ```madgraphMLM``` tag explicitly in the sample name (somehow most UL16 samples only), this should be the case for all years.
I guess that it's the same for the pT-binned samples, that's why I added the flag for all QCD samples here.

See also https://github.com/UHH2/UHH2/pull/1643.

[only compile]
