### PR TITLE
PSWeights module: fix public inheritance / constructor arg to be able to force use of dummy weights

### DIFF
--- a/common/include/PSWeights.h
+++ b/common/include/PSWeights.h
@@ -3,7 +3,7 @@
 #include "UHH2/core/include/Event.h"
 
 
-class PSWeights: uhh2::AnalysisModule {
+class PSWeights: public uhh2::AnalysisModule {
 public:
   explicit PSWeights(uhh2::Context & ctx);
   virtual bool process(uhh2::Event & event) override;

--- a/common/include/PSWeights.h
+++ b/common/include/PSWeights.h
@@ -5,7 +5,7 @@
 
 class PSWeights: public uhh2::AnalysisModule {
 public:
-  explicit PSWeights(uhh2::Context & ctx);
+  explicit PSWeights(uhh2::Context & ctx, const bool sample_without_ps_weights_ = false);
   virtual bool process(uhh2::Event & event) override;
 
   // Inclusive Variations - up sqrt(2; down 1/sqrt(2)
@@ -49,6 +49,7 @@ public:
   uhh2::Event::Handle<float> handle_isr_g2xg_dn;
 
 private:
+  const bool sample_without_ps_weights;
   void initialise_handles(uhh2::Event & event);
   void write_inclusive_weights_from_geninfo(uhh2::Event & event);
   void write_split_weights_from_geninfo(uhh2::Event & event);

--- a/common/src/PSWeights.cxx
+++ b/common/src/PSWeights.cxx
@@ -3,7 +3,9 @@
 using namespace std;
 using namespace uhh2;
 
-PSWeights::PSWeights(Context & ctx) {
+PSWeights::PSWeights(Context & ctx, const bool sample_without_ps_weights_):
+sample_without_ps_weights(sample_without_ps_weights_)
+{
 
   auto dataset_type = ctx.get("dataset_type");
   is_mc = dataset_type == "MC";
@@ -182,7 +184,7 @@ void PSWeights::write_split_weights_from_geninfo(Event & event) {
 
 
 bool PSWeights::process(Event & event) {
-  if(!is_mc){
+  if(!is_mc || sample_without_ps_weights){
     initialise_handles(event);
   }
   else{


### PR DESCRIPTION
[only compile]
Fixed missing `public` that caused compilation error "`error: 'uhh2::AnalysisModule' is an inaccessible base of 'PSWeights'`"