### PR TITLE
add missing 2016 UL map elements in year_str_map_simple

### DIFF
--- a/common/include/Utils.h
+++ b/common/include/Utils.h
@@ -127,6 +127,8 @@ const std::map<Year, std::string> year_str_map_simple = {
     {Year::is2017v1,        "2017"},
     {Year::is2017v2,        "2017"},
     {Year::is2018,          "2018"},
+    {Year::isUL16preVFP,    "2016"},
+    {Year::isUL16postVFP,   "2016"},
     {Year::isUL17,          "2017"},
     {Year::isUL18,          "2018"},
 };


### PR DESCRIPTION
This Pull Request will start automatic compilation, then making + testing of ntuples:

- Don't want to run any of this? (e.g. only XML files) Remove the @: [ci @ skip]

- Only want to compile, but don't make + test ntuples? (e.g. change `CommonModules.cxx`) Remove the @: [only @ compile]

Please include destination branch in title, e.g. `[102X]`, + short meaningful title

Please include an explanation message if it's something more complex than just XML dataset files:

