### PR TITLE
update PSWeights module

### DIFF
--- a/common/include/PSWeights.h
+++ b/common/include/PSWeights.h
@@ -2,53 +2,79 @@
 #include "UHH2/core/include/AnalysisModule.h"
 #include "UHH2/core/include/Event.h"
 
-
+// See this TWiki for explanation of all the different weights:
+// https://twiki.cern.ch/twiki/bin/view/CMS/HowToPDF#Parton_shower_weights
+// You have the option to turn off writing the splitted weights to your AnalysisTree if you don't need those
 class PSWeights: public uhh2::AnalysisModule {
 public:
-  explicit PSWeights(uhh2::Context & ctx, const bool sample_without_ps_weights_ = false);
+  explicit PSWeights(uhh2::Context & ctx, const bool do_split_weights_ = true, const bool sample_without_ps_weights_ = false);
   virtual bool process(uhh2::Event & event) override;
 
-  // Inclusive Variations - up sqrt(2; down 1/sqrt(2)
-  uhh2::Event::Handle<float> handle_isr_05sqrt2_dn;
-  uhh2::Event::Handle<float> handle_isr_sqrt2_up;
-  uhh2::Event::Handle<float> handle_fsr_05sqrt2_dn;
-  uhh2::Event::Handle<float> handle_fsr_sqrt2_up;
-  uhh2::Event::Handle<float> handle_isrfsr_05sqrt2_dn;
-  uhh2::Event::Handle<float> handle_isrfsr_sqrt2_up;
-  // Inclusive Variations - up 2.0; down 0.5
-  uhh2::Event::Handle<float> handle_isr_05_dn;
-  uhh2::Event::Handle<float> handle_isr_20_up;
-  uhh2::Event::Handle<float> handle_fsr_05_dn;
-  uhh2::Event::Handle<float> handle_fsr_20_up;
-  uhh2::Event::Handle<float> handle_isrfsr_05_dn;
-  uhh2::Event::Handle<float> handle_isrfsr_20_up;
-  // Inclusive Variations - up 4.0; down 0.25
-  uhh2::Event::Handle<float> handle_isr_025_dn;
-  uhh2::Event::Handle<float> handle_isr_40_up;
-  uhh2::Event::Handle<float> handle_fsr_025_dn;
-  uhh2::Event::Handle<float> handle_fsr_40_up;
-  uhh2::Event::Handle<float> handle_isrfsr_025_dn;
-  uhh2::Event::Handle<float> handle_isrfsr_40_up;
-  // Split Variations -- fsr
-  uhh2::Event::Handle<float> handle_fsr_g2gg_up;
-  uhh2::Event::Handle<float> handle_fsr_g2gg_dn;
-  uhh2::Event::Handle<float> handle_fsr_g2qq_up;
-  uhh2::Event::Handle<float> handle_fsr_g2qq_dn;
-  uhh2::Event::Handle<float> handle_fsr_g2qg_up;
-  uhh2::Event::Handle<float> handle_fsr_g2qg_dn;
-  uhh2::Event::Handle<float> handle_fsr_g2xg_up;
-  uhh2::Event::Handle<float> handle_fsr_g2xg_dn;
-  // Split Variations -- isr
-  uhh2::Event::Handle<float> handle_isr_g2gg_up;
-  uhh2::Event::Handle<float> handle_isr_g2gg_dn;
-  uhh2::Event::Handle<float> handle_isr_g2qq_up;
-  uhh2::Event::Handle<float> handle_isr_g2qq_dn;
-  uhh2::Event::Handle<float> handle_isr_g2qg_up;
-  uhh2::Event::Handle<float> handle_isr_g2qg_dn;
-  uhh2::Event::Handle<float> handle_isr_g2xg_up;
-  uhh2::Event::Handle<float> handle_isr_g2xg_dn;
-
 private:
+
+  // Inclusive Variations - up sqrt(2; down 1/sqrt(2)
+  uhh2::Event::Handle<float> handle_isr_sqrt2_dn;
+  uhh2::Event::Handle<float> handle_isr_sqrt2_up;
+  uhh2::Event::Handle<float> handle_fsr_sqrt2_dn;
+  uhh2::Event::Handle<float> handle_fsr_sqrt2_up;
+  uhh2::Event::Handle<float> handle_isrfsr_sqrt2_dn;
+  uhh2::Event::Handle<float> handle_isrfsr_sqrt2_up;
+
+  // Inclusive Variations - up 2.0; down 0.5
+  uhh2::Event::Handle<float> handle_isr_2_dn;
+  uhh2::Event::Handle<float> handle_isr_2_up;
+  uhh2::Event::Handle<float> handle_fsr_2_dn;
+  uhh2::Event::Handle<float> handle_fsr_2_up;
+  uhh2::Event::Handle<float> handle_isrfsr_2_dn;
+  uhh2::Event::Handle<float> handle_isrfsr_2_up;
+
+  // Inclusive Variations - up 4.0; down 0.25
+  uhh2::Event::Handle<float> handle_isr_4_dn;
+  uhh2::Event::Handle<float> handle_isr_4_up;
+  uhh2::Event::Handle<float> handle_fsr_4_dn;
+  uhh2::Event::Handle<float> handle_fsr_4_up;
+  uhh2::Event::Handle<float> handle_isrfsr_4_dn;
+  uhh2::Event::Handle<float> handle_isrfsr_4_up;
+
+  // Split Variations -- fsr
+  uhh2::Event::Handle<float> handle_fsr_g2gg_mur_dn;
+  uhh2::Event::Handle<float> handle_fsr_g2gg_mur_up;
+  uhh2::Event::Handle<float> handle_fsr_g2qq_mur_dn;
+  uhh2::Event::Handle<float> handle_fsr_g2qq_mur_up;
+  uhh2::Event::Handle<float> handle_fsr_q2qg_mur_dn;
+  uhh2::Event::Handle<float> handle_fsr_q2qg_mur_up;
+  uhh2::Event::Handle<float> handle_fsr_x2xg_mur_dn;
+  uhh2::Event::Handle<float> handle_fsr_x2xg_mur_up;
+
+  uhh2::Event::Handle<float> handle_fsr_g2gg_cns_dn;
+  uhh2::Event::Handle<float> handle_fsr_g2gg_cns_up;
+  uhh2::Event::Handle<float> handle_fsr_g2qq_cns_dn;
+  uhh2::Event::Handle<float> handle_fsr_g2qq_cns_up;
+  uhh2::Event::Handle<float> handle_fsr_q2qg_cns_dn;
+  uhh2::Event::Handle<float> handle_fsr_q2qg_cns_up;
+  uhh2::Event::Handle<float> handle_fsr_x2xg_cns_dn;
+  uhh2::Event::Handle<float> handle_fsr_x2xg_cns_up;
+
+  // Split Variations -- isr
+  uhh2::Event::Handle<float> handle_isr_g2gg_mur_dn;
+  uhh2::Event::Handle<float> handle_isr_g2gg_mur_up;
+  uhh2::Event::Handle<float> handle_isr_g2qq_mur_dn;
+  uhh2::Event::Handle<float> handle_isr_g2qq_mur_up;
+  uhh2::Event::Handle<float> handle_isr_q2qg_mur_dn;
+  uhh2::Event::Handle<float> handle_isr_q2qg_mur_up;
+  uhh2::Event::Handle<float> handle_isr_x2xg_mur_dn;
+  uhh2::Event::Handle<float> handle_isr_x2xg_mur_up;
+
+  uhh2::Event::Handle<float> handle_isr_g2gg_cns_dn;
+  uhh2::Event::Handle<float> handle_isr_g2gg_cns_up;
+  uhh2::Event::Handle<float> handle_isr_g2qq_cns_dn;
+  uhh2::Event::Handle<float> handle_isr_g2qq_cns_up;
+  uhh2::Event::Handle<float> handle_isr_q2qg_cns_dn;
+  uhh2::Event::Handle<float> handle_isr_q2qg_cns_up;
+  uhh2::Event::Handle<float> handle_isr_x2xg_cns_dn;
+  uhh2::Event::Handle<float> handle_isr_x2xg_cns_up;
+
+  const bool do_split_weights;
   const bool sample_without_ps_weights;
   void initialise_handles(uhh2::Event & event);
   void write_inclusive_weights_from_geninfo(uhh2::Event & event);

--- a/common/src/PSWeights.cxx
+++ b/common/src/PSWeights.cxx
@@ -3,55 +3,81 @@
 using namespace std;
 using namespace uhh2;
 
-PSWeights::PSWeights(Context & ctx, const bool sample_without_ps_weights_):
-sample_without_ps_weights(sample_without_ps_weights_)
+PSWeights::PSWeights(Context & ctx, const bool do_split_weights_, const bool sample_without_ps_weights_):
+  do_split_weights(do_split_weights_),
+  sample_without_ps_weights(sample_without_ps_weights_)
 {
 
-  auto dataset_type = ctx.get("dataset_type");
+  const string dataset_type = ctx.get("dataset_type");
   is_mc = dataset_type == "MC";
 
   // Inclusive Variations - up sqrt(2; down 1/sqrt(2)
-  handle_isr_05sqrt2_dn = ctx.declare_event_output<float>("weight_isr_sqrt2_down");
+  handle_isr_sqrt2_dn = ctx.declare_event_output<float>("weight_isr_sqrt2_down");
   handle_isr_sqrt2_up = ctx.declare_event_output<float>("weight_isr_sqrt2_up");
-  handle_fsr_05sqrt2_dn = ctx.declare_event_output<float>("weight_fsr_sqrt2_down");
+  handle_fsr_sqrt2_dn = ctx.declare_event_output<float>("weight_fsr_sqrt2_down");
   handle_fsr_sqrt2_up = ctx.declare_event_output<float>("weight_fsr_sqrt2_up");
-  handle_isrfsr_05sqrt2_dn = ctx.declare_event_output<float>("weight_isrfsr_sqrt2_down");
+  handle_isrfsr_sqrt2_dn = ctx.declare_event_output<float>("weight_isrfsr_sqrt2_down");
   handle_isrfsr_sqrt2_up = ctx.declare_event_output<float>("weight_isrfsr_sqrt2_up");
   // Inclusive Variations - up 2.0; down 0.5
-  handle_isr_05_dn = ctx.declare_event_output<float>("weight_isr_20_05_down");
-  handle_isr_20_up = ctx.declare_event_output<float>("weight_isr_20_05_up");
-  handle_fsr_05_dn = ctx.declare_event_output<float>("weight_fsr_20_05_down");
-  handle_fsr_20_up = ctx.declare_event_output<float>("weight_fsr_20_05_up");
-  handle_isrfsr_05_dn = ctx.declare_event_output<float>("weight_isrfsr_20_05_down");
-  handle_isrfsr_20_up = ctx.declare_event_output<float>("weight_isrfsr_20_05_up");
+  handle_isr_2_dn = ctx.declare_event_output<float>("weight_isr_2_down");
+  handle_isr_2_up = ctx.declare_event_output<float>("weight_isr_2_up");
+  handle_fsr_2_dn = ctx.declare_event_output<float>("weight_fsr_2_down");
+  handle_fsr_2_up = ctx.declare_event_output<float>("weight_fsr_2_up");
+  handle_isrfsr_2_dn = ctx.declare_event_output<float>("weight_isrfsr_2_down");
+  handle_isrfsr_2_up = ctx.declare_event_output<float>("weight_isrfsr_2_up");
   // Inclusive Variations - up 4.0; down 0.25
-  handle_isr_025_dn = ctx.declare_event_output<float>("weight_isr_40_025_down");
-  handle_isr_40_up = ctx.declare_event_output<float>("weight_isr_40_025_up");
-  handle_fsr_025_dn = ctx.declare_event_output<float>("weight_fsr_40_025_down");
-  handle_fsr_40_up = ctx.declare_event_output<float>("weight_fsr_40_025_up");
-  handle_isrfsr_025_dn = ctx.declare_event_output<float>("weight_isrfsr_40_025_down");
-  handle_isrfsr_40_up = ctx.declare_event_output<float>("weight_isrfsr_40_025_up");
-  // Split Variations -- fsr
-  handle_fsr_g2gg_up = ctx.declare_event_output<float>("weight_fsr_g2gg_up");
-  handle_fsr_g2gg_dn = ctx.declare_event_output<float>("weight_fsr_g2gg_down");
-  handle_fsr_g2qq_up = ctx.declare_event_output<float>("weight_fsr_g2qq_up");
-  handle_fsr_g2qq_dn = ctx.declare_event_output<float>("weight_fsr_g2qq_down");
-  handle_fsr_g2qg_up = ctx.declare_event_output<float>("weight_fsr_g2qg_up");
-  handle_fsr_g2qg_dn = ctx.declare_event_output<float>("weight_fsr_g2qg_down");
-  handle_fsr_g2xg_up = ctx.declare_event_output<float>("weight_fsr_g2xg_up");
-  handle_fsr_g2xg_dn = ctx.declare_event_output<float>("weight_fsr_g2xg_down");
-  // Split Variations -- isr
-  handle_isr_g2gg_up = ctx.declare_event_output<float>("weight_isr_g2gg_up");
-  handle_isr_g2gg_dn = ctx.declare_event_output<float>("weight_isr_g2gg_down");
-  handle_isr_g2qq_up = ctx.declare_event_output<float>("weight_isr_g2qq_up");
-  handle_isr_g2qq_dn = ctx.declare_event_output<float>("weight_isr_g2qq_down");
-  handle_isr_g2qg_up = ctx.declare_event_output<float>("weight_isr_g2qg_up");
-  handle_isr_g2qg_dn = ctx.declare_event_output<float>("weight_isr_g2qg_down");
-  handle_isr_g2xg_up = ctx.declare_event_output<float>("weight_isr_g2xg_up");
-  handle_isr_g2xg_dn = ctx.declare_event_output<float>("weight_isr_g2xg_down");
+  handle_isr_4_dn = ctx.declare_event_output<float>("weight_isr_4_down");
+  handle_isr_4_up = ctx.declare_event_output<float>("weight_isr_4_up");
+  handle_fsr_4_dn = ctx.declare_event_output<float>("weight_fsr_4_down");
+  handle_fsr_4_up = ctx.declare_event_output<float>("weight_fsr_4_up");
+  handle_isrfsr_4_dn = ctx.declare_event_output<float>("weight_isrfsr_4_down");
+  handle_isrfsr_4_up = ctx.declare_event_output<float>("weight_isrfsr_4_up");
+
+  if(do_split_weights) {
+    // Split Variations -- fsr (muR)
+    handle_fsr_g2gg_mur_dn = ctx.declare_event_output<float>("weight_fsr_g2gg_mur_down");
+    handle_fsr_g2gg_mur_up = ctx.declare_event_output<float>("weight_fsr_g2gg_mur_up");
+    handle_fsr_g2qq_mur_dn = ctx.declare_event_output<float>("weight_fsr_g2qq_mur_down");
+    handle_fsr_g2qq_mur_up = ctx.declare_event_output<float>("weight_fsr_g2qq_mur_up");
+    handle_fsr_q2qg_mur_dn = ctx.declare_event_output<float>("weight_fsr_q2qg_mur_down");
+    handle_fsr_q2qg_mur_up = ctx.declare_event_output<float>("weight_fsr_q2qg_mur_up");
+    handle_fsr_x2xg_mur_dn = ctx.declare_event_output<float>("weight_fsr_x2xg_mur_down");
+    handle_fsr_x2xg_mur_up = ctx.declare_event_output<float>("weight_fsr_x2xg_mur_up");
+    // Split Variations -- fsr (cNS)
+    handle_fsr_g2gg_cns_dn = ctx.declare_event_output<float>("weight_fsr_g2gg_cns_down");
+    handle_fsr_g2gg_cns_up = ctx.declare_event_output<float>("weight_fsr_g2gg_cns_up");
+    handle_fsr_g2qq_cns_dn = ctx.declare_event_output<float>("weight_fsr_g2qq_cns_down");
+    handle_fsr_g2qq_cns_up = ctx.declare_event_output<float>("weight_fsr_g2qq_cns_up");
+    handle_fsr_q2qg_cns_dn = ctx.declare_event_output<float>("weight_fsr_q2qg_cns_down");
+    handle_fsr_q2qg_cns_up = ctx.declare_event_output<float>("weight_fsr_q2qg_cns_up");
+    handle_fsr_x2xg_cns_dn = ctx.declare_event_output<float>("weight_fsr_x2xg_cns_down");
+    handle_fsr_x2xg_cns_up = ctx.declare_event_output<float>("weight_fsr_x2xg_cns_up");
+    // Split Variations -- isr (muR)
+    handle_isr_g2gg_mur_dn = ctx.declare_event_output<float>("weight_isr_g2gg_mur_down");
+    handle_isr_g2gg_mur_up = ctx.declare_event_output<float>("weight_isr_g2gg_mur_up");
+    handle_isr_g2qq_mur_dn = ctx.declare_event_output<float>("weight_isr_g2qq_mur_down");
+    handle_isr_g2qq_mur_up = ctx.declare_event_output<float>("weight_isr_g2qq_mur_up");
+    handle_isr_q2qg_mur_dn = ctx.declare_event_output<float>("weight_isr_q2qg_mur_down");
+    handle_isr_q2qg_mur_up = ctx.declare_event_output<float>("weight_isr_q2qg_mur_up");
+    handle_isr_x2xg_mur_dn = ctx.declare_event_output<float>("weight_isr_x2xg_mur_down");
+    handle_isr_x2xg_mur_up = ctx.declare_event_output<float>("weight_isr_x2xg_mur_up");
+    // Split Variations -- isr (cNS)
+    handle_isr_g2gg_cns_dn = ctx.declare_event_output<float>("weight_isr_g2gg_cns_down");
+    handle_isr_g2gg_cns_up = ctx.declare_event_output<float>("weight_isr_g2gg_cns_up");
+    handle_isr_g2qq_cns_dn = ctx.declare_event_output<float>("weight_isr_g2qq_cns_down");
+    handle_isr_g2qq_cns_up = ctx.declare_event_output<float>("weight_isr_g2qq_cns_up");
+    handle_isr_q2qg_cns_dn = ctx.declare_event_output<float>("weight_isr_q2qg_cns_down");
+    handle_isr_q2qg_cns_up = ctx.declare_event_output<float>("weight_isr_q2qg_cns_up");
+    handle_isr_x2xg_cns_dn = ctx.declare_event_output<float>("weight_isr_x2xg_cns_down");
+    handle_isr_x2xg_cns_up = ctx.declare_event_output<float>("weight_isr_x2xg_cns_up");
+  }
 
   if(!is_mc){
-    cout << "Warning: MCScaleVariation will not have an effect on this non-MC sample (dataset_type = '" + dataset_type + "')" << endl;
+    cout << "Warning: PSWeights will not have an effect on this non-MC sample (dataset_type = '" + dataset_type + "'). Will only write dummy weights" << endl;
+    return;
+  }
+  if(sample_without_ps_weights){
+    cout << "Warning: PSWeights will not have an effect on this sample since you specified that this sample has no PS weights stored. Will only write dummy weights" << endl;
     return;
   }
 }
@@ -59,127 +85,187 @@ sample_without_ps_weights(sample_without_ps_weights_)
 
 void PSWeights::initialise_handles(Event & event){
   // Inclusive
+  event.set(handle_isr_sqrt2_dn, 1.0);
   event.set(handle_isr_sqrt2_up, 1.0);
-  event.set(handle_isr_05sqrt2_dn, 1.0);
+  event.set(handle_fsr_sqrt2_dn, 1.0);
   event.set(handle_fsr_sqrt2_up, 1.0);
-  event.set(handle_fsr_05sqrt2_dn, 1.0);
+  event.set(handle_isrfsr_sqrt2_dn, 1.0);
   event.set(handle_isrfsr_sqrt2_up, 1.0);
-  event.set(handle_isrfsr_05sqrt2_dn, 1.0);
-  event.set(handle_isr_20_up, 1.0);
-  event.set(handle_isr_05_dn, 1.0);
-  event.set(handle_fsr_20_up, 1.0);
-  event.set(handle_fsr_05_dn, 1.0);
-  event.set(handle_isrfsr_20_up, 1.0);
-  event.set(handle_isrfsr_05_dn, 1.0);
-  event.set(handle_isr_40_up, 1.0);
-  event.set(handle_isr_025_dn, 1.0);
-  event.set(handle_fsr_40_up, 1.0);
-  event.set(handle_fsr_025_dn, 1.0);
-  event.set(handle_isrfsr_40_up, 1.0);
-  event.set(handle_isrfsr_025_dn, 1.0);
+
+  event.set(handle_isr_2_dn, 1.0);
+  event.set(handle_isr_2_up, 1.0);
+  event.set(handle_fsr_2_dn, 1.0);
+  event.set(handle_fsr_2_up, 1.0);
+  event.set(handle_isrfsr_2_dn, 1.0);
+  event.set(handle_isrfsr_2_up, 1.0);
+
+  event.set(handle_isr_4_dn, 1.0);
+  event.set(handle_isr_4_up, 1.0);
+  event.set(handle_fsr_4_dn, 1.0);
+  event.set(handle_fsr_4_up, 1.0);
+  event.set(handle_isrfsr_4_dn, 1.0);
+  event.set(handle_isrfsr_4_up, 1.0);
+
   // Split
-  event.set(handle_fsr_g2gg_dn, 1.0);
-  event.set(handle_fsr_g2gg_up, 1.0);
-  event.set(handle_fsr_g2qq_dn, 1.0);
-  event.set(handle_fsr_g2qq_up, 1.0);
-  event.set(handle_fsr_g2qg_dn, 1.0);
-  event.set(handle_fsr_g2qg_up, 1.0);
-  event.set(handle_fsr_g2xg_dn, 1.0);
-  event.set(handle_fsr_g2xg_up, 1.0);
-  event.set(handle_isr_g2gg_dn, 1.0);
-  event.set(handle_isr_g2gg_up, 1.0);
-  event.set(handle_isr_g2qq_dn, 1.0);
-  event.set(handle_isr_g2qq_up, 1.0);
-  event.set(handle_isr_g2qg_dn, 1.0);
-  event.set(handle_isr_g2qg_up, 1.0);
-  event.set(handle_isr_g2xg_dn, 1.0);
-  event.set(handle_isr_g2xg_up, 1.0);
+  if(do_split_weights) {
+    event.set(handle_fsr_g2gg_mur_dn, 1.0);
+    event.set(handle_fsr_g2gg_mur_up, 1.0);
+    event.set(handle_fsr_g2qq_mur_dn, 1.0);
+    event.set(handle_fsr_g2qq_mur_up, 1.0);
+    event.set(handle_fsr_q2qg_mur_dn, 1.0);
+    event.set(handle_fsr_q2qg_mur_up, 1.0);
+    event.set(handle_fsr_x2xg_mur_dn, 1.0);
+    event.set(handle_fsr_x2xg_mur_up, 1.0);
+
+    event.set(handle_fsr_g2gg_cns_dn, 1.0);
+    event.set(handle_fsr_g2gg_cns_up, 1.0);
+    event.set(handle_fsr_g2qq_cns_dn, 1.0);
+    event.set(handle_fsr_g2qq_cns_up, 1.0);
+    event.set(handle_fsr_q2qg_cns_dn, 1.0);
+    event.set(handle_fsr_q2qg_cns_up, 1.0);
+    event.set(handle_fsr_x2xg_cns_dn, 1.0);
+    event.set(handle_fsr_x2xg_cns_up, 1.0);
+
+    event.set(handle_isr_g2gg_mur_dn, 1.0);
+    event.set(handle_isr_g2gg_mur_up, 1.0);
+    event.set(handle_isr_g2qq_mur_dn, 1.0);
+    event.set(handle_isr_g2qq_mur_up, 1.0);
+    event.set(handle_isr_q2qg_mur_dn, 1.0);
+    event.set(handle_isr_q2qg_mur_up, 1.0);
+    event.set(handle_isr_x2xg_mur_dn, 1.0);
+    event.set(handle_isr_x2xg_mur_up, 1.0);
+
+    event.set(handle_isr_g2gg_cns_dn, 1.0);
+    event.set(handle_isr_g2gg_cns_up, 1.0);
+    event.set(handle_isr_g2qq_cns_dn, 1.0);
+    event.set(handle_isr_g2qq_cns_up, 1.0);
+    event.set(handle_isr_q2qg_cns_dn, 1.0);
+    event.set(handle_isr_q2qg_cns_up, 1.0);
+    event.set(handle_isr_x2xg_cns_dn, 1.0);
+    event.set(handle_isr_x2xg_cns_up, 1.0);
+  }
 }
 
 
 void PSWeights::write_inclusive_weights_from_geninfo(Event & event) {
   // The indexing is according to the documentation in:
   // https://twiki.cern.ch/twiki/bin/view/CMS/HowToPDF#Parton_shower_weights
-  float nominal = event.genInfo->weights().at(0);
+  const float nominal = event.genInfo->weights().at(0);
 
   // up sqrt(2); down 1/sqrt(2)
-  float isr_05sqrt2_dn = event.genInfo->weights().at(24) / nominal;
-  float isr_sqrt2_up = event.genInfo->weights().at(25) / nominal;
-  float fsr_05sqrt2_dn = event.genInfo->weights().at(2) / nominal;
-  float fsr_sqrt2_up = event.genInfo->weights().at(3) / nominal;
+  const float isr_sqrt2_dn = event.genInfo->weights().at(24) / nominal;
+  const float isr_sqrt2_up = event.genInfo->weights().at(25) / nominal;
+  const float fsr_sqrt2_dn = event.genInfo->weights().at(2) / nominal;
+  const float fsr_sqrt2_up = event.genInfo->weights().at(3) / nominal;
+  event.set(handle_isr_sqrt2_dn, isr_sqrt2_dn);
   event.set(handle_isr_sqrt2_up, isr_sqrt2_up);
-  event.set(handle_isr_05sqrt2_dn, isr_05sqrt2_dn);
+  event.set(handle_fsr_sqrt2_dn, fsr_sqrt2_dn);
   event.set(handle_fsr_sqrt2_up, fsr_sqrt2_up);
-  event.set(handle_fsr_05sqrt2_dn, fsr_05sqrt2_dn);
-  event.set(handle_isrfsr_05sqrt2_dn, isr_05sqrt2_dn * fsr_05sqrt2_dn);
+  event.set(handle_isrfsr_sqrt2_dn, isr_sqrt2_dn * fsr_sqrt2_dn);
   event.set(handle_isrfsr_sqrt2_up, isr_sqrt2_up * fsr_sqrt2_up);
 
   // up 2.0; down 0.5
-  float isr_05_dn = event.genInfo->weights().at(26) / nominal;
-  float isr_20_up = event.genInfo->weights().at(27) / nominal;
-  float fsr_05_dn = event.genInfo->weights().at(4) / nominal;
-  float fsr_20_up = event.genInfo->weights().at(5) / nominal;
-  event.set(handle_isr_20_up, isr_20_up);
-  event.set(handle_isr_05_dn, isr_05_dn);
-  event.set(handle_fsr_20_up, fsr_20_up);
-  event.set(handle_fsr_05_dn, fsr_05_dn);
-  event.set(handle_isrfsr_05_dn, isr_05_dn * fsr_05_dn);
-  event.set(handle_isrfsr_20_up, isr_20_up * fsr_20_up);
+  const float isr_2_dn = event.genInfo->weights().at(26) / nominal;
+  const float isr_2_up = event.genInfo->weights().at(27) / nominal;
+  const float fsr_2_dn = event.genInfo->weights().at(4) / nominal;
+  const float fsr_2_up = event.genInfo->weights().at(5) / nominal;
+  event.set(handle_isr_2_dn, isr_2_dn);
+  event.set(handle_isr_2_up, isr_2_up);
+  event.set(handle_fsr_2_dn, fsr_2_dn);
+  event.set(handle_fsr_2_up, fsr_2_up);
+  event.set(handle_isrfsr_2_dn, isr_2_dn * fsr_2_dn);
+  event.set(handle_isrfsr_2_up, isr_2_up * fsr_2_up);
 
   // up 4.0; down 0.25
-  float isr_025_dn = event.genInfo->weights().at(28) / nominal;
-  float isr_40_up = event.genInfo->weights().at(29) / nominal;
-  float fsr_025_dn = event.genInfo->weights().at(6) / nominal;
-  float fsr_40_up = event.genInfo->weights().at(7) / nominal;
-  event.set(handle_isr_40_up, isr_40_up);
-  event.set(handle_isr_025_dn, isr_025_dn);
-  event.set(handle_fsr_40_up, fsr_40_up);
-  event.set(handle_fsr_025_dn, fsr_025_dn);
-  event.set(handle_isrfsr_025_dn, isr_025_dn * fsr_025_dn);
-  event.set(handle_isrfsr_40_up, isr_40_up * fsr_40_up);
+  const float isr_4_dn = event.genInfo->weights().at(28) / nominal;
+  const float isr_4_up = event.genInfo->weights().at(29) / nominal;
+  const float fsr_4_dn = event.genInfo->weights().at(6) / nominal;
+  const float fsr_4_up = event.genInfo->weights().at(7) / nominal;
+  event.set(handle_isr_4_dn, isr_4_dn);
+  event.set(handle_isr_4_up, isr_4_up);
+  event.set(handle_fsr_4_dn, fsr_4_dn);
+  event.set(handle_fsr_4_up, fsr_4_up);
+  event.set(handle_isrfsr_4_dn, isr_4_dn * fsr_4_dn);
+  event.set(handle_isrfsr_4_up, isr_4_up * fsr_4_up);
 }
 
 
 void PSWeights::write_split_weights_from_geninfo(Event & event) {
   // The indexing is according to the documentation in:
   // https://twiki.cern.ch/twiki/bin/view/CMS/HowToPDF#Parton_shower_weights
-  float nominal = event.genInfo->weights().at(0);
+  const float nominal = event.genInfo->weights().at(0);
 
-  float fsr_g2gg_dn = event.genInfo->weights().at(8) / nominal;
-  float fsr_g2gg_up = event.genInfo->weights().at(9) / nominal;
-  float fsr_g2qq_dn = event.genInfo->weights().at(10) / nominal;
-  float fsr_g2qq_up = event.genInfo->weights().at(11) / nominal;
-  float fsr_g2qg_dn = event.genInfo->weights().at(12) / nominal;
-  float fsr_g2qg_up = event.genInfo->weights().at(13) / nominal;
-  float fsr_g2xg_dn = event.genInfo->weights().at(14) / nominal;
-  float fsr_g2xg_up = event.genInfo->weights().at(15) / nominal;
+  const float fsr_g2gg_mur_dn = event.genInfo->weights().at(8) / nominal;
+  const float fsr_g2gg_mur_up = event.genInfo->weights().at(9) / nominal;
+  const float fsr_g2qq_mur_dn = event.genInfo->weights().at(10) / nominal;
+  const float fsr_g2qq_mur_up = event.genInfo->weights().at(11) / nominal;
+  const float fsr_q2qg_mur_dn = event.genInfo->weights().at(12) / nominal;
+  const float fsr_q2qg_mur_up = event.genInfo->weights().at(13) / nominal;
+  const float fsr_x2xg_mur_dn = event.genInfo->weights().at(14) / nominal;
+  const float fsr_x2xg_mur_up = event.genInfo->weights().at(15) / nominal;
 
-  float isr_g2gg_dn = event.genInfo->weights().at(30) / nominal;
-  float isr_g2gg_up = event.genInfo->weights().at(31) / nominal;
-  float isr_g2qq_dn = event.genInfo->weights().at(32) / nominal;
-  float isr_g2qq_up = event.genInfo->weights().at(33) / nominal;
-  float isr_g2qg_dn = event.genInfo->weights().at(34) / nominal;
-  float isr_g2qg_up = event.genInfo->weights().at(35) / nominal;
-  float isr_g2xg_dn = event.genInfo->weights().at(36) / nominal;
-  float isr_g2xg_up = event.genInfo->weights().at(37) / nominal;
+  const float fsr_g2gg_cns_dn = event.genInfo->weights().at(16) / nominal;
+  const float fsr_g2gg_cns_up = event.genInfo->weights().at(17) / nominal;
+  const float fsr_g2qq_cns_dn = event.genInfo->weights().at(18) / nominal;
+  const float fsr_g2qq_cns_up = event.genInfo->weights().at(19) / nominal;
+  const float fsr_q2qg_cns_dn = event.genInfo->weights().at(20) / nominal;
+  const float fsr_q2qg_cns_up = event.genInfo->weights().at(21) / nominal;
+  const float fsr_x2xg_cns_dn = event.genInfo->weights().at(22) / nominal;
+  const float fsr_x2xg_cns_up = event.genInfo->weights().at(23) / nominal;
 
-  event.set(handle_fsr_g2gg_dn, fsr_g2gg_dn);
-  event.set(handle_fsr_g2gg_up, fsr_g2gg_up);
-  event.set(handle_fsr_g2qq_dn, fsr_g2qq_dn);
-  event.set(handle_fsr_g2qq_up, fsr_g2qq_up);
-  event.set(handle_fsr_g2qg_dn, fsr_g2qg_dn);
-  event.set(handle_fsr_g2qg_up, fsr_g2qg_up);
-  event.set(handle_fsr_g2xg_dn, fsr_g2xg_dn);
-  event.set(handle_fsr_g2xg_up, fsr_g2xg_up);
+  const float isr_g2gg_mur_dn = event.genInfo->weights().at(30) / nominal;
+  const float isr_g2gg_mur_up = event.genInfo->weights().at(31) / nominal;
+  const float isr_g2qq_mur_dn = event.genInfo->weights().at(32) / nominal;
+  const float isr_g2qq_mur_up = event.genInfo->weights().at(33) / nominal;
+  const float isr_q2qg_mur_dn = event.genInfo->weights().at(34) / nominal;
+  const float isr_q2qg_mur_up = event.genInfo->weights().at(35) / nominal;
+  const float isr_x2xg_mur_dn = event.genInfo->weights().at(36) / nominal;
+  const float isr_x2xg_mur_up = event.genInfo->weights().at(37) / nominal;
 
-  event.set(handle_isr_g2gg_dn, isr_g2gg_dn);
-  event.set(handle_isr_g2gg_up, isr_g2gg_up);
-  event.set(handle_isr_g2qq_dn, isr_g2qq_dn);
-  event.set(handle_isr_g2qq_up, isr_g2qq_up);
-  event.set(handle_isr_g2qg_dn, isr_g2qg_dn);
-  event.set(handle_isr_g2qg_up, isr_g2qg_up);
-  event.set(handle_isr_g2xg_dn, isr_g2xg_dn);
-  event.set(handle_isr_g2xg_up, isr_g2xg_up);
+  const float isr_g2gg_cns_dn = event.genInfo->weights().at(38) / nominal;
+  const float isr_g2gg_cns_up = event.genInfo->weights().at(39) / nominal;
+  const float isr_g2qq_cns_dn = event.genInfo->weights().at(40) / nominal;
+  const float isr_g2qq_cns_up = event.genInfo->weights().at(41) / nominal;
+  const float isr_q2qg_cns_dn = event.genInfo->weights().at(42) / nominal;
+  const float isr_q2qg_cns_up = event.genInfo->weights().at(43) / nominal;
+  const float isr_x2xg_cns_dn = event.genInfo->weights().at(44) / nominal;
+  const float isr_x2xg_cns_up = event.genInfo->weights().at(45) / nominal;
+
+  event.set(handle_fsr_g2gg_mur_dn, fsr_g2gg_mur_dn);
+  event.set(handle_fsr_g2gg_mur_up, fsr_g2gg_mur_up);
+  event.set(handle_fsr_g2qq_mur_dn, fsr_g2qq_mur_dn);
+  event.set(handle_fsr_g2qq_mur_up, fsr_g2qq_mur_up);
+  event.set(handle_fsr_q2qg_mur_dn, fsr_q2qg_mur_dn);
+  event.set(handle_fsr_q2qg_mur_up, fsr_q2qg_mur_up);
+  event.set(handle_fsr_x2xg_mur_dn, fsr_x2xg_mur_dn);
+  event.set(handle_fsr_x2xg_mur_up, fsr_x2xg_mur_up);
+
+  event.set(handle_fsr_g2gg_cns_dn, fsr_g2gg_cns_dn);
+  event.set(handle_fsr_g2gg_cns_up, fsr_g2gg_cns_up);
+  event.set(handle_fsr_g2qq_cns_dn, fsr_g2qq_cns_dn);
+  event.set(handle_fsr_g2qq_cns_up, fsr_g2qq_cns_up);
+  event.set(handle_fsr_q2qg_cns_dn, fsr_q2qg_cns_dn);
+  event.set(handle_fsr_q2qg_cns_up, fsr_q2qg_cns_up);
+  event.set(handle_fsr_x2xg_cns_dn, fsr_x2xg_cns_dn);
+  event.set(handle_fsr_x2xg_cns_up, fsr_x2xg_cns_up);
+
+  event.set(handle_isr_g2gg_mur_dn, isr_g2gg_mur_dn);
+  event.set(handle_isr_g2gg_mur_up, isr_g2gg_mur_up);
+  event.set(handle_isr_g2qq_mur_dn, isr_g2qq_mur_dn);
+  event.set(handle_isr_g2qq_mur_up, isr_g2qq_mur_up);
+  event.set(handle_isr_q2qg_mur_dn, isr_q2qg_mur_dn);
+  event.set(handle_isr_q2qg_mur_up, isr_q2qg_mur_up);
+  event.set(handle_isr_x2xg_mur_dn, isr_x2xg_mur_dn);
+  event.set(handle_isr_x2xg_mur_up, isr_x2xg_mur_up);
+
+  event.set(handle_isr_g2gg_cns_dn, isr_g2gg_cns_dn);
+  event.set(handle_isr_g2gg_cns_up, isr_g2gg_cns_up);
+  event.set(handle_isr_g2qq_cns_dn, isr_g2qq_cns_dn);
+  event.set(handle_isr_g2qq_cns_up, isr_g2qq_cns_up);
+  event.set(handle_isr_q2qg_cns_dn, isr_q2qg_cns_dn);
+  event.set(handle_isr_q2qg_cns_up, isr_q2qg_cns_up);
+  event.set(handle_isr_x2xg_cns_dn, isr_x2xg_cns_dn);
+  event.set(handle_isr_x2xg_cns_up, isr_x2xg_cns_up);
 }
 
 
@@ -189,7 +275,7 @@ bool PSWeights::process(Event & event) {
   }
   else{
     write_inclusive_weights_from_geninfo(event);
-    write_split_weights_from_geninfo(event);
+    if(do_split_weights) write_split_weights_from_geninfo(event);
   }
   return true;
 }


### PR DESCRIPTION
[only compile]

Updates PSWeights module

- made all event handles private
- better naming scheme for all handles/weights; also corrected the naming of `g2qg` to `q2qg` and `g2xg` to `x2xg`; now only using sqrt2, 2, or 4 in the names for easier reading (no 025, 05 etc. anymore)
- includes now also the cNS weights for the splitted weights
- new option to skip writing the splitted weights to your AnalysisTree if you don't need those weights, see new constructor argument