### PR TITLE
[MCWeight] extend is_azh check

### DIFF
--- a/common/src/MCWeight.cxx
+++ b/common/src/MCWeight.cxx
@@ -247,7 +247,8 @@ MCScaleVariation::MCScaleVariation(Context & ctx){
   is_wjets = ctx.get("dataset_version").find("WJets") == 0;
   is_qcd_HTbinned = ctx.get("dataset_version").find("QCD_HT") == 0;
   is_alps = ctx.get("dataset_version").find("ALP") == 0;
-  is_azh = ctx.get("dataset_version").find("AZH") == 0;
+  is_azh = (ctx.get("dataset_version").find("AZH") == 0) ||
+           (ctx.get("dataset_version").find("AToZHToLLTTbar") == 0);
   is_htott_scalar = ctx.get("dataset_version").find("HscalarToTTTo") == 0;
   is_htott_pseudo = ctx.get("dataset_version").find("HpseudoToTTTo") == 0;
   is_zprimetott = ctx.get("dataset_version").find("ZPrimeToTT_") == 0;


### PR DESCRIPTION
This Pull Request will start automatic compilation, then making + testing of ntuples:

- Don't want to run any of this? (e.g. only XML files) Remove the @: [ci @ skip]

- Only want to compile, but don't make + test ntuples? (e.g. change `CommonModules.cxx`) Remove the @: [only @ compile]

Please include destination branch in title, e.g. `[102X]`, + short meaningful title

Please include an explanation message if it's something more complex than just XML dataset files:

Minor change in `MCWeight` module to handle the new `dataset_version` name of AZH samples (cf. https://github.com/UHH2/UHH2-datasets/pull/207)